### PR TITLE
tests: construct ResourceClaim differently on v1

### DIFF
--- a/tests/bats/setup_suite.bash
+++ b/tests/bats/setup_suite.bash
@@ -47,6 +47,13 @@ validate_prerequisites() {
 
     # Examples: v1, or v1beta1
     export TEST_K8S_RESOURCE_API_VERSION
+
+    # For resource.k8s.io API versions before v1, a ResourceClaim spec looks
+    # slightly differently. Use flow-style YAML.
+    export TEST_DEVCLASSNAME_CD_CHANNEL="exactly: {deviceClassName: compute-domain-default-channel.nvidia.com}"
+    if [[ "${TEST_K8S_RESOURCE_API_VERSION}" != "v1" ]]; then
+        export TEST_DEVCLASSNAME_CD_CHANNEL="deviceClassName: compute-domain-default-channel.nvidia.com"
+    fi
 }
 
 

--- a/tests/bats/specs/rc-opaque-cfg-unknown-field.yaml.tmpl
+++ b/tests/bats/specs/rc-opaque-cfg-unknown-field.yaml.tmpl
@@ -5,8 +5,10 @@ metadata:
 spec:
   devices:
     requests:
-    - deviceClassName: compute-domain-default-channel.nvidia.com
-      name: chan
+    - name: chan
+      # This part of the ResourceClaim spec changed in
+      # resource.k8s.io/v1 compared to previous API versions.
+      ${TEST_DEVCLASSNAME_CD_CHANNEL}
     config:
     - opaque:
         driver: compute-domain.nvidia.com


### PR DESCRIPTION
Resolves #684.

Not tested against a 1.34 cluster yet. But I've printed the resulting spec, and it looks good:

```yaml
   kind: ResourceClaim
   metadata:
     name: batssuite-rc-bad-opaque-config
   spec:
     devices:
       requests:
       - name: chan
         exactly:
           deviceClassName: compute-domain-default-channel.nvidia.com
       config:
       - opaque:
...
```

Against 1.32, the test suite still passes with this patch.