### PR TITLE
ci: push image w/o version prefix

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -49,3 +49,6 @@ jobs:
         run: |
           echo "${VERSION}"
           make -f deployments/container/Makefile build
+          # Push the image again, using a shorter tag (only commit hash + ubi9 suffix)
+          export IMAGE_TAG="$(echo $GITHUB_SHA | cut -c1-8)-ubi9"
+          make -f deployments/container/Makefile build


### PR DESCRIPTION
In a downstream pipeline, we still need this to exist: `ghcr.io/nvidia/k8s-dra-driver-gpu:e3d43f63-ubi9`. It doesn't currently (only `ghcr.io/nvidia/k8s-dra-driver-gpu:v25.3.1-e3d43f63-ubi9` does). This patch implements a very pragmatic way to get GHA to push the same image to the other target.