### PR TITLE
fix syntax error where "{$var}" results in literal {} wrapped around file name

### DIFF
--- a/scripts/unbind_from_driver.sh
+++ b/scripts/unbind_from_driver.sh
@@ -19,7 +19,7 @@ acquire_unbind_lock()
    while [[ $attempt -le ${lock_retries} ]]; do
       echo "[retry $attempt/${lock_retries}] Attempting to acquire unbindLock for $gpu" >&1
 
-      echo 1 > "{$unbind_lock_file}"
+      echo 1 > "${unbind_lock_file}"
       read -r unbind_lock < "${unbind_lock_file}"
       if [ ${unbind_lock} -eq 1 ]; then
          echo "UnbindLock acquired for $gpu" >&1


### PR DESCRIPTION
while working on #912, found that `scripts/unbind_from_driver.sh` has a syntax error where "{}" was added to filename.

This issue likely will cause the `acquire_unbind_lock` to spin and always fail to acquire unbind lock.