### PR TITLE
Add label app.kubernetes.io/name:nvidia-dra-driver-gpu to all project components

### DIFF
--- a/cmd/compute-domain-controller/controller.go
+++ b/cmd/compute-domain-controller/controller.go
@@ -29,6 +29,10 @@ import (
 // It contains essential fields for driver identification, Kubernetes client access,
 // and work queue management.
 type ManagerConfig struct {
+	// appName is the app name to use for the app.kubernetes.io/name label value
+	// to be used on manager pods
+	appName string
+
 	// driverName is the unique identifier for this DRA driver
 	driverName string
 
@@ -63,6 +67,7 @@ func (c *Controller) Run(ctx context.Context) error {
 	workQueue := workqueue.New(workqueue.DefaultControllerRateLimiter())
 
 	managerConfig := &ManagerConfig{
+		appName:         c.config.flags.appName,
 		driverName:      c.config.driverName,
 		driverNamespace: c.config.flags.namespace,
 		imageName:       c.config.flags.imageName,

--- a/cmd/compute-domain-controller/daemonset.go
+++ b/cmd/compute-domain-controller/daemonset.go
@@ -47,6 +47,7 @@ type DaemonSetTemplateData struct {
 	Finalizer                 string
 	ComputeDomainLabelKey     string
 	ComputeDomainLabelValue   types.UID
+	AppLabelValue             string
 	ResourceClaimTemplateName string
 	ImageName                 string
 }
@@ -180,6 +181,7 @@ func (m *DaemonSetManager) Create(ctx context.Context, namespace string, cd *nva
 		Finalizer:                 computeDomainFinalizer,
 		ComputeDomainLabelKey:     computeDomainLabelKey,
 		ComputeDomainLabelValue:   cd.UID,
+		AppLabelValue:             m.config.appName,
 		ResourceClaimTemplateName: rct.Name,
 		ImageName:                 m.config.imageName,
 	}

--- a/cmd/compute-domain-controller/main.go
+++ b/cmd/compute-domain-controller/main.go
@@ -53,6 +53,7 @@ type Flags struct {
 	podName   string
 	namespace string
 	imageName string
+	appName   string
 
 	httpEndpoint string
 	metricsPath  string
@@ -98,6 +99,14 @@ func newApp() *cli.App {
 			Required:    true,
 			Destination: &flags.imageName,
 			EnvVars:     []string{"IMAGE_NAME"},
+		},
+		&cli.StringFlag{
+			Name:        "chart-name",
+			Usage:       "The Helm chart name to use for the app label value.",
+			Required:    true,
+			Destination: &flags.appName,
+			Value:       "nvidia-dra-driver-gpu",
+			EnvVars:     []string{"HELM_CHART_NAME"},
 		},
 		&cli.StringFlag{
 			Category:    "HTTP server:",

--- a/cmd/compute-domain-controller/resourceclaimtemplate.go
+++ b/cmd/compute-domain-controller/resourceclaimtemplate.go
@@ -49,6 +49,7 @@ type ResourceClaimTemplateTemplateData struct {
 	Finalizer               string
 	ComputeDomainLabelKey   string
 	ComputeDomainLabelValue types.UID
+	AppLabelValue           string
 	TargetLabelKey          string
 	TargetLabelValue        string
 	DeviceClassName         string
@@ -298,6 +299,7 @@ func (m *DaemonSetResourceClaimTemplateManager) Create(ctx context.Context, name
 		Finalizer:               computeDomainFinalizer,
 		ComputeDomainLabelKey:   computeDomainLabelKey,
 		ComputeDomainLabelValue: cd.UID,
+		AppLabelValue:           m.config.appName,
 		TargetLabelKey:          computeDomainResourceClaimTemplateTargetLabelKey,
 		TargetLabelValue:        computeDomainResourceClaimTemplateTargetDaemon,
 		DeviceClassName:         computeDomainDaemonDeviceClass,
@@ -356,6 +358,7 @@ func (m *WorkloadResourceClaimTemplateManager) Create(ctx context.Context, names
 		Namespace:               namespace,
 		Name:                    name,
 		Finalizer:               computeDomainFinalizer,
+		AppLabelValue:           m.config.appName,
 		ComputeDomainLabelKey:   computeDomainLabelKey,
 		ComputeDomainLabelValue: cd.UID,
 		TargetLabelKey:          computeDomainResourceClaimTemplateTargetLabelKey,

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -48,6 +48,7 @@ type Flags struct {
 	hostDriverRoot      string
 	nvidiaCTKPath       string
 	imageName           string
+	appName             string
 }
 
 type Config struct {
@@ -116,6 +117,14 @@ func newApp() *cli.App {
 			Required:    true,
 			Destination: &flags.imageName,
 			EnvVars:     []string{"IMAGE_NAME"},
+		},
+		&cli.StringFlag{
+			Name:        "app-name",
+			Usage:       "The app name to use for the app.kubernetes.io/name label value.",
+			Required:    true,
+			Destination: &flags.appName,
+			Value:       "nvidia-dra-driver-gpu",
+			EnvVars:     []string{"HELM_CHART_NAME"},
 		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)

--- a/cmd/gpu-kubelet-plugin/sharing.go
+++ b/cmd/gpu-kubelet-plugin/sharing.go
@@ -85,6 +85,7 @@ type MpsControlDaemonTemplateData struct {
 	NodeName                        string
 	MpsControlDaemonNamespace       string
 	MpsControlDaemonName            string
+	AppLabelValue                   string
 	CUDA_VISIBLE_DEVICES            string //nolint:stylecheck
 	DefaultActiveThreadPercentage   string
 	DefaultPinnedDeviceMemoryLimits map[string]string
@@ -200,6 +201,7 @@ func (m *MpsControlDaemon) Start(ctx context.Context, config *configapi.MpsConfi
 		NodeName:                        m.nodeName,
 		MpsControlDaemonNamespace:       m.namespace,
 		MpsControlDaemonName:            m.name,
+		AppLabelValue:                   m.manager.config.flags.appName,
 		CUDA_VISIBLE_DEVICES:            strings.Join(deviceUUIDs, ","),
 		DefaultActiveThreadPercentage:   "",
 		DefaultPinnedDeviceMemoryLimits: nil,

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/controller.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/controller.yaml
@@ -66,6 +66,8 @@ spec:
               fieldPath: metadata.namespace
         - name: IMAGE_NAME
           value: {{ include "nvidia-dra-driver-gpu.fullimage" . }}
+        - name: HELM_CHART_NAME
+          value: {{ .Chart.Name }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -72,6 +72,8 @@ spec:
         resources:
           {{- toYaml .Values.kubeletPlugin.containers.computeDomains.resources | nindent 10 }}
         env:
+        - name: HELM_CHART_NAME
+          value: {{ .Chart.Name }}
         - name: MASK_NVIDIA_DRIVER_PARAMS
           value: "{{ .Values.maskNvidiaDriverParams }}"
         - name: NVIDIA_CTK_PATH

--- a/templates/compute-domain-daemon-claim-template.tmpl.yaml
+++ b/templates/compute-domain-daemon-claim-template.tmpl.yaml
@@ -7,6 +7,7 @@ metadata:
   finalizers:
     - {{ .Finalizer }}
   labels:
+    app.kubernetes.io/name: {{ .AppLabelValue }}
     {{ .ComputeDomainLabelKey }}: {{ .ComputeDomainLabelValue }}
     {{ .TargetLabelKey }}: {{ .TargetLabelValue }}
 spec:

--- a/templates/compute-domain-daemon.tmpl.yaml
+++ b/templates/compute-domain-daemon.tmpl.yaml
@@ -7,6 +7,7 @@ metadata:
   finalizers:
     - {{ .Finalizer }}
   labels:
+    app.kubernetes.io/name: {{ .AppLabelValue }}
     {{ .ComputeDomainLabelKey }}: {{ .ComputeDomainLabelValue }}
 spec:
   selector:

--- a/templates/compute-domain-workload-claim-template.tmpl.yaml
+++ b/templates/compute-domain-workload-claim-template.tmpl.yaml
@@ -7,6 +7,7 @@ metadata:
   finalizers:
     - {{ .Finalizer }}
   labels:
+    app.kubernetes.io/name: {{ .AppLabelValue }}
     {{ .ComputeDomainLabelKey }}: {{ .ComputeDomainLabelValue }}
     {{ .TargetLabelKey }}: {{ .TargetLabelValue }}
 spec:

--- a/templates/mps-control-daemon.tmpl.yaml
+++ b/templates/mps-control-daemon.tmpl.yaml
@@ -5,16 +5,17 @@ metadata:
   namespace: {{ .MpsControlDaemonNamespace }}
   name: {{ .MpsControlDaemonName }}
   labels:
-    app: {{ .MpsControlDaemonName }}
+    app.kubernetes.io/name: {{ .AppLabelValue }}
+    component: {{ .MpsControlDaemonName }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .MpsControlDaemonName }}
+      component: {{ .MpsControlDaemonName }}
   template:
     metadata:
       labels:
-        app: {{ .MpsControlDaemonName }}
+        component: {{ .MpsControlDaemonName }}
     spec:
       nodeName: {{ .NodeName }}
       hostPID: true


### PR DESCRIPTION
This patch proposes the `app.kubernetes.io/name` label to all managed components of both the computeDomain controller and the kubelet plugin, enabling better identification and organization of Kubernetes resources. The changes primarily involve adding support for the `appName` configuration, updating templates to include the new label, and modifying Helm charts to propagate the label value.

As recommended in https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels we use the label `app.kubernetes.io/name` across all project components.

```bash
kubectl get pods -lapp.kubernetes.io/name=nvidia-dra-driver-gpu -A -ojsonpath={.items[].metadata.namespace} --ignore-not-found
```

Then becomes sufficient to identify all pods deployed from the project, both controllers and managed pods.

This label is of interest only in pods, as objects like the ComputeDomain CRD can be easily retrieved by filtering for it's name

```bash
kubectl get computedomain -A
```

Will retrieve all computeDomains in the cluster.

This is important when debugging in production environments, where we don't know how the user has deployed the project initially, then having a reliable method to query all project pods becomes a handy tool.


### Configuration Updates:
* Added the `appName` field to `ManagerConfig`, `DaemonSetTemplateData`, `ResourceClaimTemplateTemplateData`, and other relevant structs to store the value for the new Kubernetes label. (`cmd/compute-domain-controller/controller.go` [[1]](diffhunk://#diff-b7f8221ce512cf8fdeae69d96468a05965153c5e5a247ad2f657a5b9ded881f4R32-R35) `cmd/compute-domain-controller/daemonset.go` [[2]](diffhunk://#diff-e7bb5d2b4dc44b7850f9bee3793443c41a94e2d16e80fc34233a7a1e377904c3R50) `cmd/compute-domain-controller/resourceclaimtemplate.go` [[3]](diffhunk://#diff-5c4f7c090675a824a0435e2224c5dbe412980252383112bfa4e895404babeb02R52) `cmd/gpu-kubelet-plugin/main.go` [[4]](diffhunk://#diff-f5a9553d7e0ccf6939468d6177c17691e12eb2a2abd2f7c39caefbf3d9fa5bc2R51) `cmd/gpu-kubelet-plugin/sharing.go` [[5]](diffhunk://#diff-eb2c222c2a3789dcc8b91ee29a09d7e4c0f7e287b8331e7df07767d1661da7d6R88)

* Updated CLI flags in `main.go` files to allow users to specify the `appName` value via the `--chart-name` or `--app-name` flag, defaulting to `nvidia-dra-driver-gpu`. (`cmd/compute-domain-controller/main.go` [[1]](diffhunk://#diff-cfc125908c5d6f4b10dcc29de4d7ca57b56c90a6eafd17f28fec478a4cfd904dR103-R110) `cmd/gpu-kubelet-plugin/main.go` [[2]](diffhunk://#diff-f5a9553d7e0ccf6939468d6177c17691e12eb2a2abd2f7c39caefbf3d9fa5bc2R121-R128)

### Template Modifications:
* Added the `app.kubernetes.io/name` label to metadata sections in Kubernetes resource templates, such as DaemonSet, ResourceClaimTemplate, and MPS Control Daemon templates. (`templates/compute-domain-daemon-claim-template.tmpl.yaml` [[1]](diffhunk://#diff-60e39b4b014f5bdbd686acf0ee303bb37a79b91bfd655360b3a0d2476be3c349R10) `templates/compute-domain-daemon.tmpl.yaml` [[2]](diffhunk://#diff-86d4988ec4903fbb89228e8f970a0761a305ede2770116c729c462f30ab29f93R10) `templates/compute-domain-workload-claim-template.tmpl.yaml` [[3]](diffhunk://#diff-21c875d05cd84e7dc6bbbca99780ea08de8e82c3f5fc0c6ae1b0fa9b167b8925R10) `templates/mps-control-daemon.tmpl.yaml` [[4]](diffhunk://#diff-2b68e2e2505addd5fab27bc1327710e5aeb7993f435525528517db1a3c8e52a6L8-R18)

### Helm Chart Updates:
* Updated Helm charts to pass the `Chart.Name` value as the `HELM_CHART_NAME` environment variable, ensuring the `app.kubernetes.io/name` label is populated dynamically. (`deployments/helm/nvidia-dra-driver-gpu/templates/controller.yaml` [[1]](diffhunk://#diff-6ce11b9b65f7ce13f88d4580869ff384624f087310d3abb2a4dd9b36c3baa24aR69-R70) `deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml` [[2]](diffhunk://#diff-e728a95d48eff880e1ef725fb4978042c1affc55b5d3d4ea06efd535309fd2e5R75-R76)

These changes collectively improve Kubernetes resource labeling, making it easier to identify and manage resources deployed by the application.