### PR TITLE
Add structured YAML issue form templates and GitHub Actions workflows…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,174 @@
+name: Bug Report
+description: Report a bug to help us improve the NVIDIA DRA Driver for GPUs
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component is affected?
+      options:
+        - gpu-kubelet-plugin
+        - compute-domain-kubelet-plugin
+        - compute-domain-controller
+        - compute-domain-daemon
+        - webhook
+        - Helm chart / installation
+        - Documentation
+        - Other / unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe what happened and what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Detailed steps to reproduce the issue.
+      placeholder: |
+        1. Deploy with Helm using values ...
+        2. Create a ResourceClaim with ...
+        3. Run a pod requesting ...
+        4. Observe error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: input
+    id: driver-version
+    attributes:
+      label: DRA Driver Version
+      description: "Version of the NVIDIA DRA Driver (e.g., v25.8.0). Run: `helm list -n <namespace>`"
+      placeholder: "e.g., v25.6.0"
+    validations:
+      required: true
+
+  - type: input
+    id: k8s-version
+    attributes:
+      label: Kubernetes Version
+      description: "Kubernetes version and distribution. Run: `kubectl version`"
+      placeholder: "e.g., K8s v1.34, GKE, EKS, OpenShift"
+    validations:
+      required: true
+
+  - type: input
+    id: gpu-model
+    attributes:
+      label: GPU Model
+      description: "GPU model(s) in your cluster. Run: `nvidia-smi -L`"
+      placeholder: "e.g., NVIDIA A100-SXM4-80GB, NVIDIA H100"
+    validations:
+      required: true
+
+  - type: input
+    id: nvidia-driver
+    attributes:
+      label: NVIDIA Driver Version
+      description: "Host NVIDIA driver version. Run: `nvidia-smi --query-gpu=driver_version --format=csv`"
+      placeholder: "e.g., 570.86.16"
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: OS / Kernel
+      description: "Node OS and kernel version. Run: `uname -a`"
+      placeholder: "e.g., Ubuntu 24.04, kernel 6.8.0-generic"
+    validations:
+      required: false
+
+  - type: input
+    id: container-runtime
+    attributes:
+      label: Container Runtime
+      description: "Container runtime and version (e.g., containerd 2.0.0, CRI-O)"
+      placeholder: "e.g., containerd 2.0.0"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: feature-gates
+    attributes:
+      label: Feature Gates (non-default settings)
+      description: Select any feature gates you have changed from their defaults (enabled Alpha gates, or disabled Beta gates).
+      multiple: true
+      options:
+        - "TimeSlicingSettings (disabled)"
+        - "MPSSupport (disabled)"
+        - "PassthroughSupport (enabled)"
+        - "DynamicMIG (disabled)"
+        - "NVMLDeviceHealthCheck (disabled)"
+        - "IMEXDaemonsWithDNSNames (disabled)"
+        - "ComputeDomainCliques (disabled)"
+        - "CrashOnNVLinkFabricErrors (disabled)"
+
+  - type: textarea
+    id: helm-values
+    attributes:
+      label: Helm Values (non-default)
+      description: Paste any non-default Helm values or flags used during installation.
+      render: yaml
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: |
+        Attach relevant logs. Common sources:
+        - Plugin logs: `kubectl logs -n <namespace> <plugin-pod> --all-containers`
+        - Kubelet logs: `journalctl -u kubelet`
+        - Events: `kubectl get events --sort-by=.metadata.creationTimestamp`
+      render: shell
+
+  - type: checkboxes
+    id: debug-info
+    attributes:
+      label: Debug Information Attached
+      description: Check any diagnostic data you have gathered and attached.
+      options:
+        - label: "`kubectl get pods -n nvidia-dra-driver-gpu -o wide`"
+        - label: "`kubectl get resourceclaims -n <namespace>`"
+        - label: "`kubectl get resourceslices.resource.k8s.io`"
+        - label: "`kubectl describe pod <pod>` or `kubectl events --for pod/<pod>`"
+        - label: "Kubelet plugin logs: `kubectl logs -n nvidia-dra-driver-gpu -l nvidia-dra-driver-gpu-component=kubelet-plugin --all-containers --prefix --tail=400`"
+        - label: "`nvidia-smi` output from the host"
+        - label: "Kubelet logs"
+
+  - type: checkboxes
+    id: imex-debug-info
+    attributes:
+      label: IMEX / ComputeDomain Debug Information (if applicable)
+      description: For issues related to ComputeDomains, IMEX, or Multi-Node NVLink (MNNVL).
+      options:
+        - label: "Host IMEX service disabled: `systemctl status nvidia-imex.service` (must be masked/disabled)"
+        - label: "Node clique labels: `kubectl get nodes -L nvidia.com/gpu.clique`"
+        - label: "Per-GPU clique info: `nvidia-smi -q | grep -E 'ClusterUUID|CliqueId'`"
+        - label: "NVLink/NVSwitch topology: `nvidia-smi topo -m`"
+        - label: "ComputeDomain status: `kubectl get computedomains.resource.nvidia.com -o yaml`"
+        - label: "ComputeDomainClique status: `kubectl get computedomaincliques.resource.nvidia.com -o yaml`"
+        - label: "IMEX daemon pods: `kubectl get pods -n <namespace> -l resource.nvidia.com/computeDomain`"
+        - label: "IMEX daemon logs: `kubectl logs -n nvidia-dra-driver-gpu -l resource.nvidia.com/computeDomain --all-containers --prefix --tail=-1`"
+        - label: "IMEX domain status: `nvidia-imex-ctl -c /etc/nvidia-imex/config.cfg -N`"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Installation & Troubleshooting Wiki
+    url: https://github.com/NVIDIA/k8s-dra-driver-gpu/wiki
+    about: Check the wiki for installation guides and common troubleshooting steps before opening an issue.
+  - name: Kubernetes DRA Documentation
+    url: https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/
+    about: Upstream Kubernetes Dynamic Resource Allocation documentation.
+  - name: WG Device Management Ecosystem
+    url: https://github.com/kubernetes-sigs/wg-device-management/tree/main/device-ecosystem
+    about: Device ecosystem overview for DRA drivers across vendors.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,77 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a feature. Please describe the problem you're trying to solve and your proposed solution.
+
+        > **Note:** Large features that introduce new feature gates or significant behavioral changes require a formal proposal. TBD
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component does this feature relate to?
+      options:
+        - gpu-kubelet-plugin
+        - compute-domain-kubelet-plugin
+        - compute-domain-controller
+        - compute-domain-daemon
+        - webhook
+        - Helm chart / installation
+        - API / CRDs
+        - Documentation
+        - CI / testing
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Is this related to a frustration with the current behavior?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or workarounds you've considered.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: How significant is this change?
+      options:
+        - "Small: CLI flag, config option, minor behavior change"
+        - "Medium: New capability behind existing feature gate"
+        - "Large: New feature gate, API change, or multi-component change"
+    validations:
+      required: true
+
+  - type: textarea
+    id: upstream
+    attributes:
+      label: Upstream Kubernetes Dependencies
+      description: Does this feature depend on any upstream Kubernetes KEPs or features? If so, link them here.
+      placeholder: "e.g., Depends on KEP-xxxx (kep-name) at (Alpha/Beta/GA)"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or references.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,39 @@
+name: Question / Support
+description: Ask a question or request help with configuration
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before asking a question, please check:
+        - [Project Wiki](https://github.com/NVIDIA/k8s-dra-driver-gpu/wiki) for installation and troubleshooting
+        - [Release Notes](https://github.com/NVIDIA/k8s-dra-driver-gpu/releases) for recent changes and known issues
+        - [Demo specs](https://github.com/NVIDIA/k8s-dra-driver-gpu/tree/main/demo/specs) for usage examples
+        - [Kubernetes DRA documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Provide context that may help us answer your question (environment details,
+        what you've already tried, relevant configuration, etc.)
+
+  - type: input
+    id: driver-version
+    attributes:
+      label: DRA Driver Version (if applicable)
+
+  - type: input
+    id: k8s-version
+    attributes:
+      label: Kubernetes Version (if applicable)

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,119 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label-by-component:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+            const title = issue.title || '';
+            const labelsToAdd = [];
+
+            // Component detection from issue form dropdown
+            const componentMap = {
+              'gpu-kubelet-plugin': 'component/gpu-kubelet-plugin',
+              'compute-domain-kubelet-plugin': 'component/compute-domain-kubelet-plugin',
+              'compute-domain-controller': 'component/compute-domain-controller',
+              'compute-domain-daemon': 'component/compute-domain-daemon',
+              'webhook': 'component/webhook',
+              'Helm chart / installation': 'component/helm',
+              'Helm chart': 'component/helm',
+              'API / CRDs': 'component/api',
+              'Documentation': 'documentation',
+              'CI / testing': 'ci',
+            };
+
+            for (const [pattern, label] of Object.entries(componentMap)) {
+              if (body.includes(pattern)) {
+                labelsToAdd.push(label);
+              }
+            }
+
+            // Feature gate detection
+            const featureGates = [
+              'TimeSlicingSettings',
+              'MPSSupport',
+              'PassthroughSupport',
+              'DynamicMIG',
+              'NVMLDeviceHealthCheck',
+              'ComputeDomainCliques',
+              'CrashOnNVLinkFabricErrors',
+              'IMEXDaemonsWithDNSNames',
+            ];
+
+            for (const gate of featureGates) {
+              if (body.includes(gate) || title.includes(gate)) {
+                labelsToAdd.push(`feature-gate/${gate}`);
+              }
+            }
+
+            // Scope detection (from feature request template)
+            if (body.includes('Large: New feature gate')) {
+              labelsToAdd.push('size/large');
+            } else if (body.includes('Medium: New capability')) {
+              labelsToAdd.push('size/medium');
+            } else if (body.includes('Small: CLI flag')) {
+              labelsToAdd.push('size/small');
+            }
+
+            // Add detected labels
+            if (labelsToAdd.length > 0) {
+              const existingLabels = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+              });
+              const existing = existingLabels.data.map(l => l.name);
+              const newLabels = labelsToAdd.filter(l => !existing.includes(l));
+
+              if (newLabels.length > 0) {
+                // Ensure labels exist before adding them
+                for (const label of newLabels) {
+                  try {
+                    await github.rest.issues.getLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: label,
+                    });
+                  } catch (e) {
+                    if (e.status === 404) {
+                      const colors = {
+                        'component/': '0075ca',
+                        'feature-gate/': 'e4e669',
+                        'size/': 'fbca04',
+                        'documentation': '0075ca',
+                        'ci': 'ededed',
+                      };
+                      const color = Object.entries(colors).find(
+                        ([prefix]) => label.startsWith(prefix)
+                      )?.[1] || 'ededed';
+
+                      await github.rest.issues.createLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        name: label,
+                        color: color,
+                      });
+                    }
+                  }
+                }
+
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: newLabels,
+                });
+                core.info(`Added labels: ${newLabels.join(', ')}`);
+              }
+            }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: Stale Issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 4 * * *"
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had activity in the last 90 days. It will be closed in 30 days if no
+            further activity occurs. To keep this issue open, add a comment or
+            remove the `lifecycle/stale` label. To exempt it permanently, apply
+            the `lifecycle/frozen` label.
+          close-issue-message: >
+            This issue was automatically closed due to inactivity. If you believe
+            this is still relevant, feel free to reopen it.
+          stale-issue-label: "lifecycle/stale"
+          exempt-issue-labels: "lifecycle/frozen,enhancement,proposal"
+          days-before-stale: 90
+          days-before-issue-close: 30
+          remove-stale-when-updated: true
+          operations-per-run: 1000


### PR DESCRIPTION
This is to add structured YAML issue form templates and GitHub Actions workflows to automate issue organization.

Over the last few days, our team has spent significant time in organizing and labeling the issues as currently we don't have a standard template which leads to:

unstructured issues and require manual effort to categorize
labels must be applied manually by maintainers
stale issues accumulating without cleanup
no consistent information is collected for bug reports (dra component, driver version, K8s version etc.)

Its also complements https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/931 

I mostly adapted these: 
- https://github.com/kubernetes/kubernetes/tree/master/.github/ISSUE_TEMPLATE
- https://github.com/NVIDIA/gpu-operator/tree/main/.github/ISSUE_TEMPLATE

TO-DO: may need to create additional labels for components and lifecycle. 

Address https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/975