### PR TITLE
Conditionally mount the host's /dev over the container's /dev

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -137,7 +137,7 @@ spec:
         # TODO: make this more surgical, see discussion in
         # https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/307.
         - name: host-dev
-          mountPath: /dev
+          mountPath: /host/dev
       {{- end }}
       {{- if .Values.resources.gpus.enabled }}
       - name: gpus


### PR DESCRIPTION
Currently, in the compute domain driver, we unconditionally mount the host's /dev over the container's /dev regardless of what the devRoot of the GPU driver is. This change was introduced in
https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/307.

Unfortunately, this causes some problems on certain systems as described in https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/477.

This patch makes this mount contingent on devRoot == "/" (which is the only case where we actually ever wanted / needed to have this mount in the first place.