### PR TITLE
gitlab ci: add image suffix: -ubi9

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -234,7 +234,7 @@ push-images-to-staging:
       fi
 
       rm -f ${VERSION_FILE}
-      echo "${IN_IMAGE_TAG} ${OUT_IMAGE_TAG}" >> ${VERSION_FILE}
+      echo "${IN_IMAGE_TAG} ${OUT_IMAGE_TAG}-ubi9" >> ${VERSION_FILE}
       cat ${VERSION_FILE}
   script:
     - cnt-ngc-publish render --project-name "${PROJECT_NAME}" --versions-file "${VERSION_FILE}" --output "${PROJECT_NAME}".yaml


### PR DESCRIPTION
To fix this error in an internal pipeline:
```
k8s-dra-driver-gpu:5b2d66da image not found in catalog
```
Will probably drop these suffixes soon, maybe as part of 'distroless' work.

