### PR TITLE
gpu plugin: fix check for 'already prepared' (do earlier)

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -155,6 +155,20 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		return nil, fmt.Errorf("unable to get checkpoint: %v", err)
 	}
 
+	// Check for existing 'completed' claim preparation before updating the
+	// checkpoint with 'PrepareStarted'. Otherwise, we effectively mark a
+	// perfectly prepared claim as only partially prepared, which may have
+	// negative side effects during Unprepare() (currently a noop in this case:
+	// unprepare noop: claim preparation started but not completed).
+	preparedClaim, exists := checkpoint.V2.PreparedClaims[claimUID]
+	if exists && preparedClaim.CheckpointState == ClaimCheckpointStatePrepareCompleted {
+		// Make this a noop. Associated device(s) has/ave been prepared by us.
+		// Prepare() must be idempotent, as it may be invoked more than once per
+		// claim (and actual device preparation must happen at most once).
+		klog.V(6).Infof("skip prepare: claim %v found in checkpoint", claimUID)
+		return preparedClaim.PreparedDevices.GetDevices(), nil
+	}
+
 	err = s.updateCheckpoint(func(checkpoint *Checkpoint) {
 		checkpoint.V2.PreparedClaims[claimUID] = PreparedClaim{
 			CheckpointState: ClaimCheckpointStatePrepareStarted,
@@ -165,15 +179,6 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		return nil, fmt.Errorf("unable to update checkpoint: %w", err)
 	}
 	klog.V(6).Infof("checkpoint updated for claim %v", claimUID)
-
-	preparedClaim, exists := checkpoint.V2.PreparedClaims[claimUID]
-	if exists && preparedClaim.CheckpointState == ClaimCheckpointStatePrepareCompleted {
-		// Make this a noop. Associated device(s) has/ave been prepared by us.
-		// Prepare() must be idempotent, as it may be invoked more than once per
-		// claim (and actual device preparation must happen at most once).
-		klog.V(6).Infof("skip prepare: claim %v found in checkpoint", claimUID)
-		return preparedClaim.PreparedDevices.GetDevices(), nil
-	}
 
 	preparedDevices, err := s.prepareDevices(ctx, claim)
 	if err != nil {


### PR DESCRIPTION
A cherry-pick from https://github.com/NVIDIA/k8s-dra-driver-gpu/commit/c12821abd86a99e647d044f5773ff917355f080f (tiny adjustment: the logrus import removed compared to the referenced commit).

Bailing out first is a simple fix for what's described in https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/729:

> the current flow incorrectly regresses the state from PrepareCompleted back to PrepareStarted

(in a second potential prepare call)

Consider this sequence:
1) prepare
2) prepare (again, for various reasons -- kubelet thinks that device is not yet prepared)
3) unprepare 

Then, as shown in the commit message of c12821abd86a99e647d044f5773ff917355f080f, the unprepare fails erroneously, and forever.

Another fallout is as described in #727: the device may be actually prepared multiple times for subsequent prepare() calls (that may or may not be a problem, depending on what exactly prepare does). In any case, when prepare for a specific claim succeeded once, we never want to execute its business logic again. Instead, by design, we want to perform a noop and return a success response.

This here is a simple patch that restores symmetry with what we do in the CD kubelet plugin (where the order of events is correct: first bail out, only after that update to PrepareStarted).

Other ideas in https://github.com/NVIDIA/k8s-dra-driver-gpu/pull/727 are generally good I think, but let's do more explicit state transition management separately, and keep code changes a little more minimal for now.

---

Note that the issue here was an oversight upon copy/pasting code -- the order of events was correctly implemented for the CD plugin:
https://github.com/NVIDIA/k8s-dra-driver-gpu/commit/614e93d186229a40807148e252238ad05a60199a#diff-0c4212f56ec6c0eb3553c9f7d86fa15f619e3d8f036912e83e12645b8f17e50dR148

In the same patch we put the checkpoint update accidentally above the 'bail out fast':
https://github.com/NVIDIA/k8s-dra-driver-gpu/commit/614e93d186229a40807148e252238ad05a60199a#diff-75b1b8582a3f9e23dca1c67f0532dbf0e95e6ed9fde0760290d6c739ab7dbd32R157


