### PR TITLE
Use only checkpoint data for CD unprepare (do not GET claim)

### DIFF
--- a/cmd/compute-domain-controller/computedomain.go
+++ b/cmd/compute-domain-controller/computedomain.go
@@ -191,7 +191,7 @@ func (m *ComputeDomainManager) RemoveFinalizer(ctx context.Context, uid string) 
 	return nil
 }
 
-// AssertWorkloadsCompletes ensures that all workloads asssociated with a ComputeDomain have completed.
+// AssertWorkloadsCompletes ensures that all workloads associated with a ComputeDomain have completed.
 //
 // TODO: We should probably also check to ensure that all ResourceClaims
 // generated from our ResourceClaimTemplate for workloads are gone. Doing

--- a/cmd/compute-domain-kubelet-plugin/checkpoint.go
+++ b/cmd/compute-domain-kubelet-plugin/checkpoint.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 
+	resourceapi "k8s.io/api/resource/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 )
 
@@ -12,14 +13,22 @@ type Checkpoint struct {
 }
 
 type CheckpointV1 struct {
-	PreparedClaims PreparedClaims `json:"preparedClaims,omitempty"`
+	PreparedClaims PreparedClaimsByUID `json:"preparedClaims,omitempty"`
+}
+
+// key: stringified claim UUID
+type PreparedClaimsByUID map[string]PreparedClaim
+
+type PreparedClaim struct {
+	Status          resourceapi.ResourceClaimStatus `json:"status,omitempty"`
+	PreparedDevices PreparedDevices                 `json:"preparedDevices,omitempty"`
 }
 
 func newCheckpoint() *Checkpoint {
 	pc := &Checkpoint{
 		Checksum: 0,
 		V1: &CheckpointV1{
-			PreparedClaims: make(PreparedClaims),
+			PreparedClaims: make(PreparedClaimsByUID),
 		},
 	}
 	return pc

--- a/cmd/compute-domain-kubelet-plugin/computedomain.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain.go
@@ -437,7 +437,7 @@ func (m *ComputeDomainManager) periodicCleanup(ctx context.Context) {
 				continue
 			}
 			if err != nil {
-				klog.Errorf("error checking for existenc of directory '%s': %v", m.configFilesRoot, err)
+				klog.Errorf("error checking for existence of directory '%s': %v", m.configFilesRoot, err)
 				continue
 			}
 

--- a/cmd/compute-domain-kubelet-plugin/main.go
+++ b/cmd/compute-domain-kubelet-plugin/main.go
@@ -32,9 +32,9 @@ import (
 )
 
 const (
-	DriverName                 = "compute-domain.nvidia.com"
-	DriverPluginPath           = "/var/lib/kubelet/plugins/" + DriverName
-	DriverPluginCheckpointFile = "checkpoint.json"
+	DriverName                         = "compute-domain.nvidia.com"
+	DriverPluginPath                   = "/var/lib/kubelet/plugins/" + DriverName
+	DriverPluginCheckpointFileBasename = "checkpoint.json"
 )
 
 type Flags struct {

--- a/cmd/compute-domain-kubelet-plugin/prepared.go
+++ b/cmd/compute-domain-kubelet-plugin/prepared.go
@@ -22,7 +22,6 @@ import (
 
 type PreparedDeviceList []PreparedDevice
 type PreparedDevices []*PreparedDeviceGroup
-type PreparedClaims map[string]PreparedDevices
 
 type PreparedDevice struct {
 	Channel *PreparedComputeDomainChannel `json:"channel"`

--- a/cmd/gpu-kubelet-plugin/checkpoint.go
+++ b/cmd/gpu-kubelet-plugin/checkpoint.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 
+	resourceapi "k8s.io/api/resource/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 )
 
@@ -12,14 +13,22 @@ type Checkpoint struct {
 }
 
 type CheckpointV1 struct {
-	PreparedClaims PreparedClaims `json:"preparedClaims,omitempty"`
+	PreparedClaims PreparedClaimsByUID `json:"preparedClaims,omitempty"`
+}
+
+// key: stringified claim UUID
+type PreparedClaimsByUID map[string]PreparedClaim
+
+type PreparedClaim struct {
+	Status          resourceapi.ResourceClaimStatus `json:"status,omitempty"`
+	PreparedDevices PreparedDevices                 `json:"preparedDevices,omitempty"`
 }
 
 func newCheckpoint() *Checkpoint {
 	pc := &Checkpoint{
 		Checksum: 0,
 		V1: &CheckpointV1{
-			PreparedClaims: make(PreparedClaims),
+			PreparedClaims: make(PreparedClaimsByUID),
 		},
 	}
 	return pc

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -86,7 +86,7 @@ func (d *driver) Shutdown() error {
 }
 
 func (d *driver) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {
-	klog.Infof("PrepareResourceClaims called with %d claim(s)", len(claims))
+	klog.V(6).Infof("PrepareResourceClaims called with %d claim(s)", len(claims))
 	results := make(map[types.UID]kubeletplugin.PrepareResult)
 
 	for _, claim := range claims {
@@ -97,7 +97,7 @@ func (d *driver) PrepareResourceClaims(ctx context.Context, claims []*resourceap
 }
 
 func (d *driver) UnprepareResourceClaims(ctx context.Context, claimRefs []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {
-	klog.Infof("UnprepareResourceClaims called with %d claim(s)", len(claimRefs))
+	klog.V(6).Infof("UnprepareResourceClaims called with %d claim(s)", len(claimRefs))
 
 	results := make(map[types.UID]error)
 

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -32,9 +32,9 @@ import (
 )
 
 const (
-	DriverName                 = "gpu.nvidia.com"
-	DriverPluginPath           = "/var/lib/kubelet/plugins/" + DriverName
-	DriverPluginCheckpointFile = "checkpoint.json"
+	DriverName                         = "gpu.nvidia.com"
+	DriverPluginPath                   = "/var/lib/kubelet/plugins/" + DriverName
+	DriverPluginCheckpointFileBasename = "checkpoint.json"
 )
 
 type Flags struct {

--- a/cmd/gpu-kubelet-plugin/prepared.go
+++ b/cmd/gpu-kubelet-plugin/prepared.go
@@ -24,7 +24,6 @@ import (
 
 type PreparedDeviceList []PreparedDevice
 type PreparedDevices []*PreparedDeviceGroup
-type PreparedClaims map[string]PreparedDevices
 
 type PreparedDevice struct {
 	Gpu *PreparedGpu       `json:"gpu"`


### PR DESCRIPTION
Generally -- as discussed with @klueska and @pohly -- resource cleanup (i.e., device unprepare) must not rely on ResourceClaim objects being available in the API server. Cleanup must built so that the only external input parameter is the ResourceClaim UID.

Any state that has to be maintained between Prepare and Unprepare (to ensure proper teardown) can of course be persisted node-locally. Checkpointing logic lends itself for maintaining such state.

Hence, this patch persists resource claim data upon Prepare() so that it can be re-discovered (by claim UID) during Unpreapre().

As such, this patch addresses https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/340.

Notably, we also don't want to fetch the claim object from the API server as an optimization or so. We have to figure out how to reliably do resource teardown using purely local state.

Initial testing looks good:
```
$ kubectl delete -f ./demo/specs/imex/channel-injection.yaml
computedomain.resource.nvidia.com "imex-channel-injection" deleted
pod "imex-channel-injection" deleted
```

```
± kubectl logs -n nvidia-dra-driver-gpu   nvidia-dra-driver-gpu-kubelet-plugin-vbv6v
...
I0506 10:48:01.503802       1 driver.go:149] UnprepareResourceClaims called with 1 claim(s)
I0506 10:48:01.510169       1 driver.go:222] unprepared devices for claim 'nvidia-dra-driver-gpu/imex-channel-injection-r4qtb-2ld9b-compute-domain-daemon-rzscg:36fa6b1d-ca97-4c72-813f-cc921ccfbe9d'
I0506 10:48:01.510206       1 nonblockinggrpcserver.go:159] "handling request succeeded" logger="dra" requestID=7 method="/k8s.io.kubelet.pkg.apis.dra.v1beta1.DRAPlugin/NodeUnprepareResources" response="&NodeUnprepareResourcesResponse{Claims:map[string]*NodeUnprepareResourceResponse{36fa6b1d-ca97-4c72-813f-cc921ccfbe9d: &NodeUnprepareResourceResponse{Error:,},},}"
```