### PR TITLE
Add GPU health check

### DIFF
--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -213,3 +213,13 @@ func (d AllocatableDevices) RemoveSiblingDevices(device *AllocatableDevice) {
 		}
 	}
 }
+
+func (d *AllocatableDevice) IsHealthy() bool {
+	switch d.Type() {
+	case GpuDeviceType:
+		return d.Gpu.Health == Healthy
+	case MigDeviceType:
+		return d.Mig.Health == Healthy
+	}
+	panic("unexpected type for AllocatableDevice")
+}

--- a/cmd/gpu-kubelet-plugin/device_health.go
+++ b/cmd/gpu-kubelet-plugin/device_health.go
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"k8s.io/klog/v2"
+)
+
+const (
+	FullGPUInstanceID uint32 = 0xFFFFFFFF
+)
+
+// For a MIG device the placement is defined by the 3-tuple <parent UUID, GI, CI>.
+// For a full device the returned 3-tuple is the device's uuid and (FullGPUInstanceID) 0xFFFFFFFF for the other two elements.
+type devicePlacementMap map[string]map[uint32]map[uint32]*AllocatableDevice
+
+type nvmlDeviceHealthMonitor struct {
+	nvmllib           nvml.Interface
+	eventSet          nvml.EventSet
+	unhealthy         chan *AllocatableDevice
+	deviceByPlacement devicePlacementMap
+	skippedXids       map[uint64]bool
+	wg                sync.WaitGroup
+}
+
+func newNvmlDeviceHealthMonitor(config *Config, allocatable AllocatableDevices, nvdevlib *deviceLib) (*nvmlDeviceHealthMonitor, error) {
+	if nvdevlib.nvmllib == nil {
+		return nil, fmt.Errorf("nvml library is nil")
+	}
+	if ret := nvdevlib.nvmllib.Init(); ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to initialize NVML: %v", ret)
+	}
+	defer func() {
+		_ = nvdevlib.nvmllib.Shutdown()
+	}()
+
+	m := &nvmlDeviceHealthMonitor{
+		nvmllib:           nvdevlib.nvmllib,
+		unhealthy:         make(chan *AllocatableDevice, len(allocatable)),
+		deviceByPlacement: getDevicePlacementMap(allocatable),
+		skippedXids:       xidsToSkip(config.flags.additionalXidsToIgnore),
+	}
+	return m, nil
+}
+
+func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
+	if ret := m.nvmllib.Init(); ret != nvml.SUCCESS {
+		return fmt.Errorf("failed to initialize NVML: %v", ret)
+	}
+
+	defer func() {
+		if rerr != nil {
+			_ = m.nvmllib.Shutdown()
+		}
+	}()
+
+	klog.V(4).Info("creating NVML events for device health monitor")
+	eventSet, ret := m.nvmllib.EventSetCreate()
+	if ret != nvml.SUCCESS {
+		return fmt.Errorf("failed to create event set: %w", ret)
+	}
+
+	m.eventSet = eventSet
+
+	klog.V(4).Info("registering NVML events for device health monitor")
+	m.registerEventsForDevices()
+
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		m.run(ctx)
+	}()
+
+	klog.V(4).Info("started device health monitoring")
+	return nil
+}
+
+func (m *nvmlDeviceHealthMonitor) registerEventsForDevices() {
+	eventMask := uint64(nvml.EventTypeXidCriticalError | nvml.EventTypeDoubleBitEccError | nvml.EventTypeSingleBitEccError)
+
+	for parentUUID, giMap := range m.deviceByPlacement {
+		gpu, ret := m.nvmllib.DeviceGetHandleByUUID(parentUUID)
+		if ret != nvml.SUCCESS {
+			klog.Warningf("Unable to get device handle from UUID[%s]: %v; marking it as unhealthy", parentUUID, ret)
+			m.markAllMigDevicesUnhealthy(giMap)
+			continue
+		}
+
+		supportedEvents, ret := gpu.GetSupportedEventTypes()
+		if ret != nvml.SUCCESS {
+			klog.Warningf("unable to determine the supported events for %s: %v; marking it as unhealthy", parentUUID, ret)
+			m.markAllMigDevicesUnhealthy(giMap)
+			continue
+		}
+
+		ret = gpu.RegisterEvents(eventMask&supportedEvents, m.eventSet)
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			klog.Warningf("Device %v is too old to support healthchecking.", parentUUID)
+		}
+		if ret != nvml.SUCCESS {
+			klog.Warningf("unable to register events for %s: %v; marking it as unhealthy", parentUUID, ret)
+			m.markAllMigDevicesUnhealthy(giMap)
+		}
+	}
+}
+
+func (m *nvmlDeviceHealthMonitor) Stop() {
+	if m == nil {
+		return
+	}
+	klog.V(6).Info("stopping health monitor")
+
+	m.wg.Wait()
+
+	if ret := m.eventSet.Free(); ret != nvml.SUCCESS {
+		klog.Warningf("failed to unset events: %v", ret)
+	}
+
+	if ret := m.nvmllib.Shutdown(); ret != nvml.SUCCESS {
+		klog.Warningf("failed to shutdown NVML: %v", ret)
+	}
+	close(m.unhealthy)
+}
+
+func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			klog.V(6).Info("Stopping event-driven GPU health monitor...")
+			return
+		default:
+			event, ret := m.eventSet.Wait(5000) // timeout in 5000 ms.
+			if ret == nvml.ERROR_TIMEOUT {
+				continue
+			}
+			// not all return errors are handled as currently there is no proper way to process these errors other than marking all devices healthy.
+			// Ref doc: [https://docs.nvidia.com/deploy/nvml-api/group__nvmlEvents.html#group__nvmlEvents_1g9714b0ca9a34c7a7780f87fee16b205c].
+			if ret != nvml.SUCCESS {
+				if ret == nvml.ERROR_GPU_IS_LOST {
+					klog.Warningf("GPU is lost error: %v; Marking all devices as unhealthy", ret)
+					m.markAllDevicesUnhealthy()
+					continue
+				}
+				klog.V(6).Infof("Error waiting for NVML event: %v. Retrying...", ret)
+				continue
+			}
+
+			// TODO: check why other supported types are not considered?
+			eType := event.EventType
+			xid := event.EventData
+			gi := event.GpuInstanceId
+			ci := event.ComputeInstanceId
+			if eType != nvml.EventTypeXidCriticalError {
+				klog.V(6).Infof("Skipping non-nvmlEventTypeXidCriticalError event: Data=%d, Type=%d, GI=%d, CI=%d", xid, eType, gi, ci)
+				continue
+			}
+
+			if m.skippedXids[xid] {
+				klog.V(6).Infof("Skipping XID event: Data=%d, Type=%d, GI=%d, CI=%d", xid, eType, gi, ci)
+				continue
+			}
+
+			klog.V(4).Infof("Processing event XID=%d event", xid)
+			// this seems an extreme action.
+			// should we just log the error and proceed anyway.
+			// TODO: look into how to properly handle this error.
+			eventUUID, ret := event.Device.GetUUID()
+			if ret != nvml.SUCCESS {
+				klog.Warningf("Failed to determine uuid for event %v: %v; Marking all devices as unhealthy.", event, ret)
+				m.markAllDevicesUnhealthy()
+				continue
+			}
+			affectedDevice := m.deviceByPlacement.get(eventUUID, gi, ci)
+			if affectedDevice == nil {
+				klog.V(6).Infof("Ignoring event for unexpected device (UUID:%s, GI:%d, CI:%d)", eventUUID, gi, ci)
+				continue
+			}
+
+			klog.V(4).Infof("Sending unhealthy notification for device %s due to event type:%v and event data:%d", affectedDevice.UUID(), eType, xid)
+			m.unhealthy <- affectedDevice
+		}
+	}
+}
+
+func (m *nvmlDeviceHealthMonitor) Unhealthy() <-chan *AllocatableDevice {
+	return m.unhealthy
+}
+
+func (m *nvmlDeviceHealthMonitor) markAllDevicesUnhealthy() {
+	for _, giMap := range m.deviceByPlacement {
+		m.markAllMigDevicesUnhealthy(giMap)
+	}
+}
+
+// markAllMigDevicesUnhealthy is a helper function to mark every mig device under a parent as unhealthy.
+func (m *nvmlDeviceHealthMonitor) markAllMigDevicesUnhealthy(giMap map[uint32]map[uint32]*AllocatableDevice) {
+	for _, ciMap := range giMap {
+		for _, dev := range ciMap {
+			// Non-blocking send to avoid deadlocks if channel is full.
+			select {
+			case m.unhealthy <- dev:
+				klog.V(6).Infof("Marked device %s as unhealthy", dev.UUID())
+			// TODO: The non-blocking send protects the health-monitor goroutine from deadlocks,
+			// but dropping an unhealthy notification means the device's health transition may
+			// never reach the consumer. Consider follow-up improvements:
+			//   - increase the channel buffer beyond len(allocatable) to reduce backpressure;
+			//   - introduce a special "all devices unhealthy" message when bulk updates occur;
+			//   - or revisit whether blocking briefly here is acceptable.
+			default:
+				klog.Errorf("Unhealthy channel full. Dropping unhealthy notification for device %s", dev.UUID())
+			}
+		}
+	}
+}
+
+func getDevicePlacementMap(allocatable AllocatableDevices) devicePlacementMap {
+	placementMap := make(devicePlacementMap)
+
+	for _, d := range allocatable {
+		var parentUUID string
+		var giID, ciID uint32
+
+		switch d.Type() {
+		case GpuDeviceType:
+			parentUUID = d.UUID()
+			if parentUUID == "" {
+				continue
+			}
+			giID = FullGPUInstanceID
+			ciID = FullGPUInstanceID
+
+		case MigDeviceType:
+			parentUUID = d.Mig.parent.UUID
+			if parentUUID == "" {
+				continue
+			}
+			giID = d.Mig.giInfo.Id
+			ciID = d.Mig.ciInfo.Id
+
+		default:
+			klog.V(6).Infof("Skipping device with unknown type: %s", d.Type())
+			continue
+		}
+		placementMap.addDevice(parentUUID, giID, ciID, d)
+	}
+	return placementMap
+}
+
+func (p devicePlacementMap) addDevice(parentUUID string, giID uint32, ciID uint32, d *AllocatableDevice) {
+	if _, ok := p[parentUUID]; !ok {
+		p[parentUUID] = make(map[uint32]map[uint32]*AllocatableDevice)
+	}
+	if _, ok := p[parentUUID][giID]; !ok {
+		p[parentUUID][giID] = make(map[uint32]*AllocatableDevice)
+	}
+	p[parentUUID][giID][ciID] = d
+}
+
+func (p devicePlacementMap) get(uuid string, gi, ci uint32) *AllocatableDevice {
+	giMap, ok := p[uuid]
+	if !ok {
+		return nil
+	}
+
+	ciMap, ok := giMap[gi]
+	if !ok {
+		return nil
+	}
+	return ciMap[ci]
+}
+
+// getAdditionalXids returns a list of additional Xids to skip from the specified string.
+// The input is treaded as a comma-separated string and all valid uint64 values are considered as Xid values.
+// Invalid values nare ignored.
+// TODO: add list of EXPLICIT XIDs from [https://github.com/NVIDIA/k8s-device-plugin/pull/1443].
+func getAdditionalXids(input string) []uint64 {
+	if input == "" {
+		return nil
+	}
+
+	var additionalXids []uint64
+	klog.V(6).Infof("Creating a list of additional xids to ignore: [%s]", input)
+	for _, additionalXid := range strings.Split(input, ",") {
+		trimmed := strings.TrimSpace(additionalXid)
+		if trimmed == "" {
+			continue
+		}
+		xid, err := strconv.ParseUint(trimmed, 10, 64)
+		if err != nil {
+			klog.V(6).Infof("Ignoring malformed Xid value %v: %v", trimmed, err)
+			continue
+		}
+		additionalXids = append(additionalXids, xid)
+	}
+
+	return additionalXids
+}
+
+func xidsToSkip(additionalXids string) map[uint64]bool {
+	// Add the list of hardcoded disabled (ignored) XIDs:
+	// http://docs.nvidia.com/deploy/xid-errors/index.html#topic_4
+	// Application errors: the GPU should still be healthy.
+	ignoredXids := []uint64{
+		13,  // Graphics Engine Exception
+		31,  // GPU memory page fault
+		43,  // GPU stopped processing
+		45,  // Preemptive cleanup, due to previous errors
+		68,  // Video processor exception
+		109, // Context Switch Timeout Error
+	}
+
+	skippedXids := make(map[uint64]bool)
+	for _, id := range ignoredXids {
+		skippedXids[id] = true
+	}
+
+	for _, additionalXid := range getAdditionalXids(additionalXids) {
+		skippedXids[additionalXid] = true
+	}
+	return skippedXids
+}

--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -28,6 +28,15 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// Defined similarly as https://pkg.go.dev/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1#Healthy.
+type HealthStatus string
+
+const (
+	Healthy HealthStatus = "Healthy"
+	// With NVMLDeviceHealthCheck, Unhealthy means that there are critcal xid errors on the device.
+	Unhealthy HealthStatus = "Unhealthy"
+)
+
 type GpuInfo struct {
 	UUID                  string `json:"uuid"`
 	minor                 int
@@ -43,6 +52,7 @@ type GpuInfo struct {
 	pcieBusID             string
 	pcieRootAttr          *deviceattribute.DeviceAttribute
 	migProfiles           []*MigProfileInfo
+	Health                HealthStatus
 }
 
 type MigDeviceInfo struct {
@@ -56,6 +66,7 @@ type MigDeviceInfo struct {
 	ciInfo        *nvml.ComputeInstanceInfo
 	pcieBusID     string
 	pcieRootAttr  *deviceattribute.DeviceAttribute
+	Health        HealthStatus
 }
 
 type VfioDeviceInfo struct {

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -53,6 +53,7 @@ type Flags struct {
 	kubeletRegistrarDirectoryPath string
 	kubeletPluginsDirectoryPath   string
 	healthcheckPort               int
+	additionalXidsToIgnore        string
 }
 
 type Config struct {
@@ -146,6 +147,14 @@ func newApp() *cli.App {
 			Value:       -1,
 			Destination: &flags.healthcheckPort,
 			EnvVars:     []string{"HEALTHCHECK_PORT"},
+		},
+		// TODO: change to StringSliceFlag.
+		&cli.StringFlag{
+			Name:        "additional-xids-to-ignore",
+			Usage:       "A comma-separated list of additional XIDs to ignore.",
+			Value:       "",
+			Destination: &flags.additionalXidsToIgnore,
+			EnvVars:     []string{"ADDITIONAL_XIDS_TO_IGNORE"},
 		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -366,6 +366,7 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		pcieBusID:             pcieBusID,
 		pcieRootAttr:          pcieRootAttr,
 		migProfiles:           migProfiles,
+		Health:                Healthy,
 	}
 
 	return gpuInfo, nil
@@ -508,6 +509,7 @@ func (l deviceLib) getMigDevices(gpuInfo *GpuInfo) (map[string]*MigDeviceInfo, e
 			ciInfo:        &ciInfo,
 			pcieBusID:     gpuInfo.pcieBusID,
 			pcieRootAttr:  gpuInfo.pcieRootAttr,
+			Health:        Healthy,
 		}
 		return nil
 	})

--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -67,6 +67,7 @@ resources:
 #   ContextualLogging: true            # Kubernetes logging feature (enabled by default)
 #   LoggingAlphaOptions: false         # Kubernetes logging alpha features
 #   LoggingBetaOptions: true           # Kubernetes logging beta features
+#   NVMLDeviceHealthCheck: false       # GPU Health Checking using NVML
 featureGates: {}
 
 # Log verbosity for all components. Zero or greater, higher number means higher

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -40,6 +40,9 @@ const (
 
 	// PassthroughSupport allows gpus to be configured with the vfio-pci driver.
 	PassthroughSupport featuregate.Feature = "PassthroughSupport"
+
+	// NVMLDeviceHealthCheck allows Device Health Checking using NVML.
+	NVMLDeviceHealthCheck featuregate.Feature = "NVMLDeviceHealthCheck"
 )
 
 // defaultFeatureGates contains the default settings for all project-specific feature gates.
@@ -67,6 +70,14 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 		},
 	},
 	PassthroughSupport: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(25, 12),
+		},
+	},
+
+	NVMLDeviceHealthCheck: {
 		{
 			Default:    false,
 			PreRelease: featuregate.Alpha,


### PR DESCRIPTION
Addressing https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/360 to add preliminary health check similar to https://github.com/NVIDIA/k8s-device-plugin. 

- Clean follow-up of https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/545 
- addressing review comments 
- republising of resourceslice on health event 
- feature gate: --set featureGates.DeviceHealthCheck=true
- xids: --set kubeletPlugin.gpus.additionalXidsToIgnore="n1,n2"

Test logs:
```
I1017 20:16:19.799738       1 device_health.go:179] Processing event {Device:{Handle:0xe4aea6b2fef0} EventType:8 EventData:43 GpuInstanceId:7 ComputeInstanceId:0}
I1017 20:16:19.799821       1 device_health.go:192] Event for mig device: &{<nil> 0x40006a0070 Healthy}
I1017 20:16:19.799843       1 device_health.go:202] Sending unhealthy notification for device MIG-4d806f22-346a-5a1d-ac01-86b505cdf485 due to event type: 8 and event data: 43
W1017 20:16:19.799870       1 driver.go:219] Received unhealthy notification for device: MIG-4d806f22-346a-5a1d-ac01-86b505cdf485
I1017 20:16:19.799884       1 device_state.go:558] Update device sattus:MIG-4d806f22-346a-5a1d-ac01-86b505cdf485 healthstatus
I1017 20:16:19.799891       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x400040c150 Healthy}
I1017 20:16:19.799955       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x40006a0ee0 Healthy}
I1017 20:16:19.799966       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x40006a0f50 Healthy}
I1017 20:16:19.799974       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x40006a0230 Healthy}
I1017 20:16:19.799983       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x40006a02a0 Healthy}
I1017 20:16:19.799992       1 driver.go:230] Device is healthy, added to resoureslice: &{0x40002ae000 <nil> Healthy}
I1017 20:16:19.800000       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x400040c0e0 Healthy}
W1017 20:16:19.800009       1 driver.go:233] Device:MIG-4d806f22-346a-5a1d-ac01-86b505cdf485 with uuid:&{%!s(*main.GpuInfo=<nil>) %!s(*main.MigDeviceInfo=&{MIG-4d806f22-346a-5a1d-ac01-86b505cdf485 1g.12gb 0x40002503c0 0x400049c130 0x4000610090 0x400045ce40 0x4000610150 0x40004840f0 0009:01:00.0 0x40002fbf50}) Unhealthy} is unhealthy
I1017 20:16:19.800021       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x40006a00e0 Healthy}
I1017 20:16:19.800031       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x400040c1c0 Healthy}
I1017 20:16:19.800043       1 driver.go:230] Device is healthy, added to resoureslice: &{0x40002503c0 <nil> Healthy}
I1017 20:16:19.800050       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x400040c000 Healthy}
I1017 20:16:19.800056       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x40006a0310 Healthy}
I1017 20:16:19.800063       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x40006a0150 Healthy}
I1017 20:16:19.800069       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x400040c070 Healthy}
I1017 20:16:19.800076       1 driver.go:230] Device is healthy, added to resoureslice: &{<nil> 0x40006a01c0 Healthy}
I1017 20:16:19.800084       1 driver.go:237] [Rebulishing resourceslice with healthy devices
I1017 20:16:19.800142       1 driver.go:247] Successfully republished resources without unhealthy device MIG-4d806f22-346a-5a1d-ac01-86b505cdf485:
I1017 20:16:19.800178       1 resourceslicecontroller.go:647] "Existing slices" logger="ResourceSlice controller" poolName="sc-starwars-mab9-b00" obsolete=[] current=["sc-starwars-mab9-b00-gpu.nvidia.com-kmcts"]
I1017 20:16:19.800209       1 resourceslicecontroller.go:724] "Need to update slice" logger="ResourceSlice controller" poolName="sc-starwars-mab9-b00" slice="sc-starwars-mab9-b00-gpu.nvidia.com-kmcts" matchIndex=0
I1017 20:16:19.800225       1 resourceslicecontroller.go:727] "Completed comparison" logger="ResourceSlice controller" poolName="sc-starwars-mab9-b00" numObsolete=0 numMatchedSlices=1 numChangedMatchedSlices=1 numNewSlices=0
I1017 20:16:19.800230       1 resourceslicecontroller.go:743] "Kept generation because at most one update API call is necessary" logger="ResourceSlice controller" poolName="sc-starwars-mab9-b00" generation=1
I1017 20:16:19.805795       1 round_trippers.go:632] "Response" logger="ResourceSlice controller" poolName="sc-starwars-mab9-b00" verb="PUT" url="https://10.96.0.1:443/apis/resource.k8s.io/v1beta1/resourceslices/sc-starwars-mab9-b00-gpu.nvidia.com-kmcts" status="200 OK" milliseconds=5
I1017 20:16:19.806290       1 resourceslicecontroller.go:779] "Updated existing resource slice" logger="ResourceSlice controller" poolName="sc-starwars-mab9-b00" slice="sc-starwars-mab9-b00-gpu.nvidia.com-kmcts"
I1017 20:16:19.807922       1 resourceslicecontroller.go:500] "ResourceSlice update" logger="ResourceSlice controller" slice="sc-starwars-mab9-b00-gpu.nvidia.com-kmcts" diff=<
	@@ -3,8 +3,8 @@
	   "name": "sc-starwars-mab9-b00-gpu.nvidia.com-kmcts",
	   "generateName": "sc-starwars-mab9-b00-gpu.nvidia.com-",
	   "uid": "7184f664-55c1-412d-bd99-4b46e7c23846",
	-  "resourceVersion": "59000652",
	-  "generation": 1,
	+  "resourceVersion": "59001011",
	+  "generation": 2,
	   "creationTimestamp": "2025-10-17T20:14:42Z",
	   "ownerReferences": [
	    {
	@@ -20,7 +20,7 @@
	     "manager": "gpu-kubelet-plugin",
	     "operation": "Update",
	     "apiVersion": "resource.k8s.io/v1beta1",
	-    "time": "2025-10-17T20:14:42Z",
	+    "time": "2025-10-17T20:16:19Z
	.....
	.....
	
		     "name": "gpu-1",
	     "attributes": {
	      "architecture": {
	@@ -161,7 +496,7 @@
	     }
	    },
	    {
	-    "name": "gpu-0-mig-19-0-1",
	+    "name": "gpu-0-mig-19-1-1",
	     "attributes": {
	      "architecture": {
	       "string": "Hopper"
	@@ -197,56 +532,230 @@
	       "string": "mig"
	      },
	      "uuid": {
	-      "string": "MIG-4d806f22-346a-5a1d-ac01-86b505cdf485"
	-     }
	-    },
```
TLDR, This device had an event and is not added `MIG-4d806f22-346a-5a1d-ac01-86b505cdf485`

The device is picked back when driver is restarted.