### PR TITLE
Dynamically get container-toolkit image sha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.basic.outputs.version }}
+      golang_version: ${{ needs.basic.outputs.golang_version }}
 
   chart:
     # For faster CI signal, do not wait for `image`.

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ inputs.golang_versions }}
+        go-version: ${{ inputs.golang_version }}
 
     - name: Lint
       uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -21,6 +21,9 @@ on:
       version:
         required: true
         type: string
+      golang_version:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -28,18 +31,27 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         name: Check out code
+      
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.golang_version }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:qemu-v7.0.0-28
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build image
         env:
           IMAGE_NAME: ghcr.io/nvidia/k8s-dra-driver-gpu


### PR DESCRIPTION
Determine the image URL based on the version format

Strategy:
 - For pseudo-versions (development/release-candidate/unreleased): Use ghcr.io with commit SHA
   These are development builds tracked from specific commits
 - For tagged releases: Use official nvcr.io images
   These are stable, tested releases with proper versioning