### PR TITLE
Add node-role.kubernetes.io/master toleration to controller

### DIFF
--- a/deployments/helm/nvidia-dra-driver-gpu/values.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/values.yaml
@@ -193,6 +193,9 @@ controller:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists
     effect: NoSchedule
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
   containers:
     computeDomain:
       securityContext: {}


### PR DESCRIPTION
This enables the controller to be scheduled on OpenShift control plane nodes, which use the older `master` taint key instead of the newer `control-plane` key.

OpenShift (including version 4.21) continues to use `node-role.kubernetes.io/master` as the taint key for control plane nodes, while upstream Kubernetes migrated to `node-role.kubernetes.io/control-plane` in version 1.24. Without this toleration, the nvidia-dra-driver-gpu-controller pod fails to schedule on OpenShift clusters, preventing the driver from functioning.

Related to issue #367 (OpenShift compatibility).