### PR TITLE
api: add Fabric GPU sharing strategy constant

### DIFF
--- a/api/nvidia.com/resource/v1beta1/sharing.go
+++ b/api/nvidia.com/resource/v1beta1/sharing.go
@@ -28,6 +28,7 @@ import (
 const (
 	TimeSlicingStrategy = "TimeSlicing"
 	MpsStrategy         = "MPS"
+	FabricStrategy      = "Fabric"
 )
 
 // These constants represent the different TimeSlicing configurations.


### PR DESCRIPTION
This change introduces a Fabric GPU sharing strategy constant at the API level.

The strategy is intentionally not enabled by default and does not change any runtime behavior.
It serves as forward-compatible scaffolding for future support of fabric-attached / IMEX-backed GPUs,
while keeping existing validation and behavior unchanged.
