### PR TITLE
don't panic if vfio-pci module is not loaded

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -98,11 +98,13 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 
 	var vfioPciManager *VfioPciManager
 	if featuregates.Enabled(featuregates.PassthroughSupport) {
-		manager := NewVfioPciManager(string(containerDriverRoot), string(hostDriverRoot), nvdevlib, true /* nvidiaEnabled */)
-		if err := manager.Prechecks(); err == nil {
-			vfioPciManager = manager
-		} else {
-			klog.Warningf("vfio-pci manager failed prechecks, will not be initialize: %v", err)
+		vfioPciManager = NewVfioPciManager(string(containerDriverRoot), string(hostDriverRoot), nvdevlib, true /* nvidiaEnabled */)
+	}
+
+	// Validate passthrough support if feature gate is enabled.
+	if featuregates.Enabled(featuregates.PassthroughSupport) {
+		if err := vfioPciManager.ValidatePassthroughSupport(); err != nil {
+			klog.Fatalf("Failed to validate passthrough support: %v", err)
 		}
 	}
 

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -72,8 +72,8 @@ func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib 
 	return vm
 }
 
-// PreChecks tests if vfio-pci device allocations can be used.
-func (vm *VfioPciManager) Prechecks() error {
+// ValidatePassthroughSupport tests if vfio-pci device allocations can be used.
+func (vm *VfioPciManager) ValidatePassthroughSupport() error {
 	if !vm.isVfioPCIModuleLoaded() {
 		return fmt.Errorf("vfio_pci module is not loaded")
 	}
@@ -110,7 +110,10 @@ func (vm *VfioPciManager) isIommuEnabled() (bool, error) {
 func (vm *VfioPciManager) isVfioPCIModuleLoaded() bool {
 	f, err := os.Stat(filepath.Join(sysModulesRoot, vfioPciModule))
 	if err != nil {
-		klog.Fatalf("failed to check if vfio_pci module is loaded: %v", err)
+		if os.IsNotExist(err) {
+			return false
+		}
+		klog.Fatalf("Failed to check if vfio_pci module is loaded: %v", err)
 	}
 
 	if !f.IsDir() {


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/803

Verified the kubeletplugin pod doesnt panic when the vfio_pci module is not loaded on startup:
```
# BEFORE
$ ls /sys/module | grep vfio
vfio
vfio_iommu_type

# RESTART kubelet-plugin
$ kubectl rollout restart ds nvidia-dra-driver-gpu-kubelet-plugin -n nvidia-dra-driver-gpu

# AFTER
$ ls /sys/module | grep vfio
vfio
vfio_iommu_type1
vfio_pci
vfio_pci_core
```