### PR TITLE
Precalculate a per-cliqueID node index at DRA driver startup

### DIFF
--- a/cmd/compute-domain-controller/cliqueconfigmap.go
+++ b/cmd/compute-domain-controller/cliqueconfigmap.go
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2025 NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// cliqueConfigMapPrefix is the prefix for ConfigMaps that store clique node-to-index mappings.
+	cliqueConfigMapPrefix = "clique-"
+)
+
+// CliqueConfigMapManager watches kubelet plugin pods and maintains ConfigMaps
+// with node-name to index mappings for each clique.
+type CliqueConfigMapManager struct {
+	config        *ManagerConfig
+	waitGroup     sync.WaitGroup
+	cancelContext context.CancelFunc
+
+	factory  informers.SharedInformerFactory
+	informer cache.SharedIndexInformer
+}
+
+// NewCliqueConfigMapManager creates a new CliqueConfigMapManager that watches
+// kubelet plugin pods with the computeDomainCliqueLabelKey label.
+func NewCliqueConfigMapManager(config *ManagerConfig) *CliqueConfigMapManager {
+	labelSelector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      computeDomainCliqueLabelKey,
+				Operator: metav1.LabelSelectorOpExists,
+			},
+		},
+	}
+
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		config.clientsets.Core,
+		informerResyncPeriod,
+		informers.WithNamespace(config.driverNamespace),
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.LabelSelector = metav1.FormatLabelSelector(labelSelector)
+		}),
+	)
+
+	informer := factory.Core().V1().Pods().Informer()
+
+	m := &CliqueConfigMapManager{
+		config:   config,
+		factory:  factory,
+		informer: informer,
+	}
+
+	return m
+}
+
+// Start begins watching kubelet plugin pods and managing clique ConfigMaps.
+func (m *CliqueConfigMapManager) Start(ctx context.Context) (rerr error) {
+	ctx, cancel := context.WithCancel(ctx)
+	m.cancelContext = cancel
+
+	defer func() {
+		if rerr != nil {
+			if err := m.Stop(); err != nil {
+				klog.Errorf("error stopping CliqueConfigMap manager: %v", err)
+			}
+		}
+	}()
+
+	_, err := m.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			m.config.workQueue.Enqueue(obj, m.onPodAddOrUpdate)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			m.config.workQueue.Enqueue(newObj, m.onPodAddOrUpdate)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error adding event handlers for pod informer: %w", err)
+	}
+
+	m.waitGroup.Add(1)
+	go func() {
+		defer m.waitGroup.Done()
+		m.factory.Start(ctx.Done())
+	}()
+
+	if !cache.WaitForCacheSync(ctx.Done(), m.informer.HasSynced) {
+		return fmt.Errorf("error syncing pod informer cache")
+	}
+
+	return nil
+}
+
+// Stop stops the CliqueConfigMapManager.
+func (m *CliqueConfigMapManager) Stop() error {
+	if m.cancelContext != nil {
+		m.cancelContext()
+	}
+	m.waitGroup.Wait()
+	return nil
+}
+
+// onPodAddOrUpdate handles pod add/update events by ensuring the node is in the
+// clique's ConfigMap with a stable index.
+func (m *CliqueConfigMapManager) onPodAddOrUpdate(ctx context.Context, obj any) error {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return fmt.Errorf("failed to cast to Pod")
+	}
+
+	nodeName := pod.Spec.NodeName
+	if nodeName == "" {
+		return nil
+	}
+
+	cliqueID := pod.Labels[computeDomainCliqueLabelKey]
+	if cliqueID == "" {
+		return nil
+	}
+
+	return m.ensureNodeInConfigMap(ctx, cliqueID, nodeName)
+}
+
+// ensureNodeInConfigMap ensures a node is present in the clique's ConfigMap.
+// If the node is already present, its index is preserved.
+// If the node is new, it gets the lowest available index.
+func (m *CliqueConfigMapManager) ensureNodeInConfigMap(ctx context.Context, cliqueID, nodeName string) error {
+	cmName := cliqueConfigMapPrefix + cliqueID
+
+	cm, err := m.config.clientsets.Core.CoreV1().ConfigMaps(m.config.driverNamespace).Get(ctx, cmName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return m.createConfigMap(ctx, cmName, nodeName)
+	}
+	if err != nil {
+		return fmt.Errorf("get ConfigMap: %w", err)
+	}
+
+	if _, exists := cm.Data[nodeName]; exists {
+		return nil
+	}
+
+	return m.addNodeToConfigMap(ctx, cm, nodeName)
+}
+
+// createConfigMap creates a new ConfigMap with the given node at index 0.
+func (m *CliqueConfigMapManager) createConfigMap(ctx context.Context, cmName, nodeName string) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: m.config.driverNamespace,
+		},
+		Data: map[string]string{
+			nodeName: "0",
+		},
+	}
+
+	if _, err := m.config.clientsets.Core.CoreV1().ConfigMaps(m.config.driverNamespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create ConfigMap: %w", err)
+	}
+
+	klog.Infof("Created ConfigMap %s", cmName)
+	return nil
+}
+
+// addNodeToConfigMap adds a node to an existing ConfigMap with the next available index.
+func (m *CliqueConfigMapManager) addNodeToConfigMap(ctx context.Context, cm *corev1.ConfigMap, nodeName string) error {
+	nextIndex, err := m.getNextAvailableIndex(cm.Data)
+	if err != nil {
+		return fmt.Errorf("get next available index: %w", err)
+	}
+
+	newCM := cm.DeepCopy()
+	if newCM.Data == nil {
+		newCM.Data = make(map[string]string)
+	}
+	newCM.Data[nodeName] = strconv.Itoa(nextIndex)
+
+	if _, err := m.config.clientsets.Core.CoreV1().ConfigMaps(m.config.driverNamespace).Update(ctx, newCM, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update ConfigMap: %w", err)
+	}
+
+	klog.Infof("Added node %s to ConfigMap %s at index %d", nodeName, cm.Name, nextIndex)
+	return nil
+}
+
+// getNextAvailableIndex finds the lowest available index not currently assigned.
+// Returns an error if no index is available within maxNodesPerIMEXDomain.
+func (m *CliqueConfigMapManager) getNextAvailableIndex(data map[string]string) (int, error) {
+	usedIndices := make(map[int]bool)
+
+	for _, indexStr := range data {
+		if index, err := strconv.Atoi(indexStr); err == nil {
+			usedIndices[index] = true
+		}
+	}
+
+	// Find the next available index, starting from 0 and filling gaps
+	nextIndex := 0
+	for usedIndices[nextIndex] {
+		nextIndex++
+	}
+
+	if nextIndex >= m.config.maxNodesPerIMEXDomain {
+		return -1, fmt.Errorf("no available index within maxNodesPerIMEXDomain (%d)", m.config.maxNodesPerIMEXDomain)
+	}
+
+	return nextIndex, nil
+}

--- a/cmd/compute-domain-controller/computedomain.go
+++ b/cmd/compute-domain-controller/computedomain.go
@@ -43,8 +43,9 @@ const (
 	// not so long that stale entries cause issues.
 	mutationCacheTTL = time.Hour
 
-	computeDomainLabelKey  = "resource.nvidia.com/computeDomain"
-	computeDomainFinalizer = computeDomainLabelKey
+	computeDomainLabelKey       = "resource.nvidia.com/computeDomain"
+	computeDomainCliqueLabelKey = "resource.nvidia.com/computeDomain.cliqueID"
+	computeDomainFinalizer      = computeDomainLabelKey
 
 	computeDomainDefaultChannelDeviceClass = "compute-domain-default-channel.nvidia.com"
 	computeDomainChannelDeviceClass        = "compute-domain-channel.nvidia.com"

--- a/cmd/compute-domain-controller/controller.go
+++ b/cmd/compute-domain-controller/controller.go
@@ -90,12 +90,21 @@ func (c *Controller) Run(ctx context.Context) error {
 	klog.Infof("controller manager config: %+v", managerConfig)
 
 	cdManager := NewComputeDomainManager(managerConfig)
+	cliqueConfigMapManager := NewCliqueConfigMapManager(managerConfig)
 
 	if err := cdManager.Start(ctx); err != nil {
 		return fmt.Errorf("error starting ComputeDomain manager: %w", err)
 	}
 
+	if err := cliqueConfigMapManager.Start(ctx); err != nil {
+		return fmt.Errorf("error starting CliqueConfigMap manager: %w", err)
+	}
+
 	workQueue.Run(ctx)
+
+	if err := cliqueConfigMapManager.Stop(); err != nil {
+		return fmt.Errorf("error stopping CliqueConfigMap manager: %w", err)
+	}
 
 	if err := cdManager.Stop(); err != nil {
 		return fmt.Errorf("error stopping ComputeDomain manager: %w", err)

--- a/cmd/compute-domain-controller/controller.go
+++ b/cmd/compute-domain-controller/controller.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/NVIDIA/k8s-dra-driver-gpu/pkg/flags"
-	"github.com/NVIDIA/k8s-dra-driver-gpu/pkg/workqueue"
 )
 
 // ManagerConfig defines the common configuration options shared across all managers.
@@ -45,9 +44,6 @@ type ManagerConfig struct {
 
 	// clientsets provides access to various Kubernetes API client interfaces
 	clientsets flags.ClientSets
-
-	// workQueue manages the asynchronous processing of tasks
-	workQueue *workqueue.WorkQueue
 
 	// additionalNamespaces is a list of additional namespaces
 	// where the driver can manage resources
@@ -70,11 +66,8 @@ func NewController(config *Config) *Controller {
 }
 
 // Run starts the controller's main loop and manages the lifecycle of its components.
-// It initializes the work queue, starts the ComputeDomain manager, and handles
-// graceful shutdown when the context is cancelled.
+// It starts the managers and handles graceful shutdown when the context is cancelled.
 func (c *Controller) Run(ctx context.Context) error {
-	workQueue := workqueue.New(workqueue.DefaultControllerRateLimiter())
-
 	managerConfig := &ManagerConfig{
 		driverName:            c.config.driverName,
 		driverNamespace:       c.config.flags.namespace,
@@ -82,7 +75,6 @@ func (c *Controller) Run(ctx context.Context) error {
 		imageName:             c.config.flags.imageName,
 		maxNodesPerIMEXDomain: c.config.flags.maxNodesPerIMEXDomain,
 		clientsets:            c.config.clientsets,
-		workQueue:             workQueue,
 		logVerbosityCDDaemon:  c.config.flags.logVerbosityCDDaemon,
 	}
 
@@ -100,7 +92,8 @@ func (c *Controller) Run(ctx context.Context) error {
 		return fmt.Errorf("error starting CliqueConfigMap manager: %w", err)
 	}
 
-	workQueue.Run(ctx)
+	// Wait for context cancellation
+	<-ctx.Done()
 
 	if err := cliqueConfigMapManager.Stop(); err != nil {
 		return fmt.Errorf("error stopping CliqueConfigMap manager: %w", err)

--- a/cmd/compute-domain-controller/daemonset.go
+++ b/cmd/compute-domain-controller/daemonset.go
@@ -130,18 +130,6 @@ func (m *DaemonSetManager) Start(ctx context.Context) (rerr error) {
 		true,
 	)
 
-	_, err := m.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			m.config.workQueue.Enqueue(obj, m.onAddOrUpdate)
-		},
-		UpdateFunc: func(objOld, objNew any) {
-			m.config.workQueue.Enqueue(objNew, m.onAddOrUpdate)
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("error adding event handlers for DaemonSet informer: %w", err)
-	}
-
 	m.waitGroup.Add(1)
 	go func() {
 		defer m.waitGroup.Done()
@@ -356,35 +344,6 @@ func (m *DaemonSetManager) assertRemoved(ctx context.Context, cdUID string) erro
 	if len(ds) != 0 {
 		return fmt.Errorf("still exists")
 	}
-	return nil
-}
-
-func (m *DaemonSetManager) onAddOrUpdate(ctx context.Context, obj any) error {
-	d, ok := obj.(*appsv1.DaemonSet)
-	if !ok {
-		return fmt.Errorf("failed to cast to DaemonSet")
-	}
-
-	klog.V(2).Infof("Processing added or updated DaemonSet: %s/%s", d.Namespace, d.Name)
-
-	cd, err := m.getComputeDomain(d.Labels[computeDomainLabelKey])
-	if err != nil {
-		return fmt.Errorf("error getting ComputeDomain: %w", err)
-	}
-	if cd == nil {
-		return nil
-	}
-
-	if int(d.Status.NumberReady) != cd.Spec.NumNodes {
-		return nil
-	}
-
-	newCD := cd.DeepCopy()
-	newCD.Status.Status = nvapi.ComputeDomainStatusReady
-	if _, err = m.config.clientsets.Nvidia.ResourceV1beta1().ComputeDomains(newCD.Namespace).UpdateStatus(ctx, newCD, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("error updating nodes in ComputeDomain status: %w", err)
-	}
-
 	return nil
 }
 

--- a/cmd/compute-domain-controller/daemonset.go
+++ b/cmd/compute-domain-controller/daemonset.go
@@ -36,6 +36,7 @@ import (
 
 	nvapi "github.com/NVIDIA/k8s-dra-driver-gpu/api/nvidia.com/resource/v1beta1"
 	"github.com/NVIDIA/k8s-dra-driver-gpu/pkg/featuregates"
+	"github.com/NVIDIA/k8s-dra-driver-gpu/pkg/workqueue"
 )
 
 const (
@@ -72,7 +73,7 @@ type DaemonSetManager struct {
 	cleanupManager               *CleanupManager[*appsv1.DaemonSet]
 }
 
-func NewDaemonSetManager(config *ManagerConfig, getComputeDomain GetComputeDomainFunc, updateComputeDomainStatus UpdateComputeDomainStatusFunc) *DaemonSetManager {
+func NewDaemonSetManager(config *ManagerConfig, workQueue *workqueue.WorkQueue, getComputeDomain GetComputeDomainFunc, updateComputeDomainStatus UpdateComputeDomainStatusFunc) *DaemonSetManager {
 	labelSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
@@ -99,7 +100,7 @@ func NewDaemonSetManager(config *ManagerConfig, getComputeDomain GetComputeDomai
 		factory:          factory,
 		informer:         informer,
 	}
-	m.daemonsetPodManager = NewDaemonSetPodManager(config, getComputeDomain, updateComputeDomainStatus)
+	m.daemonsetPodManager = NewDaemonSetPodManager(config, workQueue, getComputeDomain, updateComputeDomainStatus)
 	m.resourceClaimTemplateManager = NewDaemonSetResourceClaimTemplateManager(config, getComputeDomain)
 	m.cleanupManager = NewCleanupManager[*appsv1.DaemonSet](informer, getComputeDomain, m.cleanup)
 

--- a/cmd/compute-domain-controller/mnsdaemonset.go
+++ b/cmd/compute-domain-controller/mnsdaemonset.go
@@ -23,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 
 	nvapi "github.com/NVIDIA/k8s-dra-driver-gpu/api/nvidia.com/resource/v1beta1"
+	"github.com/NVIDIA/k8s-dra-driver-gpu/pkg/workqueue"
 )
 
 // MultiNamespaceDaemonSetManager manages DaemonSets across multiple namespaces.
@@ -33,7 +34,7 @@ type MultiNamespaceDaemonSetManager struct {
 
 // NewMultiNamespaceDaemonSetManager creates a new multi-namespace DaemonSet manager
 // It creates individual DaemonSet managers for the driver namespace and all additional namespaces.
-func NewMultiNamespaceDaemonSetManager(config *ManagerConfig, getComputeDomain GetComputeDomainFunc, updateComputeDomainStatus UpdateComputeDomainStatusFunc) *MultiNamespaceDaemonSetManager {
+func NewMultiNamespaceDaemonSetManager(config *ManagerConfig, workQueue *workqueue.WorkQueue, getComputeDomain GetComputeDomainFunc, updateComputeDomainStatus UpdateComputeDomainStatusFunc) *MultiNamespaceDaemonSetManager {
 	m := &MultiNamespaceDaemonSetManager{
 		config:   config,
 		managers: make(map[string]*DaemonSetManager),
@@ -51,7 +52,7 @@ func NewMultiNamespaceDaemonSetManager(config *ManagerConfig, getComputeDomain G
 		configNew := *config
 		configNew.driverNamespace = ns
 		configNew.additionalNamespaces = nil
-		m.managers[ns] = NewDaemonSetManager(&configNew, getComputeDomain, updateComputeDomainStatus)
+		m.managers[ns] = NewDaemonSetManager(&configNew, workQueue, getComputeDomain, updateComputeDomainStatus)
 	}
 
 	return m

--- a/cmd/compute-domain-daemon/controller.go
+++ b/cmd/compute-domain-daemon/controller.go
@@ -34,6 +34,7 @@ type ManagerConfig struct {
 	computeDomainName      string
 	computeDomainNamespace string
 	cliqueID               string
+	cliqueNodeIndex        int
 	podIP                  string
 	podName                string
 	podNamespace           string
@@ -47,6 +48,7 @@ type ControllerConfig struct {
 	computeDomainName      string
 	computeDomainNamespace string
 	cliqueID               string
+	cliqueNodeIndex        int
 	podIP                  string
 	podName                string
 	podNamespace           string
@@ -78,6 +80,7 @@ func NewController(config *ControllerConfig) (*Controller, error) {
 		computeDomainName:      config.computeDomainName,
 		computeDomainNamespace: config.computeDomainNamespace,
 		cliqueID:               config.cliqueID,
+		cliqueNodeIndex:        config.cliqueNodeIndex,
 		podIP:                  config.podIP,
 		podName:                config.podName,
 		podNamespace:           config.podNamespace,

--- a/cmd/compute-domain-daemon/main.go
+++ b/cmd/compute-domain-daemon/main.go
@@ -49,6 +49,7 @@ const (
 
 type Flags struct {
 	cliqueID               string
+	cliqueNodeIndex        int
 	computeDomainUUID      string
 	computeDomainName      string
 	computeDomainNamespace string
@@ -100,6 +101,12 @@ func newApp() *cli.App {
 			Usage:       "The clique ID for this node.",
 			EnvVars:     []string{"CLIQUE_ID"},
 			Destination: &flags.cliqueID,
+		},
+		&cli.IntFlag{
+			Name:        "clique-node-index",
+			Usage:       "The node index within the clique (assigned by controller).",
+			EnvVars:     []string{"CLIQUE_NODE_INDEX"},
+			Destination: &flags.cliqueNodeIndex,
 		},
 		&cli.StringFlag{
 			Name:        "compute-domain-uuid",
@@ -192,6 +199,7 @@ func run(ctx context.Context, cancel context.CancelFunc, flags *Flags) error {
 
 	config := &ControllerConfig{
 		cliqueID:               flags.cliqueID,
+		cliqueNodeIndex:        flags.cliqueNodeIndex,
 		computeDomainUUID:      flags.computeDomainUUID,
 		computeDomainName:      flags.computeDomainName,
 		computeDomainNamespace: flags.computeDomainNamespace,

--- a/cmd/compute-domain-kubelet-plugin/computedomain.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -37,6 +38,9 @@ import (
 )
 
 const (
+	// cliqueConfigMapPrefix is the prefix for ConfigMaps that store clique node-to-index mappings.
+	cliqueConfigMapPrefix = "clique-"
+
 	computeDomainLabelKey       = "resource.nvidia.com/computeDomain"
 	computeDomainCliqueLabelKey = "resource.nvidia.com/computeDomain.cliqueID"
 
@@ -57,6 +61,7 @@ type ComputeDomainManager struct {
 
 	configFilesRoot string
 	cliqueID        string
+	cliqueNodeIndex *int
 }
 
 type ComputeDomainDaemonSettings struct {
@@ -159,10 +164,18 @@ func (s *ComputeDomainDaemonSettings) GetCDIContainerEditsCommon(ctx context.Con
 		return nil, fmt.Errorf("compute domain not found: %s", s.domainID)
 	}
 
+	// Get the clique node index from the ConfigMap (managed by the controller).
+	// This will error if not available yet, causing a retry.
+	cliqueNodeIndex, err := s.manager.GetCliqueNodeIndex(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting clique node index: %w", err)
+	}
+
 	edits := &cdiapi.ContainerEdits{
 		ContainerEdits: &cdispec.ContainerEdits{
 			Env: []string{
 				fmt.Sprintf("CLIQUE_ID=%s", s.manager.cliqueID),
+				fmt.Sprintf("CLIQUE_NODE_INDEX=%d", cliqueNodeIndex),
 				fmt.Sprintf("COMPUTE_DOMAIN_UUID=%s", cd.UID),
 				fmt.Sprintf("COMPUTE_DOMAIN_NAME=%s", cd.Name),
 				fmt.Sprintf("COMPUTE_DOMAIN_NAMESPACE=%s", cd.Namespace),
@@ -382,6 +395,39 @@ func (m *ComputeDomainManager) SetPodCliqueLabel(ctx context.Context) error {
 
 	klog.Infof("Set pod label %s=%s on pod %s/%s", computeDomainCliqueLabelKey, m.cliqueID, m.config.flags.namespace, m.config.flags.podName)
 	return nil
+}
+
+// GetCliqueNodeIndex retrieves this node's index from the clique ConfigMap.
+// The result is cached after the first successful lookup since it never changes
+// for the lifetime of the kubelet plugin pod.
+// Returns an error if the ConfigMap doesn't exist or the node isn't in it yet.
+func (m *ComputeDomainManager) GetCliqueNodeIndex(ctx context.Context) (int, error) {
+	if m.cliqueID == "" {
+		return 0, nil
+	}
+
+	if m.cliqueNodeIndex != nil {
+		return *m.cliqueNodeIndex, nil
+	}
+
+	cmName := cliqueConfigMapPrefix + m.cliqueID
+	cm, err := m.config.clientsets.Core.CoreV1().ConfigMaps(m.config.flags.namespace).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		return -1, fmt.Errorf("get ConfigMap %s: %w", cmName, err)
+	}
+
+	indexStr, exists := cm.Data[m.config.flags.nodeName]
+	if !exists {
+		return -1, fmt.Errorf("node %s not found in ConfigMap %s", m.config.flags.nodeName, cmName)
+	}
+
+	index, err := strconv.Atoi(indexStr)
+	if err != nil {
+		return -1, fmt.Errorf("invalid index value %q for node %s in ConfigMap %s: %w", indexStr, m.config.flags.nodeName, cmName, err)
+	}
+
+	m.cliqueNodeIndex = &index
+	return index, nil
 }
 
 func (m *ComputeDomainManager) periodicCleanup(ctx context.Context) {

--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -122,6 +122,11 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		return nil, fmt.Errorf("error starting ComputeDomain manager: %w", err)
 	}
 
+	// Set the clique label on the pod when the plugin comes online
+	if err := state.computeDomainManager.SetPodCliqueLabel(ctx); err != nil {
+		return nil, fmt.Errorf("error setting pod clique label: %w", err)
+	}
+
 	// Pass `nodeUnprepareResource` function in the cleanup manager.
 	if err := state.checkpointCleanupManager.Start(ctx, driver.nodeUnprepareResource); err != nil {
 		return nil, fmt.Errorf("error starting CheckpointCleanupManager: %w", err)

--- a/cmd/compute-domain-kubelet-plugin/main.go
+++ b/cmd/compute-domain-kubelet-plugin/main.go
@@ -48,6 +48,7 @@ type Flags struct {
 
 	nodeName                      string
 	namespace                     string
+	podName                       string
 	cdiRoot                       string
 	containerDriverRoot           string
 	hostDriverRoot                string
@@ -92,6 +93,12 @@ func newApp() *cli.App {
 			Value:       "default",
 			Destination: &flags.namespace,
 			EnvVars:     []string{"NAMESPACE"},
+		},
+		&cli.StringFlag{
+			Name:        "pod-name",
+			Usage:       "The name of the pod running this plugin.",
+			Destination: &flags.podName,
+			EnvVars:     []string{"POD_NAME"},
 		},
 		&cli.StringFlag{
 			Name:        "cdi-root",

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -148,6 +148,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         {{- if .Values.nvidiaCDIHookPath }}
         - name: NVIDIA_CDI_HOOK_PATH
           value: "{{ .Values.nvidiaCDIHookPath }}"

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/rbac-controller.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/rbac-controller.yaml
@@ -57,6 +57,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["daemonsets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/rbac-kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/rbac-kubeletplugin.yaml
@@ -57,6 +57,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["update"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]
 {{- if (and $.Values.resources.gpus.enabled $.Values.featureGates.MPSSupport) }}
 - apiGroups: ["apps"]
   resources: ["deployments"]

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/rbac-kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/rbac-kubeletplugin.yaml
@@ -54,6 +54,9 @@ metadata:
   name: {{ include "nvidia-dra-driver-gpu.name" $ }}-role-kubeletplugin
   namespace: {{ $namespace }}
 rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["update"]
 {{- if (and $.Values.resources.gpus.enabled $.Values.featureGates.MPSSupport) }}
 - apiGroups: ["apps"]
   resources: ["deployments"]


### PR DESCRIPTION
This removes the need to dynamically calculate this each time a copute-domain is brought up or torn down, dramatically reducing the startup time of an individual compute domain daemon since it no longer needs to run a distributed protocol to determine its index. Instead, it is able to start up immediately.