### PR TITLE
Use per-component matchLabels selector in pod specs (fix #355)

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/controller.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/controller.yaml
@@ -25,7 +25,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "nvidia-dra-driver-gpu.selectorLabels" . | nindent 6 }}
+      {{- include "nvidia-dra-driver-gpu.selectorLabels" (dict "context" . "componentName" "controller") | nindent 6 }}
   template:
     metadata:
       {{- with .Values.controller.podAnnotations }}
@@ -34,6 +34,7 @@ spec:
       {{- end }}
       labels:
         {{- include "nvidia-dra-driver-gpu.templateLabels" . | nindent 8 }}
+        {{- include "nvidia-dra-driver-gpu.selectorLabels" (dict "context" . "componentName" "controller") | nindent 8 }}
     spec:
       {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "nvidia-dra-driver-gpu.selectorLabels" . | nindent 6 }}
+      {{- include "nvidia-dra-driver-gpu.selectorLabels" (dict "context" . "componentName" "kubelet-plugin") | nindent 6 }}
   {{- with .Values.kubeletPlugin.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -37,6 +37,7 @@ spec:
       {{- end }}
       labels:
         {{- include "nvidia-dra-driver-gpu.templateLabels" . | nindent 8 }}
+        {{- include "nvidia-dra-driver-gpu.selectorLabels" (dict "context" . "componentName" "kubelet-plugin") | nindent 8 }}
     spec:
       {{- if .Values.kubeletPlugin.priorityClassName }}
       priorityClassName: {{ .Values.kubeletPlugin.priorityClassName }}


### PR DESCRIPTION
A pragmatic proposal for addressing https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/355.

Consider a scenario with one controller and four plugin pods:
```
$ kubectl get pods -A | grep dra-driver
nvidia-dra-driver-gpu-6894   gpu-operator-node-feature-discovery-prune-fcxrx               0/1     Completed   0             57d
nvidia-dra-driver-gpu        nvidia-dra-driver-gpu-controller-9f5846bdb-bh2vq              1/1     Running     0             3h45m
nvidia-dra-driver-gpu        nvidia-dra-driver-gpu-kubelet-plugin-dk7hp                    1/1     Running     0             3h45m
nvidia-dra-driver-gpu        nvidia-dra-driver-gpu-kubelet-plugin-lmhhn                    1/1     Running     0             3h45m
nvidia-dra-driver-gpu        nvidia-dra-driver-gpu-kubelet-plugin-mvmc7                    1/1     Running     0             3h45m
nvidia-dra-driver-gpu        nvidia-dra-driver-gpu-kubelet-plugin-t2ddp                    1/1     Running     0             3h45m
```

Without the patch, the following type/name selector _for the controller_ yields all pods, and we after all do not see controller logs:
```
$ kubectl logs -n nvidia-dra-driver-gpu deploy/nvidia-dra-driver-gpu-controller 
Found 5 pods, using pod/nvidia-dra-driver-gpu-kubelet-plugin-npxss
...
```

With the patch, the same command yields only controller logs, as expected:
```
$ kubectl logs kubectl logs -n nvidia-dra-driver-gpu deploy/nvidia-dra-driver-gpu-controller
I0514 09:42:42.216011       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0514 09:42:42.216127       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
...
```

With the patch, the following command refers to just the plugin pods (as expected):
```
$ kubectl logs ds/nvidia-dra-driver-gpu-kubelet-plugin -n nvidia-dra-driver-gpu | head -n2
Found 4 pods, using pod/nvidia-dra-driver-gpu-kubelet-plugin-dk7hp
I0514 09:42:42.104011       1 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
```
(without the patch, this may erroneously yield controller logs as shown in https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/355).


Before the change, these are the labels for the controller selector:
```
$ kubectl describe deployment -n nvidia-dra-driver-gpu   nvidia-dra-driver-gpu-controller        
...
Selector:               app.kubernetes.io/instance=nvidia-dra-driver-gpu-1747137149,app.kubernetes.io/name=nvidia-dra-driver-gpu
...
```
I would love for others to chime in, but as far as I now understand the purpose of this selector the current value is wrong as it resolves to _all_ pods deployed by the NVIDIA DRA Driver for GPUs. Instead, we want it to resolve to just the controller pods.

After the change:
```
$ kubectl describe deployment -n nvidia-dra-driver-gpu   nvidia-dra-driver-gpu-controller| grep Selector
Selector:               nvidia-dra-driver-gpu-component=controller
```


CC @nojnhuh
