### PR TITLE
Allow `resource.k8s.io` API version override via Helm chart parameter

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/_helpers.tpl
@@ -172,10 +172,15 @@ Get all namespaces (driver namespace + additional namespaces from environment va
 
 {{/*
 Get the latest available resource.k8s.io API version
-Returns the highest available version or empty string if none found
+
+Priority:
+  1. If .Values.resourceApiVersion is set, use that.
+  2. Otherwise, returns the highest available version or empty string if none found
 */}}
 {{- define "nvidia-dra-driver-gpu.resourceApiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "resource.k8s.io/v1" -}}
+{{- if .Values.resourceApiVersion }}
+{{- .Values.resourceApiVersion }}
+{{- else if .Capabilities.APIVersions.Has "resource.k8s.io/v1" -}}
 resource.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "resource.k8s.io/v1beta2" -}}
 resource.k8s.io/v1beta2

--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -34,6 +34,20 @@ gpuResourcesEnabledOverride: false
 
 allowDefaultNamespace: false
 
+# resourceApiVersion sets the resource.k8s.io API version used for DRA resources (DeviceClass,
+# ResourceClaim, ResourceClaimTemplate).
+#
+# By default, the chart auto-detects the highest supported version from the
+# cluster via .Capabilities.APIVersions (v1 > v1beta2 > v1beta1). However, some
+# environments may incorrectly report supported versions, causing Helm to render
+# manifests with an API version that the API server does not actually serve.
+#
+# Set this field to explicitly override auto-detection:
+#   resourceApiVersion: "resource.k8s.io/v1beta1"
+#
+# Leave empty to use auto-detection.
+resourceApiVersion: ""
+
 imagePullSecrets: []
 image:
   repository: nvcr.io/nvidia/k8s-dra-driver-gpu


### PR DESCRIPTION
Add resourceApiVersion Helm parameter that allows overriding API version. 

Fix for https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/728

Test:
```
$ helm template test . --namespace gpu-test --kube-version 1.32.0 --api-versions resource.k8s.io/v1 --api-versions resource.k8s.io/v1beta1  --set resourceApiVersion="resource.k8s.io/v1beta1"  --set resources.gpus.enabled=false   | grep -A2 '^apiVersion: resource.k8s.io'
apiVersion: resource.k8s.io/v1beta1
kind: DeviceClass
metadata:
--
apiVersion: resource.k8s.io/v1beta1
kind: DeviceClass
metadata:
```
