### PR TITLE
fix new staticcheck failure reported by golangci-lint v2.10.1

### DIFF
--- a/cmd/compute-domain-daemon/dnsnames.go
+++ b/cmd/compute-domain-daemon/dnsnames.go
@@ -176,7 +176,7 @@ func (m *DNSNameManager) updateHostsFile() error {
 
 	// Add new DNS name mappings
 	for ip, dnsName := range m.ipToDNSName {
-		newHostsContent.WriteString(fmt.Sprintf("%s\t%s\n", ip, dnsName))
+		_, _ = fmt.Fprintf(&newHostsContent, "%s\t%s\n", ip, dnsName)
 	}
 
 	// Write the updated hosts file


### PR DESCRIPTION
This PR addresses the following lint failure:

```
Error: cmd/compute-domain-daemon/dnsnames.go:179:3: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
  		newHostsContent.WriteString(fmt.Sprintf("%s\t%s\n", ip, dnsName))
  		^
  1 issues:
  * staticcheck: 1
  ```