### PR TITLE
gpu plugin: remove duplicate device attribute

### DIFF
--- a/cmd/gpu-kubelet-plugin/partitions.go
+++ b/cmd/gpu-kubelet-plugin/partitions.go
@@ -59,9 +59,6 @@ func (d *GpuInfo) PartDevAttributes() map[resourceapi.QualifiedName]resourceapi.
 		"cudaDriverVersion": {
 			VersionValue: ptr.To(semver.MustParse(d.cudaDriverVersion).String()),
 		},
-		"pcieBusID": {
-			StringValue: &d.pcieBusID,
-		},
 		pciBusIDAttrName: {
 			StringValue: &d.pcieBusID,
 		},


### PR DESCRIPTION
This did sneak in as part of a large merge conflict resolution, I believe.
Shouldn't rely on manual review -- should be covered by tests.