### PR TITLE
build: retry TCP RST when curling bash source

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -64,7 +64,7 @@ RUN ARCH="$TARGETARCH" && STRIP=strip && \
     echo "strip to use: $STRIP" && \
     cd bash-static && git checkout ${BASH_STATIC_GIT_REF} && \
     sed -i 's|https://ftp\.gnu\.org/gnu|https://ftpmirror.gnu.org/|g' ./build.sh && \
-    sed -i 's/-sLO/-sSfLO --retry 300 --connect-timeout 20 --retry-delay 2/g' ./build.sh && \
+    sed -i 's/-sLO/-sSfLO --retry 300 --connect-timeout 20 --retry-delay 5 --retry-all-errors /g' ./build.sh && \
     sed -i 's/strip/$STRIP/g' ./build.sh && \
     sed -i 's/make -s \&\& make -s tests/make -j4/g' ./build.sh && \
     bash version-52.sh && STRIP=$STRIP CC=$CC ./build.sh linux $ARCH


### PR DESCRIPTION
Resolves https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/681.

Commit msg:
```
Error seen:

curl: (7) Failed to connect to mirror.cs.odu.edu port 443 after 306 ms: Connection refused

By default, a TCP connection rejection (RST) is not treated
by curl as a transient error, see

https://curl.se/docs/manpage.html#--retry-connrefused

It's a transient error in the sense that it's often a way to
implement backpressure. We retry at slow rate.

`--retry-all-errors` is what we want here, it includes
`--retry-connrefused`.
```