### PR TITLE
ci: run tests periodically on `main`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,10 @@
 name: test
 
 on:
+  # Run periodically, for stability sampling
+  # as well as for detecting changes fast.
+  schedule:
+    - cron: '0 */2 * * *'
   workflow_call:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Note: GitHub evaluates the schedule trigger only from the workflow file located in the default branch. In other words,  scheduled GitHub Actions workflows only run on the repository's default branch.

Multi-faceted motivation.

Running CI periodically reveals unexpected breakage faster, and provides valuable stability distribution data.
Was reminded by https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/895.