### PR TITLE
filter device requests from other drivers

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -474,6 +474,9 @@ func (s *DeviceState) getConfigResultsMap(rcs *resourceapi.ResourceClaimStatus) 
 	// each device allocation result based on their order of precedence and type.
 	configResultsMap := make(map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult)
 	for _, result := range rcs.Allocation.Devices.Results {
+		if result.Driver != DriverName {
+			continue
+		}
 		device, exists := s.allocatable[result.Device]
 		if !exists {
 			return nil, fmt.Errorf("requested device is not allocatable: %v", result.Device)

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -237,6 +237,9 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 	// each device allocation result based on their order of precedence and type.
 	configResultsMap := make(map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult)
 	for _, result := range claim.Status.Allocation.Devices.Results {
+		if result.Driver != DriverName {
+			continue
+		}
 		device, exists := s.allocatable[result.Device]
 		if !exists {
 			return nil, fmt.Errorf("requested device is not allocatable: %v", result.Device)


### PR DESCRIPTION
The same claim can reference multiple devices with different owners/drivers, so those should be skipped or the NodePrepareResources hook will fail because the gpu-driver will not know how to allocate that device and will return the error "requested device is not allocatable:"

