### PR TITLE
Use just the binary name for the IMEX bins not their full path to exec

### DIFF
--- a/cmd/compute-domain-daemon/main.go
+++ b/cmd/compute-domain-daemon/main.go
@@ -41,8 +41,8 @@ const (
 	nodesConfigPath    = "/etc/nvidia-imex/nodes_config.cfg"
 	imexConfigPath     = "/etc/nvidia-imex/config.cfg"
 	imexConfigTmplPath = "/etc/nvidia-imex/config.tmpl.cfg"
-	imexBinaryPath     = "/usr/bin/nvidia-imex"
-	imexCtlPath        = "/usr/bin/nvidia-imex-ctl"
+	imexBinaryName     = "nvidia-imex"
+	imexCtlBinaryName  = "nvidia-imex-ctl"
 )
 
 type Flags struct {
@@ -209,7 +209,7 @@ func run(ctx context.Context, cancel context.CancelFunc, flags *Flags) error {
 	}
 
 	// Prepare IMEX daemon process manager.
-	daemonCommandLine := []string{imexBinaryPath, "-c", imexConfigPath}
+	daemonCommandLine := []string{imexBinaryName, "-c", imexConfigPath}
 	processManager := NewProcessManager(daemonCommandLine)
 
 	// Prepare controller with CD manager (not invoking the controller yet).
@@ -326,7 +326,7 @@ func check(ctx context.Context, cancel context.CancelFunc, flags *Flags) error {
 	}
 
 	// Check if IMEX daemon is ready
-	cmd := exec.CommandContext(ctx, imexCtlPath, "-q")
+	cmd := exec.CommandContext(ctx, imexCtlBinaryName, "-q")
 
 	// CombinedOutput captures both, stdout and stderr.
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
Depending on where these binaries exist in /driver-root, they may be mountd into the deaemon at different locations. We now rely on the PATH envvar to be set instead of hardcoding the full path to these binaries.

Note: GKE with `25.8.0-dev` is broken without this change.