### PR TITLE
ci: skip bash build (use pre-built binary)

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -45,19 +45,12 @@ RUN apt-get update && \
         gcc-aarch64-linux-gnu \
         gcc
 
-# Install dependencies for `bash-static` build.
-RUN apt-get install -y gpg curl autoconf file
-
-# Build static bash binary (against musl).
-WORKDIR /bashbuild
-RUN git clone https://github.com/robxu9/bash-static/
 
 RUN wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${BUILDARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
-
 WORKDIR /build
 
 # Copy everything that is needed for the go build, but do not invalidate go
@@ -82,8 +75,22 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi && \
     make CC=${cc} GOARCH=${TARGETARCH} PREFIX=/artifacts cmds
 
-# GNU mirrors are down, building bash from source has been a bit of a pain for
-# various reasons. Use binaries built before, from an older image.
+# Build static bash binary (against musl). Notes: cross-compilation isn't
+# robust (see non-deterministic segfaults tracked in issues/502; source code
+# download instabilities tracked in issues/743) and generally takes signifiant
+# time even on happy path (dominiates CI duration as of the time of writing). Do
+# not build this every time. Instead, consume it from a previous image on GHCR
+# -- also, leave machinery (out-commented) in place.
+#
+# Choose: 1) fresh bash build or 2) use binary from previous image
+#
+# option 1:
+# WORKDIR /bashbuild
+# COPY hack/build-bash-static.sh .
+# RUN export BASH_STATIC_GIT_REF && bash /bashbuild/build-bash-static.sh
+# RUN cd /bashbuild/bash-static/releases && ./bash*-static --version && mv bash-*-static /bashbuild/bash && file /bashbuild/bash
+
+# option 2:
 FROM ghcr.io/nvidia/k8s-dra-driver-gpu:v25.12.0-dev-839e966a AS bash
 
 # Pull the nvidia-cdi-hook binary out of the relevant toolkit container
@@ -118,8 +125,13 @@ LABEL org.opencontainers.image.source="https://github.com/NVIDIA/k8s-dra-driver-
 # Add top-level license (AL2) file into the container image
 COPY LICENSE /
 
-COPY --from=toolkit /artifacts/rpm/usr/bin/nvidia-cdi-hook    /usr/bin/nvidia-cdi-hook
+# option 1: fresh bash build
+#COPY --from=build   /bashbuild/bash                           /bin/bash
+
+# option 2: bash from previous image
 COPY --from=bash    /bin/bash                                 /bin/bash
+
+COPY --from=toolkit /artifacts/rpm/usr/bin/nvidia-cdi-hook    /usr/bin/nvidia-cdi-hook
 COPY --from=build   /artifacts/compute-domain-controller      /usr/bin/compute-domain-controller
 COPY --from=build   /artifacts/compute-domain-kubelet-plugin  /usr/bin/compute-domain-kubelet-plugin
 COPY --from=build   /artifacts/compute-domain-daemon          /usr/bin/compute-domain-daemon

--- a/hack/build-bash-static.sh
+++ b/hack/build-bash-static.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+# Debug-log input values.
+declare -p TARGETARCH
+declare -p BASH_STATIC_GIT_REF
+
+# Dependencies for bash-static build.
+apt-get install -y gpg curl autoconf file
+
+git clone https://github.com/robxu9/bash-static/
+
+# Copied unchanged from Dockerfile. Can of course be improved for readability.
+ARCH="$TARGETARCH" && STRIP=strip && \
+[ "$ARCH" = "arm64" ] && ARCH="aarch64" || true && \
+[ "$ARCH" = "amd64" ] && ARCH="x86_64" || true && \
+[ "$ARCH" = "aarch64" ] && STRIP="aarch64-linux-gnu-strip" && CC="aarch64-linux-gnu-gcc" || true && \
+echo "detected arch: $ARCH" && \
+echo "cc to use: $CC" && \
+echo "strip to use: $STRIP" && \
+cd bash-static && git checkout ${BASH_STATIC_GIT_REF} && \
+sed -i 's|https://ftp\.gnu\.org/gnu|https://mirrors.kernel.org/gnu/|g' ./build.sh && \
+sed -i 's/-sLO/-sSfLO --retry 300 --connect-timeout 20 --retry-delay 5 --retry-all-errors /g' ./build.sh && \
+sed -i 's/strip/$STRIP/g' ./build.sh && \
+sed -i 's/make -s \&\& make -s tests/make -j4/g' ./build.sh && \
+bash version-52.sh && STRIP=$STRIP CC=$CC ./build.sh linux $ARCH


### PR DESCRIPTION
Relief for:
https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/743
https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/502

And for significantly reducing overall CI duration (currently, at least, this image build dominates that).

It's a pragmatic change motivated by acute pain perceived (accumulated over the last weeks/months).

Of course we can and will shift gears further. 

## Before:
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/0006e67d-83ed-4008-994d-8d786b80d7cb" />

or

<img width="350" alt="image" src="https://github.com/user-attachments/assets/7ee68cec-1401-4e7e-bd68-c19618371d4d" />

or up to 15 minutes.


## After:
<img width="425" height="41" alt="image" src="https://github.com/user-attachments/assets/34ba455e-e60b-4193-80ad-08f2f670b502" />


## Next:
Let's also use cross-runner container image layer cache; so that we don't need to build the image from scratch every single time. That's rather ridiculous; any more or less normal CI uses the container image layer cache to a full extent, across runners.
