### PR TITLE
Remove reliance on injection of /host/dev for ComputeDomains

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/computedomain.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 	cdispec "tags.cncf.io/container-device-interface/specs-go"
@@ -139,15 +140,16 @@ func (m *ComputeDomainManager) NewSettings(domain string) *ComputeDomainDaemonSe
 	}
 }
 
-func (m *ComputeDomainManager) GetComputeDomainChannelContainerEdits(devRoot string, info *ComputeDomainChannelInfo) *cdiapi.ContainerEdits {
-	channelPath := fmt.Sprintf("/dev/nvidia-caps-imex-channels/channel%d", info.ID)
-
+func (m *ComputeDomainManager) GetComputeDomainChannelContainerEdits(devRoot string, info *nvcapDeviceInfo) *cdiapi.ContainerEdits {
 	return &cdiapi.ContainerEdits{
 		ContainerEdits: &cdispec.ContainerEdits{
 			DeviceNodes: []*cdispec.DeviceNode{
 				{
-					Path:     channelPath,
-					HostPath: filepath.Join(devRoot, channelPath),
+					Path:     info.path,
+					Type:     "c",
+					FileMode: ptr.To(os.FileMode(info.mode)),
+					Major:    int64(info.major),
+					Minor:    int64(info.minor),
 				},
 			},
 		},
@@ -185,7 +187,10 @@ func (s *ComputeDomainDaemonSettings) GetCDIContainerEdits(ctx context.Context, 
 			DeviceNodes: []*cdispec.DeviceNode{
 				{
 					Path:     info.path,
-					HostPath: filepath.Join(devRoot, info.path),
+					Type:     "c",
+					FileMode: ptr.To(os.FileMode(info.mode)),
+					Major:    int64(info.major),
+					Minor:    int64(info.minor),
 				},
 			},
 		},

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -382,10 +382,11 @@ func (s *DeviceState) applyComputeDomainChannelConfig(ctx context.Context, confi
 			return nil, fmt.Errorf("error asserting ComputeDomain Ready: %w", err)
 		}
 		if s.computeDomainManager.cliqueID != "" {
-			if err := s.nvdevlib.createComputeDomainChannelDevice(channel.ID); err != nil {
-				return nil, fmt.Errorf("error creating ComputeDomain channel device: %w", err)
+			info, err := s.nvdevlib.getNVCapIMEXChannelDeviceInfo(channel.ID)
+			if err != nil {
+				return nil, fmt.Errorf("error getting nvcap for IMEX channel '%d': %w", channel.ID, err)
 			}
-			configState.containerEdits = configState.containerEdits.Append(s.computeDomainManager.GetComputeDomainChannelContainerEdits(s.cdi.devRoot, channel))
+			configState.containerEdits = configState.containerEdits.Append(s.computeDomainManager.GetComputeDomainChannelContainerEdits(s.cdi.devRoot, info))
 		}
 	}
 
@@ -421,11 +422,6 @@ func (s *DeviceState) applyComputeDomainDaemonConfig(ctx context.Context, config
 		nvcapDeviceInfo, err := s.nvdevlib.parseNVCapDeviceInfo(nvidiaCapFabricImexMgmtPath)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing nvcap device info for fabic-imex-mgmt: %w", err)
-		}
-
-		// Create the device node for the fabic-imex-mgmt nvcap.
-		if err := s.nvdevlib.createNvCapDevice(nvidiaCapFabricImexMgmtPath); err != nil {
-			return nil, fmt.Errorf("error creating nvcap device for fabic-imex-mgmt: %w", err)
 		}
 
 		// Create new ComputeDomain daemon settings from the ComputeDomainManager.

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -162,11 +162,6 @@ spec:
           mountPath: /driver-root
           readOnly: true
           mountPropagation: HostToContainer
-        # For host-managed drivers located not at /.
-        # TODO: make this more surgical, see discussion in
-        # https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/307.
-        - name: host-dev
-          mountPath: /host/dev
       {{- end }}
       {{- if .Values.resources.gpus.enabled }}
       - name: gpus
@@ -278,9 +273,6 @@ spec:
         hostPath:
           path: {{ .Values.nvidiaDriverRoot }}
           type: DirectoryOrCreate
-      - name: host-dev
-        hostPath:
-          path: /dev
       {{- with .Values.kubeletPlugin.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.11.0
 	github.com/urfave/cli/v2 v2.27.7
-	golang.org/x/sys v0.35.0
 	google.golang.org/grpc v1.75.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
@@ -89,6 +88,7 @@ require (
 	golang.org/x/mod v0.26.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/term v0.32.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	golang.org/x/time v0.9.0 // indirect


### PR DESCRIPTION
Previously we relied on the host's /dev directory to be injected into the DRA driver for compute domains so that it could create NV caps directly on the host to then bind mount into any daemonset and workload containers as required. However, this is not actually necessary.

This patch leverages a feature of the OCI and CDI runtime specs to create a device node inside a container (with proper cgroups permissions) without actually requiring the same device to exist at some path back on the host (thus removing the need for that devices creation / bind mounting into the container).