### PR TITLE
Set version to 25.8.0-dev

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/Chart.yaml
@@ -19,10 +19,10 @@ description: Official Helm chart for the NVIDIA DRA Driver for GPUs
 type: application
 
 # Note(JP): strict semver: no v prefix allowed
-version: "25.3.0"
+version: "25.8.0-dev"
 
 # Note(JP): templating logic consumes `appVersion` for building the default
 # `tag` value used in a k8s image specification. That logic expects the version
 # number below to not have a "v" prefix (a "v" is added by said logic to yield a
 # valid image reference).
-appVersion: "25.3.0"
+appVersion: "25.8.0-dev"

--- a/versions.mk
+++ b/versions.mk
@@ -18,7 +18,7 @@ MODULE := github.com/NVIDIA/$(DRIVER_NAME)
 
 REGISTRY ?= nvcr.io/nvidia
 
-VERSION  ?= v25.3.0
+VERSION  ?= v25.8.0-dev
 
 # vVERSION represents the version with a guaranteed v-prefix
 # Note: this is probably not consumed in our build chain.


### PR DESCRIPTION
A small step towards a more expressive head-of-main version string. So that during dev/testing we can more easily distinguish actual releases from ad-hoc builds (e.g., `helm list -A` would in the past always output something that looks like a proper release).

In the future, we can maybe also add parts of the commit hash.

For the record, a helpful two-step strategy for development (which some of us use):

1. Build image locally and copy to relevant nodes, e.g. `make -f deployments/container/Makefile build && bash copy-images-11-12.sh nvcr.io/nvidia/k8s-dra-driver-gpu:v25.8.0-dev` (fill in the copy script)
1. Install Helm chart from directory, e.g. `helm install nvidia-dra-driver-gpu deployments/helm/nvidia-dra-driver-gpu/ --create-namespace --namespace nvidia-dra-driver-gpus --set resources.gpus.enabled=false --set nvidiaDriverRoot=/run/nvidia/driver`

