### PR TITLE
ci: fix cancel-on-push

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,11 +14,19 @@ on:
         - all
 
 
-# Allow only one workflow at any time, and cancel in-progress Cancel upon. push
+# Allow only one workflow at any time, and cancel in-progress (only) upon push
 # to the same branch. The jobs below are run in parallel, and they are both
-# cancelled when this cancel criterion hits in.
+# cancelled when this cancel criterion hits in. Note that `github.head_ref` is
+# only set for pull_request events. In our repository, after merge-to-main or
+# for copy-pr-bot-managed branches, the `head_ref` is undefined. The || operator
+# below provides a fallback: when github.head_ref is undefined, use github.ref
+# (e.g., refs/heads/main). This ensures each branch gets its own concurrency
+# group, preventing cross-branch cancellations while still canceling in-progress
+# runs when new commits are pushed to the same branch. Note that using `ref`
+# isn't great usage in context of pull_request events (head_ref for pull
+# requests yields the actual source branch name).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
I noticed that some CI runs were cancelled unexpectedly, and debugged that. Indeed the name of the concurrency group was not constructed wisely and became  just `<workflow-name>-` (empty branch name part) for all push events (such as those issued by copy-pr-bot, in response to pull request activity). That is how different pull requests could cross-contaminate each other.

This patch tries to fix that. I think that will work now.