### PR TITLE
CD daemon: consolidate IPSet change detection, make diff readable

### DIFF
--- a/cmd/compute-domain-daemon/cdclique.go
+++ b/cmd/compute-domain-daemon/cdclique.go
@@ -416,13 +416,12 @@ func (m *ComputeDomainCliqueManager) maybePushDaemonsUpdate(clique *nvapi.Comput
 	// perform a stable sort of IP addresses before writing them to the nodes
 	// config file.
 	if !maps.Equal(newIPs, previousIPs) {
-		klog.V(2).Infof("IP set changed")
-		// This log message gets large for large node numbers
-		klog.V(6).Infof("previous: %v; new: %v", previousIPs, newIPs)
+		added, removed := previousIPs.Diff(newIPs)
+		klog.V(2).Infof("IP set for clique changed.\nAdded: %v\nRemoved: %v", added, removed)
 		m.previousDaemons = clique.Daemons
 		m.updatedDaemonsChan <- clique.Daemons
 	} else {
-		klog.V(6).Infof("IP set did not change")
+		klog.V(6).Infof("IP set for clique did not change")
 	}
 }
 

--- a/cmd/compute-domain-daemon/common.go
+++ b/cmd/compute-domain-daemon/common.go
@@ -16,7 +16,10 @@
 
 package main
 
-import "time"
+import (
+	"sort"
+	"time"
+)
 
 const (
 	// Detecting when a CD daemon transitions from NotReady to Ready (based on
@@ -32,3 +35,29 @@ const (
 
 // IPSet is a set of IP addresses.
 type IPSet map[string]struct{}
+
+// Diff compares two IP sets. It returns a list of IPs that were added and a
+// list of IPs that were removed. `s` is the reference set.
+func (s IPSet) Diff(cmp IPSet) ([]string, []string) {
+	var added []string
+	var removed []string
+
+	// Find IPs in `s` (reference) that are not in `cmp` (removed).
+	for ip := range s {
+		if _, exists := cmp[ip]; !exists {
+			removed = append(removed, ip)
+		}
+	}
+
+	// Find IPs in `cmp` that are not in `s` (added).
+	for ip := range cmp {
+		if _, exists := s[ip]; !exists {
+			added = append(added, ip)
+		}
+	}
+
+	// Sort, for logging purposes.
+	sort.Strings(added)
+	sort.Strings(removed)
+	return added, removed
+}


### PR DESCRIPTION
This patch mainly acts on this TODO:

> Note/TODO: we probably want to limit this check to IP addresses relevant to _this_ clique.

So that we push updates towards the IMEX daemon config machinery not unnecessarily often (only when our clique changed).

Also, so far we log a large message containing all IPs within the CD before and after a change (where the change itself becomes hard to identify).

To improve on that, this patch adds a utility function that extracts the difference between the before/after sets from two perspectives: added, removed -- and logs that. Example:
```
I0126 18:32:30.985734       1 computedomain.go:557] IP set for clique changed.
Added: [192.168.33.29 192.168.34.144]
Removed: []
```