### PR TITLE
helm: DeviceClass apiVersion: prefer v1beta2 over v1beta1

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/_helpers.tpl
@@ -177,10 +177,10 @@ Returns the highest available version or empty string if none found
 {{- define "nvidia-dra-driver-gpu.resourceApiVersion" -}}
 {{- if .Capabilities.APIVersions.Has "resource.k8s.io/v1" -}}
 resource.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "resource.k8s.io/v1beta1" -}}
-resource.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "resource.k8s.io/v1beta2" -}}
 resource.k8s.io/v1beta2
+{{- else if .Capabilities.APIVersions.Has "resource.k8s.io/v1beta1" -}}
+resource.k8s.io/v1beta1
 {{- else -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Resolves https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/592.