### PR TITLE
fix: check existence of ComputeDomain in cache before processing updates

### DIFF
--- a/cmd/compute-domain-controller/computedomain.go
+++ b/cmd/compute-domain-controller/computedomain.go
@@ -234,6 +234,14 @@ func (m *ComputeDomainManager) onAddOrUpdate(ctx context.Context, obj any) error
 
 	klog.V(2).Infof("Processing added or updated ComputeDomain: %s/%s/%s", cd.Namespace, cd.Name, cd.UID)
 
+	cd, err := m.Get(string(cd.UID))
+	if err != nil {
+		return fmt.Errorf("error getting ComputeDomain: %w", err)
+	}
+	if cd == nil {
+		return nil
+	}
+
 	if cd.GetDeletionTimestamp() != nil {
 		if err := m.resourceClaimTemplateManager.Delete(ctx, string(cd.UID)); err != nil {
 			return fmt.Errorf("error deleting ResourceClaimTemplate: %w", err)


### PR DESCRIPTION
fix https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/799

We found if the compute domain is removed from the cluster before the controller can pickup the update, it will constantly requeue the update for the removed domain, without dropping it from the queue.