### PR TITLE
Add an extended resource name in the default device-class for full GPU requests

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-gpu.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/deviceclass-gpu.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.resources.gpus.enabled }}
+{{- $resourceApiVersion := (include "nvidia-dra-driver-gpu.resourceApiVersion" . | trim) }}
 ---
-apiVersion: {{ include "nvidia-dra-driver-gpu.resourceApiVersion" . }}
+apiVersion: {{ $resourceApiVersion }}
 kind: DeviceClass
 metadata:
   name: gpu.nvidia.com
@@ -8,4 +9,7 @@ spec:
   selectors:
   - cel:
       expression: "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].type == 'gpu'"
+  {{- if eq $resourceApiVersion "resource.k8s.io/v1" }}
+  extendedResourceName: nvidia.com/gpu
+  {{- end }}
 {{- end }}


### PR DESCRIPTION


* This allows users to continue using extended resource requests in a pod to request either extended resoures provided by the device-plugin or DRA.
* To make use of this, users need to enable an alpha feature gate 'DRAExtendedResource'