### PR TITLE
IMEX daemon template: fix echoing nodes config

### DIFF
--- a/templates/compute-domain-daemon.tmpl.yaml
+++ b/templates/compute-domain-daemon.tmpl.yaml
@@ -37,7 +37,8 @@ spec:
             tail -f /dev/null & wait
           fi
           # Emit nodes config for facilitating debug.
-          echo -e "/etc/nvidia-imex/nodes_config.cfg:\n\n" && cat /etc/nvidia-imex/nodes_config.cfg
+          echo "/etc/nvidia-imex/nodes_config.cfg:"
+          cat /etc/nvidia-imex/nodes_config.cfg
           /usr/bin/nvidia-imex -c /etc/nvidia-imex/config.cfg
           tail -n +1 -f /var/log/nvidia-imex.log & wait
         resources:


### PR DESCRIPTION
I don't quite understand this, but with the recent patch https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/298 in the output we see:
```
$ kubectl logs -n nvidia-dra-driver-gpu   repro2-compute-domain-x6dpf-m6z2l
-e /etc/nvidia-imex/nodes_config.cfg:


10.115.131.12
```

The fact that "-e" appears in the output is surprising. This should be a command line argument to `echo`. On my machine:
```
$ echo -e "test \n\n"
test 


```
Is that a different `echo`?

