### PR TITLE
README: refer to external install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,25 +42,8 @@ For exploration and demonstration purposes, see the "demo" section below, and al
 
 ## Installation
 
-As of today, the recommended installation method is via Helm.
-Detailed instructions can (for now) be found [here](https://github.com/NVIDIA/k8s-dra-driver-gpu/discussions/249).
+Configuration and installation instructions can for now be found [in our Wiki](https://github.com/NVIDIA/k8s-dra-driver-gpu/wiki/Installation).
 In the future, this driver will be included in the [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) and does not need to be installed separately anymore.
-
-### Validating Admission Webhook
-
-The validating admission webhook is disabled by default. To enable it, install cert-manager and its CRDs, then set the `webhook.enabled=true` value when the nvidia-dra-driver-gpu chart is installed.
-
-```bash
-helm install \
-  --repo https://charts.jetstack.io \
-  --version v1.16.3 \
-  --create-namespace \
-  --namespace cert-manager \
-  --wait \
-  --set crds.enabled=true \
-  cert-manager \
-  cert-manager
-```
 
 ## A (kind) demo
 


### PR DESCRIPTION
Refer to installation instructions from the README.

As a middle-ground, as things are rather heavily in flux, point to the Wiki for now. That's also where we will for now point to from within the CNT docs until things stabilize (upon GPU Operator integration, maybe).