### PR TITLE
internal/common: guard SIGUSR2 debug handler on Windows

### DIFF
--- a/internal/common/util.go
+++ b/internal/common/util.go
@@ -34,6 +34,10 @@ const dumpPath = "/tmp/goroutine-stacks.dump"
 // output didn't work.
 func StartDebugSignalHandlers() {
 	go func() {
+		if runtime.GOOS == "windows" {
+			klog.Infof("Debug signal handlers are disabled on Windows")
+			return
+		}
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, syscall.SIGUSR2)
 		for range c {


### PR DESCRIPTION
This change disables the SIGUSR2-based debug signal handler on Windows.

Windows does not support SIGUSR2, which causes build failures due to
syscall.SIGUSR2 being undefined. The handler is now conditionally skipped
at runtime on Windows while preserving existing behavior on Unix-like
platforms.

No functional changes on Linux.
