### PR TITLE
Allow ComputeDomain resources to be removed from any namespace

### DIFF
--- a/cmd/compute-domain-controller/daemonset.go
+++ b/cmd/compute-domain-controller/daemonset.go
@@ -79,7 +79,6 @@ func NewDaemonSetManager(config *ManagerConfig, getComputeDomain GetComputeDomai
 	factory := informers.NewSharedInformerFactoryWithOptions(
 		config.clientsets.Core,
 		informerResyncPeriod,
-		informers.WithNamespace(config.driverNamespace),
 		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 			opts.LabelSelector = metav1.FormatLabelSelector(labelSelector)
 		}),
@@ -315,6 +314,11 @@ func (m *DaemonSetManager) onAddOrUpdate(ctx context.Context, obj any) error {
 	d, ok := obj.(*appsv1.DaemonSet)
 	if !ok {
 		return fmt.Errorf("failed to cast to DaemonSet")
+	}
+
+	// Only process events from the driver namespace
+	if d.Namespace != m.config.driverNamespace {
+		return nil
 	}
 
 	klog.Infof("Processing added or updated DaemonSet: %s/%s", d.Namespace, d.Name)

--- a/cmd/compute-domain-controller/resourceclaimtemplate.go
+++ b/cmd/compute-domain-controller/resourceclaimtemplate.go
@@ -81,7 +81,6 @@ func newBaseResourceClaimTemplateManager(config *ManagerConfig, getComputeDomain
 	factory := informers.NewSharedInformerFactoryWithOptions(
 		config.clientsets.Core,
 		informerResyncPeriod,
-		informers.WithNamespace(namespace),
 		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 			opts.LabelSelector = metav1.FormatLabelSelector(labelSelector)
 		}),


### PR DESCRIPTION
Prwviously, this sequence of events did not work properly:
1. Install the DRA driver in e.g. the `nvidia-dra-driver-gpu` namespace
2. Create a compute domain / run a workload
3. Uninstall the DRA driver
4. Reinstall the DRA driver in a new namespace, e.g. `gpu-operator`
5. Attempt to delete the workload and its corresponding ComputeDomain

When this happened, ComputeDomain deletion would hang on trying to delete the `daemonset` because it was started in a different namespace.

To address this, this patch removes filtering by a specific namespace for the daemonset and resourceclaimtemplate resources managed by the compute domain controller.

Fixes #393