### PR TITLE
Only warn when pcieRoot can't be determined

### DIFF
--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -41,7 +41,7 @@ type GpuInfo struct {
 	driverVersion         string
 	cudaDriverVersion     string
 	pcieBusID             string
-	pcieRootAttr          deviceattribute.DeviceAttribute
+	pcieRootAttr          *deviceattribute.DeviceAttribute
 	migProfiles           []*MigProfileInfo
 }
 
@@ -56,7 +56,7 @@ type MigDeviceInfo struct {
 	ciProfileInfo *nvml.ComputeInstanceProfileInfo
 	ciInfo        *nvml.ComputeInstanceInfo
 	pcieBusID     string
-	pcieRootAttr  deviceattribute.DeviceAttribute
+	pcieRootAttr  *deviceattribute.DeviceAttribute
 }
 
 type MigProfileInfo struct {
@@ -125,13 +125,15 @@ func (d *GpuInfo) GetDevice() resourceapi.Device {
 			"pcieBusID": {
 				StringValue: &d.pcieBusID,
 			},
-			d.pcieRootAttr.Name: d.pcieRootAttr.Value,
 		},
 		Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
 			"memory": {
 				Value: *resource.NewQuantity(int64(d.memoryBytes), resource.BinarySI),
 			},
 		},
+	}
+	if d.pcieRootAttr != nil {
+		device.Attributes[d.pcieRootAttr.Name] = d.pcieRootAttr.Value
 	}
 	return device
 }
@@ -179,7 +181,6 @@ func (d *MigDeviceInfo) GetDevice() resourceapi.Device {
 			"pcieBusID": {
 				StringValue: &d.pcieBusID,
 			},
-			d.pcieRootAttr.Name: d.pcieRootAttr.Value,
 		},
 		Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
 			"multiprocessors": {
@@ -198,6 +199,9 @@ func (d *MigDeviceInfo) GetDevice() resourceapi.Device {
 		device.Capacity[capacity] = resourceapi.DeviceCapacity{
 			Value: *resource.NewQuantity(1, resource.BinarySI),
 		}
+	}
+	if d.pcieRootAttr != nil {
+		device.Attributes[d.pcieRootAttr.Name] = d.pcieRootAttr.Value
 	}
 	return device
 }

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -201,9 +201,11 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		return nil, fmt.Errorf("error getting PCIe bus ID for device %d: %w", index, err)
 	}
 
-	pcieRootAttr, err := deviceattribute.GetPCIeRootAttributeByPCIBusID(pcieBusID)
-	if err != nil {
-		return nil, fmt.Errorf("error getting PCIe root for device %d: %w", index, err)
+	var pcieRootAttr *deviceattribute.DeviceAttribute
+	if attr, err := deviceattribute.GetPCIeRootAttributeByPCIBusID(pcieBusID); err == nil {
+		pcieRootAttr = &attr
+	} else {
+		klog.Warningf("error getting PCIe root for device %d, continuing without attribute: %v", index, err)
 	}
 
 	var migProfiles []*MigProfileInfo


### PR DESCRIPTION
This PR makes the GPU/MIG kubelet plugin only log a warning when the standard `pcieRoot` attribute cannot be determined instead of crashing.

Fixes #575

Here's an example of how the new log message looks:

```
W0915 18:12:07.677975       1 nvlib.go:206] error getting PCIe root for device 0, continuing without attribute: failed to resolve PCIe Root Complex for PCI Bus ID 0001:00:00.0: symlink target for PCI Bus ID 0001:00:00.0 is invalid: it must start with /sys/devices/pci: /sys/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/VMBUS:00/000000c1-0001-0000-3130-444532304235/pci0001:00/0001:00:00.0
```