### PR TITLE
ci: speed up bash build: do not run tests

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -66,6 +66,7 @@ RUN ARCH="$TARGETARCH" && STRIP=strip && \
     sed -i 's|https://ftp\.gnu\.org/gnu|https://ftpmirror.gnu.org/|g' ./build.sh && \
     sed -i 's/-sLO/-sSfLO --retry 300 --connect-timeout 20 --retry-delay 2/g' ./build.sh && \
     sed -i 's/strip/$STRIP/g' ./build.sh && \
+    sed -i 's/make -s \&\& make -s tests/make -j4/g' ./build.sh && \
     bash version-52.sh && STRIP=$STRIP CC=$CC ./build.sh linux $ARCH
 
 # With above's commit, this emits


### PR DESCRIPTION
This cuts ~two minutes from the image build time. We do not change the bash source code, and our build environment is rather stable. There is little confidence gained by running the bash test suite upon uncached every build.

The approach of patching `build.sh` via many sed commands is of course not very sane (also discussed with @klueska, there are various ideas here that we can follow through with when the time is right).