### PR TITLE
Updated the Go download URL 

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && \
         gcc
 
 
-RUN wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${BUILDARCH}.tar.gz \
+RUN wget -nv -O - https://go.dev/dl/go${GOLANG_VERSION}.linux-${BUILDARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV GOPATH=/go


### PR DESCRIPTION
Updated the Go download URL from storage.googleapis.com to the official go.dev/dl endpoint

For reference see:
* https://github.com/actions/setup-go/issues/664
* https://github.com/NVIDIA/libnvidia-container/pull/333
* https://github.com/NVIDIA/nvidia-container-toolkit/pull/1506