### PR TITLE
kubelet plugins: add /opt/bin to binary search paths

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/root.go
+++ b/cmd/compute-domain-kubelet-plugin/root.go
@@ -47,6 +47,7 @@ func (r root) getDriverLibraryPath() (string, error) {
 // getNvidiaSMIPath returns path to the `nvidia-smi` executable in the driver root.
 func (r root) getNvidiaSMIPath() (string, error) {
 	binarySearchPaths := []string{
+		"/opt/bin",
 		"/usr/bin",
 		"/usr/sbin",
 		"/bin",

--- a/cmd/gpu-kubelet-plugin/root.go
+++ b/cmd/gpu-kubelet-plugin/root.go
@@ -47,6 +47,7 @@ func (r root) getDriverLibraryPath() (string, error) {
 // getNvidiaSMIPath returns path to the `nvidia-smi` executable in the driver root.
 func (r root) getNvidiaSMIPath() (string, error) {
 	binarySearchPaths := []string{
+		"/opt/bin",
 		"/usr/bin",
 		"/usr/sbin",
 		"/bin",

--- a/hack/kubelet-plugin-prestart.sh
+++ b/hack/kubelet-plugin-prestart.sh
@@ -43,9 +43,10 @@ validate_and_exit_on_success () {
 
     NV_PATH=$( \
         find \
-            /driver-root/bin \
-            /driver-root/sbin \
+            /driver-root/opt/bin \
             /driver-root/usr/bin \
+            /driver-root/usr/sbin \
+            /driver-root/bin \
             /driver-root/sbin \
         -maxdepth 1 -type f -name "nvidia-smi" 2> /dev/null | head -n1
     )


### PR DESCRIPTION
Hello everyone!

This is my first contribution to this repository, so please feel free to point me to any requirement for contributions I might have missed.

This change in particular adds support for finding the `nvidia-smi` binary on distributions which have it installed to `/opt/bin` on the host. Flatcar Linux for example offers an NVIDIA sysext which installs the binaries and drivers when run on a GPU instance. This way you do not need to provide them via a DaemonSet or sidecar container.

Sadly the current approach of searching for the `nvidia-smi` binary does not cover `/opt/bin`. Actually the Flatcar NVIDIA sysext creates a symlink `/usr/bin/nvidia-smi`, but this is pointing to `/opt/bin/nvidia-smi`. So when either the kubelet plugin pre-start script or the kubelet plugin itself look for the `nvidia-smi` in `/driver-root/usr/bin`, they only find a symlink pointing to outside the host filesystem mounted below `/driver-root` and therefore fail to access the actual binary.

My change adds `/opt/bin` to the search directories of the pre-start script and both kubelet plugins, so they can find the real binary there before looking for it in `/usr/bin` where they would only find a dead end symlink.

Additionally I fixed a minor bug in the pre-start script: `/sbin` was duplicated there, while it most likely should be `/usr/sbin` and `/sbin`. Also I re-ordered the paths to be aligned with the kubelet plugins.

Thanks for reviewing my PR in advance
Marco