### PR TITLE
Change rollingUpdate.maxUnavailable to 100% in kubeletPlugin and webhook

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -78,6 +78,8 @@ webhook:
   priorityClassName: "system-cluster-critical"
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "100%"
   podAnnotations: {}
   podSecurityContext: {}
   nodeSelector: {}
@@ -145,6 +147,8 @@ kubeletPlugin:
   priorityClassName: "system-node-critical"
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "100%"
   podAnnotations: {}
   podSecurityContext: {}
   nodeSelector: {}


### PR DESCRIPTION
This allows all components to be upgraded in parallel rather than wait for each one to roll out individually.