### PR TITLE
Add nvidiaCDIHookPath helm chart to allow for preinstalled hook binary

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -117,6 +117,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.nvidiaCDIHookPath }}
+        - name: NVIDIA_CDI_HOOK_PATH
+          value: "{{ .Values.nvidiaCDIHookPath }}"
+        {{- end }}
         volumeMounts:
         - name: plugins-registry
           mountPath: /var/lib/kubelet/plugins_registry
@@ -177,6 +181,10 @@ spec:
               fieldPath: metadata.namespace
         - name: IMAGE_NAME
           value: {{ include "nvidia-dra-driver-gpu.fullimage" . }}
+        {{- if .Values.nvidiaCDIHookPath }}
+        - name: NVIDIA_CDI_HOOK_PATH
+          value: "{{ .Values.nvidiaCDIHookPath }}"
+        {{- end }}
         volumeMounts:
         - name: plugins-registry
           mountPath: /var/lib/kubelet/plugins_registry

--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -22,6 +22,10 @@
 # For driver installed directly on a host, a value of `/` is used.
 nvidiaDriverRoot: /
 
+# Optional path to the nvidia-cdi-hook executable.
+# If not specified, the default path inferred from the nvidia-container-toolkit library version will be used.
+nvidiaCDIHookPath: ""
+
 nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""


### PR DESCRIPTION
GKE has a requirement to build / ship all binaries installed on their base OS themselves. This allows for a preinstalled nvidia-cdi-hook binary to be used instead of using the embedded one.