### PR TITLE
chart: add network policies

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/networkpolicy-controller.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/networkpolicy-controller.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.controller.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "nvidia-dra-driver-gpu.name" . }}-controller
+  namespace: {{ include "nvidia-dra-driver-gpu.namespace" . }}
+  labels:
+    {{- include "nvidia-dra-driver-gpu.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "nvidia-dra-driver-gpu.selectorLabels" (dict "context" . "componentName" "controller") | nindent 6 }}
+  policyTypes:
+  - Egress
+  egress:
+  # Some CNIs are not capable of controlling access to host network resources nor plain IP addresses,
+  # as they are identity based and these resources are not being covered this way.
+  #
+  # Therefore, we cannot filter egress traffic by destination using native network policies and pod selectors.
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/networkpolicy-kubelet-plugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/networkpolicy-kubelet-plugin.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.kubeletPlugin.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "nvidia-dra-driver-gpu.name" . }}-kubelet-plugin
+  namespace: {{ include "nvidia-dra-driver-gpu.namespace" . }}
+  labels:
+    {{- include "nvidia-dra-driver-gpu.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "nvidia-dra-driver-gpu.selectorLabels" (dict "context" . "componentName" "kubelet-plugin") | nindent 6 }}
+  policyTypes:
+  - Egress
+  egress:
+  # Some CNIs are not capable of controlling access to host network resources nor plain IP addresses,
+  # as they are identity based and these resources are not being covered this way.
+  #
+  # Therefore, we cannot filter egress traffic by destination using native network policies and pod selectors.
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -190,6 +190,10 @@ controller:
         - matchExpressions:
           - key: "node-role.kubernetes.io/control-plane"
             operator: "Exists"
+  # Network policy settings
+  networkPolicy:
+    # If the network policy is enabled or not
+    enabled: false
 
 kubeletPlugin:
   priorityClassName: "system-node-critical"
@@ -245,3 +249,7 @@ kubeletPlugin:
             operator: In
             values:
             - "true"
+  # Network policy settings
+  networkPolicy:
+    # If the network policy is enabled or not
+    enabled: false


### PR DESCRIPTION
When deploying the chart to clusters with network access restricted by network policies, you might not be able access the API server.

This PR adds network policies for the controller and kubelet plugin, so they can access the API server in such environments.