### PR TITLE
Force crash on NVLink fabric errors instead of silently falling back

### DIFF
--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -47,6 +47,10 @@ const (
 	// ComputeDomainCliques enables using ComputeDomainClique CRD objects instead of
 	// storing daemon info directly in ComputeDomainStatus.Nodes.
 	ComputeDomainCliques featuregate.Feature = "ComputeDomainCliques"
+
+	// CrashOnNVLinkFabricErrors causes the kubelet plugin to crash instead of
+	// falling back to non-fabric mode when NVLink fabric errors are detected.
+	CrashOnNVLinkFabricErrors featuregate.Feature = "CrashOnNVLinkFabricErrors"
 )
 
 // defaultFeatureGates contains the default settings for all project-specific feature gates.
@@ -92,6 +96,13 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 		{
 			Default:    false,
 			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(25, 12),
+		},
+	},
+	CrashOnNVLinkFabricErrors: {
+		{
+			Default:    true,
+			PreRelease: featuregate.Beta,
 			Version:    version.MajorMinor(25, 12),
 		},
 	},


### PR DESCRIPTION
CD kubelet plugin: force crash on NVLink fabric errors instead of silently falling back

Fixes #837

Previously, when NVLink fabric was supported but not attached or had
errors, the plugin would silently fall back to no-clique mode with just
an info log. This made it difficult for operators to detect fabric
problems on systems that should have working MNNVL/IMEX support.

Now the plugin reliably distinguishes between two cases:
1. Platform doesn't support NVLink fabric (pre-Hopper, no NVSwitch)
   → Run in no-clique mode (expected behavior)
2. Platform supports NVLink fabric but it's broken/not attached
   → Crash with clear error message (alerts operators immediately)

This causes the CD plugin container to crash-loop when fabric is broken,
making the problem visible in DaemonSet status and allowing automatic
recovery when fabric is restored.

As part of this, we removed redundant IsFabricAttached() call which was calling
GetGpuFabricInfo() again internally - now we check all conditions
directly using the single info struct we already retrieved.