### PR TITLE
Remove external dependency on nvidia-container-toolkit (i.e. nvidia-cdi-hook)

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/cdi.go
+++ b/cmd/compute-domain-kubelet-plugin/cdi.go
@@ -47,16 +47,16 @@ const (
 )
 
 type CDIHandler struct {
-	logger           *logrus.Logger
-	nvml             nvml.Interface
-	nvdevice         nvdevice.Interface
-	nvcdiDevice      nvcdi.Interface
-	nvcdiClaim       nvcdi.Interface
-	cache            *cdiapi.Cache
-	driverRoot       string
-	devRoot          string
-	targetDriverRoot string
-	nvidiaCTKPath    string
+	logger            *logrus.Logger
+	nvml              nvml.Interface
+	nvdevice          nvdevice.Interface
+	nvcdiDevice       nvcdi.Interface
+	nvcdiClaim        nvcdi.Interface
+	cache             *cdiapi.Cache
+	driverRoot        string
+	devRoot           string
+	targetDriverRoot  string
+	nvidiaCDIHookPath string
 
 	cdiRoot     string
 	vendor      string
@@ -102,7 +102,7 @@ func NewCDIHandler(opts ...cdiOption) (*CDIHandler, error) {
 			nvcdi.WithMode("management"),
 			nvcdi.WithVendor(h.vendor),
 			nvcdi.WithClass(h.deviceClass),
-			nvcdi.WithNVIDIACDIHookPath(h.nvidiaCTKPath),
+			nvcdi.WithNVIDIACDIHookPath(h.nvidiaCDIHookPath),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create CDI library for devices: %w", err)
@@ -119,9 +119,7 @@ func NewCDIHandler(opts ...cdiOption) (*CDIHandler, error) {
 			nvcdi.WithMode("nvml"),
 			nvcdi.WithVendor(h.vendor),
 			nvcdi.WithClass(h.claimClass),
-			nvcdi.WithNVIDIACDIHookPath(h.nvidiaCTKPath),
-			// TODO: This should be removed once the use of a NVIDIA Container Toolkit >= v1.17.5 is commonplace.
-			nvcdi.WithDisabledHook(nvcdi.HookEnableCudaCompat),
+			nvcdi.WithNVIDIACDIHookPath(h.nvidiaCDIHookPath),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create CDI library for claims: %w", err)

--- a/cmd/compute-domain-kubelet-plugin/cdioptions.go
+++ b/cmd/compute-domain-kubelet-plugin/cdioptions.go
@@ -52,10 +52,10 @@ func WithCDIRoot(cdiRoot string) cdiOption {
 	}
 }
 
-// WithNvidiaCTKPath provides an cdiOption to set the nvidia-ctk path used by the 'cdi' interface.
-func WithNvidiaCTKPath(path string) cdiOption {
+// WithNVIDIACDIHookPath provides an cdiOption to set the nvidia-cdi-hook path used by the 'cdi' interface.
+func WithNVIDIACDIHookPath(path string) cdiOption {
 	return func(c *CDIHandler) {
-		c.nvidiaCTKPath = path
+		c.nvidiaCDIHookPath = path
 	}
 }
 

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -76,7 +76,7 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		WithDriverRoot(string(containerDriverRoot)),
 		WithDevRoot(devRoot),
 		WithTargetDriverRoot(hostDriverRoot),
-		WithNvidiaCTKPath(config.flags.nvidiaCTKPath),
+		WithNVIDIACDIHookPath(config.flags.nvidiaCDIHookPath),
 		WithCDIRoot(config.flags.cdiRoot),
 		WithVendor(cdiVendor),
 	)

--- a/cmd/gpu-kubelet-plugin/cdi.go
+++ b/cmd/gpu-kubelet-plugin/cdi.go
@@ -47,16 +47,16 @@ const (
 )
 
 type CDIHandler struct {
-	logger           *logrus.Logger
-	nvml             nvml.Interface
-	nvdevice         nvdevice.Interface
-	nvcdiDevice      nvcdi.Interface
-	nvcdiClaim       nvcdi.Interface
-	cache            *cdiapi.Cache
-	driverRoot       string
-	devRoot          string
-	targetDriverRoot string
-	nvidiaCTKPath    string
+	logger            *logrus.Logger
+	nvml              nvml.Interface
+	nvdevice          nvdevice.Interface
+	nvcdiDevice       nvcdi.Interface
+	nvcdiClaim        nvcdi.Interface
+	cache             *cdiapi.Cache
+	driverRoot        string
+	devRoot           string
+	targetDriverRoot  string
+	nvidiaCDIHookPath string
 
 	cdiRoot     string
 	vendor      string
@@ -102,7 +102,7 @@ func NewCDIHandler(opts ...cdiOption) (*CDIHandler, error) {
 			nvcdi.WithMode("nvml"),
 			nvcdi.WithVendor(h.vendor),
 			nvcdi.WithClass(h.deviceClass),
-			nvcdi.WithNVIDIACDIHookPath(h.nvidiaCTKPath),
+			nvcdi.WithNVIDIACDIHookPath(h.nvidiaCDIHookPath),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create CDI library for devices: %w", err)
@@ -119,7 +119,7 @@ func NewCDIHandler(opts ...cdiOption) (*CDIHandler, error) {
 			nvcdi.WithMode("nvml"),
 			nvcdi.WithVendor(h.vendor),
 			nvcdi.WithClass(h.claimClass),
-			nvcdi.WithNVIDIACDIHookPath(h.nvidiaCTKPath),
+			nvcdi.WithNVIDIACDIHookPath(h.nvidiaCDIHookPath),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create CDI library for claims: %w", err)

--- a/cmd/gpu-kubelet-plugin/cdioptions.go
+++ b/cmd/gpu-kubelet-plugin/cdioptions.go
@@ -52,10 +52,10 @@ func WithCDIRoot(cdiRoot string) cdiOption {
 	}
 }
 
-// WithNvidiaCTKPath provides an cdiOption to set the nvidia-ctk path used by the 'cdi' interface.
-func WithNvidiaCTKPath(path string) cdiOption {
+// WithNVIDIACDIHookPath provides an cdiOption to set the nvidia-cdi-hook path used by the 'cdi' interface.
+func WithNVIDIACDIHookPath(path string) cdiOption {
 	return func(c *CDIHandler) {
-		c.nvidiaCTKPath = path
+		c.nvidiaCDIHookPath = path
 	}
 }
 

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -76,7 +76,7 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		WithDriverRoot(string(containerDriverRoot)),
 		WithDevRoot(devRoot),
 		WithTargetDriverRoot(hostDriverRoot),
-		WithNvidiaCTKPath(config.flags.nvidiaCTKPath),
+		WithNVIDIACDIHookPath(config.flags.nvidiaCDIHookPath),
 		WithCDIRoot(config.flags.cdiRoot),
 		WithVendor(cdiVendor),
 	)

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/urfave/cli/v2"
@@ -46,7 +47,7 @@ type Flags struct {
 	cdiRoot             string
 	containerDriverRoot string
 	hostDriverRoot      string
-	nvidiaCTKPath       string
+	nvidiaCDIHookPath   string
 	imageName           string
 }
 
@@ -104,11 +105,10 @@ func newApp() *cli.App {
 			EnvVars:     []string{"CONTAINER_DRIVER_ROOT"},
 		},
 		&cli.StringFlag{
-			Name:        "nvidia-ctk-path",
-			Value:       "/usr/bin/nvidia-ctk",
-			Usage:       "the path to use for the nvidia-ctk in the generated CDI specification. Note that this represents the path on the host.",
-			Destination: &flags.nvidiaCTKPath,
-			EnvVars:     []string{"NVIDIA_CTK_PATH"},
+			Name:        "nvidia-cdi-hook-path",
+			Usage:       "Absolute path to the nvidia-cdi-hook executable in the host file system. Used in the generated CDI specification.",
+			Destination: &flags.nvidiaCDIHookPath,
+			EnvVars:     []string{"NVIDIA_CDI_HOOK_PATH"},
 		},
 		&cli.StringFlag{
 			Name:        "image-name",
@@ -160,12 +160,20 @@ func newApp() *cli.App {
 	return app
 }
 
+// StartPlugin initializes and runs the GPU kubelet plugin.
 func StartPlugin(ctx context.Context, config *Config) error {
+	// Create the plugin directory
 	err := os.MkdirAll(DriverPluginPath, 0750)
 	if err != nil {
 		return err
 	}
 
+	// Setup nvidia-cdi-hook binary
+	if err := config.flags.setNvidiaCDIHookPath(); err != nil {
+		return fmt.Errorf("error setting up nvidia-cdi-hook: %w", err)
+	}
+
+	// Initialize CDI root directory
 	info, err := os.Stat(config.flags.cdiRoot)
 	switch {
 	case err != nil && os.IsNotExist(err):
@@ -179,9 +187,11 @@ func StartPlugin(ctx context.Context, config *Config) error {
 		return fmt.Errorf("path for cdi file generation is not a directory: '%v'", config.flags.cdiRoot)
 	}
 
+	// Setup signal handling for graceful shutdown
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
+	// Create a cancellable context for cleanup
 	var driver *driver
 	ctx, cancel := context.WithCancel(ctx)
 	defer func() {
@@ -191,12 +201,42 @@ func StartPlugin(ctx context.Context, config *Config) error {
 		}
 	}()
 
+	// Create and start the driver
 	driver, err = NewDriver(ctx, config)
 	if err != nil {
 		return fmt.Errorf("error creating driver: %w", err)
 	}
 
+	// Wait for shutdown signal
 	<-sigs
+
+	return nil
+}
+
+// If 'f.nvidiaCDIHookPath' is already set (from the command line), do nothing.
+// If 'f.nvidiaCDIHookPath' is empty, it copies the nvidia-cdi-hook binary from
+// /usr/bin/nvidia-cdi-hook to DriverPluginPath and sets 'f.nvidiaCDIHookPath'
+// to this path. The /usr/bin/nvidia-cdi-hook is present in the current
+// container image because it is copied from the toolkit image into this
+// container at build time.
+func (f *Flags) setNvidiaCDIHookPath() error {
+	if f.nvidiaCDIHookPath != "" {
+		return nil
+	}
+
+	sourcePath := "/usr/bin/nvidia-cdi-hook"
+	targetPath := filepath.Join(DriverPluginPath, "nvidia-cdi-hook")
+
+	input, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return fmt.Errorf("error reading nvidia-cdi-hook: %w", err)
+	}
+
+	if err := os.WriteFile(targetPath, input, 0755); err != nil {
+		return fmt.Errorf("error copying nvidia-cdi-hook: %w", err)
+	}
+
+	f.nvidiaCDIHookPath = targetPath
 
 	return nil
 }

--- a/demo/clusters/kind/install-dra-driver-gpu.sh
+++ b/demo/clusters/kind/install-dra-driver-gpu.sh
@@ -25,7 +25,6 @@ source "${CURRENT_DIR}/scripts/common.sh"
 kubectl label node -l node-role.x-k8s.io/worker --overwrite nvidia.com/gpu.present=true
 
 helm upgrade -i --create-namespace --namespace nvidia-dra-driver-gpu nvidia-dra-driver-gpu ${PROJECT_DIR}/deployments/helm/nvidia-dra-driver-gpu \
-    ${NVIDIA_CTK_PATH:+--set nvidiaCtkPath=${NVIDIA_CTK_PATH}} \
     ${NVIDIA_DRIVER_ROOT:+--set nvidiaDriverRoot=${NVIDIA_DRIVER_ROOT}} \
     ${MASK_NVIDIA_DRIVER_PARAMS:+--set maskNvidiaDriverParams=${MASK_NVIDIA_DRIVER_PARAMS}} \
     --set gpuResourcesEnabledOverride=true \

--- a/demo/clusters/kind/scripts/kind-cluster-config.yaml
+++ b/demo/clusters/kind/scripts/kind-cluster-config.yaml
@@ -59,13 +59,6 @@ nodes:
   # in `/etc/nvidia-container-runtime/config.toml`
   - hostPath: /dev/null
     containerPath: /var/run/nvidia-container-devices/cdi/runtime.nvidia.com/gpu/all
-  # The generated CDI specification assumes that `nvidia-ctk` is available on a
-  # node -- specifically for the `nvidia-ctk hook` subcommand. As a workaround,
-  # we mount it from the host.
-  # TODO: Remove this once we have a more stable solution to make `nvidia-ctk`
-  # on the kind nodes.
-  - hostPath: /usr/bin/nvidia-ctk
-    containerPath: /usr/bin/nvidia-ctk
   # We need to inject the fabricmanager socket to support MIG with toolkit 1.16.2
   # TODO: Remove this once we have a version of the toolkit where this is not required
   - hostPath: /run/nvidia-fabricmanager/socket

--- a/demo/clusters/nvkind/scripts/kind-cluster-config.yaml
+++ b/demo/clusters/nvkind/scripts/kind-cluster-config.yaml
@@ -60,13 +60,6 @@ nodes:
   # in `/etc/nvidia-container-runtime/config.toml`
   - hostPath: /dev/null
     containerPath: /var/run/nvidia-container-devices/cdi/runtime.nvidia.com/gpu/{{ $gpu }}
-  # The generated CDI specification assumes that `nvidia-ctk` is available on a
-  # node -- specifically for the `nvidia-ctk hook` subcommand. As a workaround,
-  # we mount it from the host.
-  # TODO: Remove this once we have a more stable solution to make `nvidia-ctk`
-  # on the kind nodes.
-  - hostPath: /usr/bin/nvidia-ctk
-    containerPath: /usr/bin/nvidia-ctk
   # We need to inject the fabricmanager socket to support MIG with toolkit 1.16.2
   # TODO: Remove this once we have a version of the toolkit where this is not required
   - hostPath: /run/nvidia-fabricmanager/socket

--- a/demo/specs/imex/README.sh
+++ b/demo/specs/imex/README.sh
@@ -20,7 +20,6 @@ helm upgrade -i \
 	nvidia-dra-driver-gpu \
 	../../../deployments/helm/nvidia-dra-driver-gpu \
     --set nvidiaDriverRoot="/" \
-    --set nvidiaCtkPath=/usr/local/nvidia/toolkit/nvidia-ctk \
 	--set resources.gpus.enabled=false \
     --wait
 

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Declared here for use in FROM directives below
+ARG TOOLKIT_CONTAINER_IMAGE=unknown
+
 # Run build with binaries native to the current build platform.
 FROM --platform=$BUILDPLATFORM nvcr.io/nvidia/cuda:12.9.0-base-ubuntu20.04 AS build
 
@@ -57,6 +60,10 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi && \
     make CC=${cc} GOARCH=${TARGETARCH} PREFIX=/artifacts cmds
 
+# Pull the nvidia-cdi-hook binary out of the relevant toolkit container
+# (arch: TARGETPLATFORM, set via --platform).
+FROM ${TOOLKIT_CONTAINER_IMAGE} AS toolkit
+
 # Construct production image (arch: TARGETPLATFORM, set via --platform).
 FROM nvcr.io/nvidia/cuda:12.9.0-base-ubi9
 
@@ -82,8 +89,9 @@ LABEL org.opencontainers.image.source="https://github.com/NVIDIA/k8s-dra-driver-
 # https://docs.docker.com/build/building/multi-platform/#install-qemu-manually
 RUN mkdir /licenses && mv /NGC-DL-CONTAINER-LICENSE /licenses/NGC-DL-CONTAINER-LICENSE
 
-COPY --from=build /artifacts/compute-domain-controller     /usr/bin/compute-domain-controller
-COPY --from=build /artifacts/compute-domain-kubelet-plugin /usr/bin/compute-domain-kubelet-plugin
-COPY --from=build /artifacts/compute-domain-daemon         /usr/bin/compute-domain-daemon
-COPY --from=build /artifacts/gpu-kubelet-plugin            /usr/bin/gpu-kubelet-plugin
-COPY --from=build /build/templates                         /templates
+COPY --from=toolkit /usr/bin/nvidia-cdi-hook                 /usr/bin/nvidia-cdi-hook
+COPY --from=build   /artifacts/compute-domain-controller     /usr/bin/compute-domain-controller
+COPY --from=build   /artifacts/compute-domain-kubelet-plugin /usr/bin/compute-domain-kubelet-plugin
+COPY --from=build   /artifacts/compute-domain-daemon         /usr/bin/compute-domain-daemon
+COPY --from=build   /artifacts/gpu-kubelet-plugin            /usr/bin/gpu-kubelet-plugin
+COPY --from=build   /build/templates                         /templates

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -84,6 +84,7 @@ $(IMAGE_TARGETS): image-%:
 		$(DOCKER_BUILD_PLATFORM_OPTIONS) \
 		--tag $(IMAGE) \
 		--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
+		--build-arg TOOLKIT_CONTAINER_IMAGE="$(TOOLKIT_CONTAINER_IMAGE)" \
 		--build-arg VERSION="$(VERSION)" \
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
 		-f $(DOCKERFILE) \

--- a/deployments/devel/Makefile
+++ b/deployments/devel/Makefile
@@ -43,6 +43,7 @@ DOCKERFILE_CONTEXT = deployments/devel
 	$(DOCKER) build \
 		--progress=plain \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		--build-arg TOOLKIT_CONTAINER_IMAGE="$(TOOLKIT_CONTAINER_IMAGE)" \
 		--tag $(BUILDIMAGE) \
 		-f $(DOCKERFILE_DEVEL) \
 		$(DOCKERFILE_CONTEXT)

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -74,8 +74,6 @@ spec:
         env:
         - name: MASK_NVIDIA_DRIVER_PARAMS
           value: "{{ .Values.maskNvidiaDriverParams }}"
-        - name: NVIDIA_CTK_PATH
-          value: "{{ .Values.nvidiaCtkPath }}"
         - name: NVIDIA_DRIVER_ROOT
           value: "{{ .Values.nvidiaDriverRoot }}"
         - name: NVIDIA_VISIBLE_DEVICES
@@ -132,8 +130,6 @@ spec:
         env:
         - name: MASK_NVIDIA_DRIVER_PARAMS
           value: "{{ .Values.maskNvidiaDriverParams }}"
-        - name: NVIDIA_CTK_PATH
-          value: "{{ .Values.nvidiaCtkPath }}"
         - name: NVIDIA_DRIVER_ROOT
           value: "{{ .Values.nvidiaDriverRoot }}"
         - name: NVIDIA_VISIBLE_DEVICES

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/validation.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/validation.yaml
@@ -38,3 +38,13 @@
 {{- $error = printf "%s\nIf you truly want to force 'resources.gpus.enabled=true' to apply, you can set 'gpuResourcesEnabledOverride=true'." $error }}
 {{- fail $error }}
 {{- end }}
+
+{{- if .Values.nvidiaCtkPath }}
+{{- $error := "" }}
+{{- $error = printf "%s\nSetting a user-defined nvidiaCtkPath is no longer supported. It can simply be removed without consequence." $error }}
+{{- $error = printf "%s\nIt was previously required to point the DRA driver at the host-path to the nvidia-ctk binary." $error }}
+{{- $error = printf "%s\nThis, in turn, was used to execute any CDI hooks injected into containers by the DRA driver." $error }}
+{{- $error = printf "%s\nNow a diffent binary is used called nvidia-cdi-hook that is installed by the DRA driver itself." $error }}
+{{- $error = printf "%s\nThis renders the need for passing this user-defined flag obsolete." $error }}
+{{- fail $error }}
+{{- end }}

--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -22,11 +22,6 @@
 # For driver installed directly on a host, a value of `/` is used.
 nvidiaDriverRoot: /
 
-# Specify the path of CTK binary (nvidia-ctk) on the host,
-# as it should appear in the the generated CDI specification.
-# The path depends on the system that runs on the node.
-nvidiaCtkPath: /usr/bin/nvidia-ctk
-
 nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""

--- a/hack/toolkit-container-image.sh
+++ b/hack/toolkit-container-image.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2025 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Currently, this is hard-coded to the sha corresponding to the 1.17.8 release
+# of the nvidia-container-toolkit. In the future, we should determine the exact
+# commit SHA corresponding to the version of the go module for the dependency
+# on `github.com/NVIDIA/nvidia-container-toolkit` -— whether it is a
+# tagged release or a pseudo-version -- and return that SHA instead.
+TOOLKIT_VERSION_SHA="f202b80a9b9d0db00d9b1d73c0128c8962c55f4d"
+
+echo ghcr.io/nvidia/container-toolkit:${TOOLKIT_VERSION_SHA:0:8}-ubi8

--- a/versions.mk
+++ b/versions.mk
@@ -28,6 +28,7 @@ VERSION  ?= v25.3.0-rc.2
 vVERSION := v$(VERSION:v%=%)
 
 GOLANG_VERSION := $(shell ./hack/golang-version.sh)
+TOOLKIT_CONTAINER_IMAGE := $(shell ./hack/toolkit-container-image.sh)
 
 # These variables are only needed when building a local image
 BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)


### PR DESCRIPTION
Instead of relying on an external installation of the nvidia-container-toolkit to provide us with the nvidia-ctk binary to use for CDI hooks, we now bundle our own nvidia-ctk binary in the k8s-dra-driver-gpu container image and install it on the host ourselves.

For now, the container image used to pull the nvidia-ctk image from is hard-coded, but eventually we will want it to match the version of whatever go dependency we have pulled in for the toolkit (to ensure their features are in sync).

Note that it is still possible to pass a host path to the nvidia-ctk binary (if desired), but this new feature makes it optional.

Fixes https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/210