### PR TITLE
tests: cover basic GPU allocation, misc improvements

### DIFF
--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -107,6 +107,7 @@ tests: image
 			--timing \
 			--abort \
 			tests/bats/test_basics.bats \
+			tests/bats/test_gpu_basic.bats \
 			tests/bats/test_cd_imex_chan_inject.bats \
 			tests/bats/test_cd_mnnvl_workload.bats \
 			tests/bats/test_cd_misc.bats \

--- a/tests/bats/README.md
+++ b/tests/bats/README.md
@@ -54,7 +54,7 @@ That's CI-oriented.
 We may want to change that.
 
 
-## Development
+## Resources for development
 
 Bats is a workable solution.
 Developing new tests might however probe your patience.
@@ -64,6 +64,11 @@ Make wise usage of
 * [skipping tests](https://bats-core.readthedocs.io/en/stable/writing-tests.html#skip-easily-skip-tests)
 * [tagging tests with `bats:focus`](https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-tags)
 * [CLI args](https://bats-core.readthedocs.io/en/stable/usage.html) such as `--verbose-run`, `--show-output-of-passing-tests`.
+
+Other references:
+* https://github.com/bats-core/bats-assert
+* https://github.com/bats-core/bats-file
+
 
 Misc notes:
 

--- a/tests/bats/clean-state-dirs-all-nodes.sh
+++ b/tests/bats/clean-state-dirs-all-nodes.sh
@@ -19,11 +19,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# TODO: think about wiping /var/run/cdi, too
-
 rm_kubelet_plugin_dirs_from_node () {
     local NODE_NAME="$1"
-    echo "Run privileged pod to remove kubelet plugin directories on node ${NODE_NAME}"
+    echo "Run privileged pod to remove /run/cdi/* and kubelet plugin directories on node ${NODE_NAME}"
     kubectl run "privpod-rm-plugindirs-${NODE_NAME}" \
         --rm \
         --image=busybox \

--- a/tests/bats/cleanup-from-previous-run.sh
+++ b/tests/bats/cleanup-from-previous-run.sh
@@ -60,6 +60,7 @@ timeout -v 5 kubectl delete -f demo/specs/imex/nvbandwidth-test-job-2.yaml 2> /d
 timeout -v 5 kubectl delete -f tests/bats/specs/nvb2.yaml 2> /dev/null
 timeout -v 5 kubectl delete pods -l env=batssuite 2> /dev/null
 timeout -v 2 kubectl delete resourceclaim batssuite-rc-bad-opaque-config --force 2> /dev/null
+timeout -v 2 kubectl delete -f demo/specs/imex/simple-mig-test 2> /dev/null
 
 # TODO: maybe more brute-forcing/best-effort: it might make sense to submit all
 # workload in this test suite into a special namespace (not `default`), and to
@@ -86,4 +87,6 @@ timeout -v 10 kubectl delete crds computedomains.resource.nvidia.com || echo "CR
 # cleanup, fail hard if this does not succeed).
 set -e
 bash tests/bats/clean-state-dirs-all-nodes.sh
+
 set +x
+echo "cleanup: done"

--- a/tests/bats/helpers.sh
+++ b/tests/bats/helpers.sh
@@ -52,7 +52,7 @@ iupgrade_wait() {
     --timeout=1m5s \
     --create-namespace \
     --namespace nvidia-dra-driver-gpu \
-    --set resources.gpus.enabled=false \
+    --set gpuResourcesEnabledOverride=true \
     --set nvidiaDriverRoot="${TEST_NVIDIA_DRIVER_ROOT}" "${ADDITIONAL_INSTALL_ARGS[@]}"
 
   # Valueable output to have in the logs in case things went pearshaped.
@@ -139,7 +139,8 @@ show_kubelet_plugin_error_logs() {
     kubectl logs \
     -l nvidia-dra-driver-gpu-component=kubelet-plugin \
     -n nvidia-dra-driver-gpu \
-    --prefix --tail=-1 | grep -E "^(E|W)[0-9]{4}"
+    --all-containers \
+    --prefix --tail=-1 | grep -E "^(E|W)[0-9]{4}" -iE "error"
   ) || true
   echo -e "KUBELET PLUGIN ERROR LOGS END\n\n"
 }
@@ -190,10 +191,52 @@ nvmm() {
     --no-headers -o custom-columns=":metadata.name")
 
   if [ -z "$pod" ]; then
-    echo "No pod found on node $node"
+    echo "get pod -n gpu-operator -l app=nvidia-mig-manager: no pod found on node $node"
     return 1
   fi
 
   echo "Executing on pod $pod (node: $node)..."
   kubectl -n gpu-operator exec -it "$pod" -- "$@"
+}
+
+restart_kubelet_on_node() {
+  local NODEIP="$1"
+  echo "sytemctl restart kubelet.service on ${NODEIP}"
+  # Assume that current user has password-less sudo privileges
+  ssh "${USER}@${NODEIP}" 'sudo systemctl restart kubelet.service'
+}
+
+restart_kubelet_all_nodes() {
+  for nodeip in $(kubectl get nodes -o jsonpath='{range .items[*]}{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}'); do
+    restart_kubelet_on_node "$nodeip"
+  done
+  #wait
+  echo "restart kubelets: done"
+}
+
+kplog () {
+  if [[ -z "$1" || -z "$2" ]]; then
+    echo "Usage: kplog [gpus|compute-domains] <node-hint-for-grep> [args]"
+    return 1
+  fi
+  local nodehint="$2"
+  local cont="$1"
+  shift
+  shift # Remove first argument, leaving remaining args in $@
+
+  local node=$(kubectl get nodes | grep "$nodehint" | awk '{print $1}')
+  echo "identified node: $node"
+
+  local pod
+  pod=$(kubectl get pod -n nvidia-dra-driver-gpu -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+    --field-selector spec.nodeName="$node" \
+    --no-headers -o custom-columns=":metadata.name")
+
+  if [ -z "$pod" ]; then
+    echo " get pod -n nvidia-dra-driver-gpu -l nvidia-dra-driver-gpu-component=kubelet-plugin: no pod found on node $node"
+    return 1
+  fi
+
+  echo "Executing on pod $pod (node: $node)..."
+  kubectl logs -n nvidia-dra-driver-gpu "$pod" -c "$cont" "$@"
 }

--- a/tests/bats/specs/gpu-1pod-2cnt-1gpu.yaml
+++ b/tests/bats/specs/gpu-1pod-2cnt-1gpu.yaml
@@ -1,0 +1,39 @@
+# One pod, two containers.
+# Each asking for shared access to a single, full GPU.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-single-gpu-full
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: shared-gpu
+  - name: ctr1
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: shared-gpu
+  resourceClaims:
+  - name: shared-gpu
+    resourceClaimTemplateName: rct-single-gpu-full

--- a/tests/bats/specs/gpu-2pods-1gpu.yaml
+++ b/tests/bats/specs/gpu-2pods-1gpu.yaml
@@ -1,0 +1,51 @@
+# Simple GPU sharing scenario:
+# Two pods, one container each, each getting access to the same, shared GPU
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: rc-single-gpu-full
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: rc-single-gpu-full
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: rc-single-gpu-full
+

--- a/tests/bats/specs/gpu-2pods-2gpus.yaml
+++ b/tests/bats/specs/gpu-2pods-2gpus.yaml
@@ -1,0 +1,51 @@
+# Two pods, one container each, each container gets 1 distinct full GPU
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-single-gpu-full
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-single-gpu-full
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-single-gpu-full
+

--- a/tests/bats/specs/gpu-simple-full.yaml
+++ b/tests/bats/specs/gpu-simple-full.yaml
@@ -1,0 +1,31 @@
+# Scenario: single pod, requesting any full GPU
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-single-gpu-full
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-full-gpu
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-single-gpu-full

--- a/tests/bats/test_gpu_basic.bats
+++ b/tests/bats/test_gpu_basic.bats
@@ -1,0 +1,114 @@
+# shellcheck disable=SC2148
+# shellcheck disable=SC2329
+
+setup_file () {
+  load 'helpers.sh'
+  _common_setup
+  local _iargs=("--set" "logVerbosity=6")
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+  run kubectl logs \
+    -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+    -n nvidia-dra-driver-gpu \
+    -c gpus \
+    --prefix --tail=-1
+}
+
+# Executed before entering each test in this file.
+setup() {
+   load 'helpers.sh'
+  _common_setup
+  log_objects
+}
+
+bats::on_failure() {
+  echo -e "\n\nFAILURE HOOK START"
+  log_objects
+  show_kubelet_plugin_error_logs
+  echo -e "FAILURE HOOK END\n\n"
+}
+
+@test "1 pod(s), 1 full GPU" {
+  local _specpath="tests/bats/specs/gpu-simple-full.yaml"
+  local _podname="pod-full-gpu"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=8s
+
+  # Confirm the following pattern:
+  # GPU 0: NVIDIA GB200 (UUID: GPU-7277883e-ce1e-3b6e-6cc1-6d52e80cdb86)
+  run kubectl logs "${_podname}"
+  assert_output --partial "UUID: GPU-"
+  echo "${output}" | wc -l | grep 1
+  kubectl delete -f  "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=10s
+}
+
+@test "2 pod(s), 1 full GPU each" {
+  local _specpath="tests/bats/specs/gpu-2pods-2gpus.yaml"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods pod1 --timeout=8s
+  kubectl wait --for=condition=READY pods pod2 --timeout=8s
+
+  run kubectl logs pod1
+  assert_output --partial "UUID: GPU-"
+  echo "${output}" | wc -l | grep 1
+  local uid1="${output}"
+
+  run kubectl logs pod2
+  assert_output --partial "UUID: GPU-"
+  echo "${output}" | wc -l | grep 1
+  local uid2="${output}"
+
+  assert_not_equal "$uid1" "$uid2"
+
+  kubectl delete -f  "${_specpath}"
+  kubectl wait --for=delete pods pod1 --timeout=10s
+  kubectl wait --for=delete pods pod2 --timeout=10s
+}
+
+@test "2 pod(s), 1 full GPU (shared, 1 RC)" {
+  local _specpath="tests/bats/specs/gpu-2pods-1gpu.yaml"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods pod1 --timeout=8s
+  kubectl wait --for=condition=READY pods pod2 --timeout=8s
+
+  run kubectl logs pod1
+  assert_output --partial "UUID: GPU-"
+  echo "${output}" | wc -l | grep 1
+  local uid1="${output}"
+
+  run kubectl logs pod2
+  assert_output --partial "UUID: GPU-"
+  echo "${output}" | wc -l | grep 1
+  local uid2="${output}"
+
+  assert_equal "$uid1" "$uid2"
+
+  kubectl delete -f  "${_specpath}"
+  kubectl wait --for=delete pods pod1 --timeout=10s
+  kubectl wait --for=delete pods pod2 --timeout=10s
+}
+
+@test "1 pod(s), 2 cntrs, 1 full GPU (shared, 1 RCT)" {
+  local _specpath="tests/bats/specs/gpu-1pod-2cnt-1gpu.yaml"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods pod1 --timeout=8s
+
+  run kubectl logs pod1 -c ctr0
+  assert_output --partial "UUID: GPU-"
+  echo "${output}" | wc -l | grep 1
+  local uid1="${output}"
+
+  run kubectl logs pod1 -c ctr1
+  assert_output --partial "UUID: GPU-"
+  echo "${output}" | wc -l | grep 1
+  local uid2="${output}"
+
+  assert_equal "$uid1" "$uid2"
+
+  kubectl delete -f  "${_specpath}"
+  kubectl wait --for=delete pods pod1 --timeout=10s
+}


### PR DESCRIPTION
As I work on [dynamic MIG device allocation support](https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/361), I need to rely on tests to not break what currently works. So, I started covering basic GPU allocation functionality in the test suite.

This patch also contains changes for test environment management, cleanup helper adjustments, etc.

Tests are passing (the section `test_gpu_basic.bats` below is new):
```
test_basics.bats
 ✓ test VERSION_W_COMMIT, VERSION_GHCR_CHART, VERSION [195]
 ✓ confirm no kubelet plugin pods running [176]
 ✓ helm-install deployments/helm/nvidia-dra-driver-gpu/25.12.0-dev [6809]
 ✓ helm list: validate output [229]
 ✓ get crd computedomains.resource.nvidia.com [156]
 ✓ wait for plugin & controller pods READY [752]
 ✓ validate CD controller container image spec [167]
test_gpu_basic.bats
 ✓ 1 pod(s), 1 full GPU [4297]
 ✓ 2 pod(s), 1 full GPU each [5180]
 ✓ 2 pod(s), 1 full GPU (shared, 1 RC) [5097]
 ✓ 1 pod(s), 2 cntrs, 1 full GPU (shared, 1 RCT) [4559]
test_cd_imex_chan_inject.bats
 ✓ IMEX channel injection (single) [13210]
 ✓ IMEX channel injection (all) [9381]
test_cd_mnnvl_workload.bats
 ✓ nickelpie (NCCL send/recv/broadcast, 2 pods, 2 nodes, small payload) [10567]
 ✓ nvbandwidth (2 nodes, 2 GPUs each) [26027]
test_cd_misc.bats
 ✓ CD daemon shutdown: confirm CD status cleanup [13226]
 ✓ reject unknown field in opaque cfg in CD chan ResourceClaim [9341]
 ✓ self-initiated unprepare of stale RCs in PrepareStarted [24027]
test_cd_logging.bats
 ✓ CD controller/plugin: startup config / detail in logs on level 0 [5993]
 ✓ CD controller: test log verbosity levels [52444]
 ✓ CD daemon: test log verbosity levels [30684]
test_cd_failover.bats
 ✓ CD failover nvb2: force-delete worker pod 0 [60367]
 ✓ CD failover nvb2: force-delete all IMEX daemons [39743]
 ✓ CD failover nvb2: regular-delete worker pod 1 [53460]
test_cd_updowngrade.bats
 ✓ downgrade: current-dev -> last-stable [40410]
 ✓ upgrade: wipe-state, install-last-stable, upgrade-to-current-dev [32076]

26 tests, 0 failures in 473 seconds
```
