### PR TITLE
Fix bug in generation of compute domain node index

### DIFF
--- a/api/nvidia.com/resource/v1beta1/computedomain.go
+++ b/api/nvidia.com/resource/v1beta1/computedomain.go
@@ -94,7 +94,9 @@ type ComputeDomainNode struct {
 	CliqueID  string `json:"cliqueID"`
 	// The Index field is used to ensure a consistent IP-to-DNS name
 	// mapping across all machines within an IMEX domain. Each node's index
-	// directly determines its DNS name. It is marked as optional (but not
+	// directly determines its DNS name within a given NVLink partition
+	// (i.e. clique). In other words, the 2-tuple of (CliqueID, Index) will
+	// always be unique. This field is marked as optional (but not
 	// omitempty) in order to support downgrades and avoid an API bump.
 	// +kubebuilder:validation:Optional
 	Index int `json:"index"`

--- a/deployments/helm/nvidia-dra-driver-gpu/crds/resource.nvidia.com_computedomains.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/crds/resource.nvidia.com_computedomains.yaml
@@ -88,7 +88,9 @@ spec:
                       description: |-
                         The Index field is used to ensure a consistent IP-to-DNS name
                         mapping across all machines within an IMEX domain. Each node's index
-                        directly determines its DNS name. It is marked as optional (but not
+                        directly determines its DNS name within a given NVLink partition
+                        (i.e. clique). In other words, the 2-tuple of (CliqueID, Index) will
+                        always be unique. This field is marked as optional (but not
                         omitempty) in order to support downgrades and avoid an API bump.
                       type: integer
                     ipAddress:


### PR DESCRIPTION
Previously we were generating a globally unique index, which caused problems when running in a multi-rack setup with more than 18 compute nodes. We instead should generate unique indices per node in the same NVLink partition (i.e. clique). This patch makes that update.