### PR TITLE
remove shell dependency from the driver image

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/main.go
+++ b/cmd/compute-domain-kubelet-plugin/main.go
@@ -69,6 +69,10 @@ func (c Config) DriverPluginPath() string {
 }
 
 func main() {
+	if err := common.MaskNvidiaDriverParams(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error masking NVIDIA driver params: %v\n", err)
+	}
+
 	if err := newApp().Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -69,6 +69,21 @@ func (c Config) DriverPluginPath() string {
 }
 
 func main() {
+	if err := common.MaskNvidiaDriverParams(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error masking NVIDIA driver params: %v\n", err)
+	}
+
+	if len(os.Args) > 1 && os.Args[1] == "prestart-init" {
+		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+		defer cancel()
+
+		if err := runPrestartInit(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	if err := newApp().Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -73,11 +73,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error masking NVIDIA driver params: %v\n", err)
 	}
 
-	if len(os.Args) > 1 && os.Args[1] == "prestart-init" {
+	if len(os.Args) > 1 && os.Args[1] == "prestart" {
 		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
 		defer cancel()
 
-		if err := runPrestartInit(ctx); err != nil {
+		if err := runPrestart(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/gpu-kubelet-plugin/prestart.go
+++ b/cmd/gpu-kubelet-plugin/prestart.go
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Main intent: help users to self-troubleshoot when the GPU driver is not set up
+// properly before installing this DRA driver. In that case, the log of the init
+// container running this script is meant to yield an actionable error message.
+// For now, rely on k8s to implement a high-level retry with back-off.
+func runPrestartInit(ctx context.Context) error {
+	// Design goal: long-running init container that retries at constant frequency,
+	// and leaves only upon success (with code 0).
+	waitS := 10 * time.Second
+	attempt := 0
+
+	nvidiaDriverRoot := os.Getenv("NVIDIA_DRIVER_ROOT")
+	if nvidiaDriverRoot == "" {
+		// Not set, or set to empty string (not distinguishable).
+		// Normalize to "/" (treated as such elsewhere).
+		nvidiaDriverRoot = "/"
+	}
+
+	driverRootParent := "/driver-root-parent"
+	// Remove trailing slash (if existing) and get last path element.
+	driverRootPath := filepath.Join(driverRootParent, filepath.Base(nvidiaDriverRoot))
+
+	// Ensure the /driver-root-parent directory exists
+	if err := os.MkdirAll(driverRootParent, 0755); err != nil {
+		klog.Warningf("Failed to create %s: %v", driverRootParent, err)
+	}
+
+	// Create in-container path /driver-root as a symlink. Expectation: link may be
+	// broken initially (e.g., if the GPU operator isn't deployed yet. The link heals
+	// once the driver becomes mounted (e.g., once GPU operator provides the driver
+	// on the host at /run/nvidia/driver).
+	fmt.Printf("create symlink: /driver-root -> %s\n", driverRootPath)
+	_ = os.Remove("/driver-root")
+	if err := os.Symlink(driverRootPath, "/driver-root"); err != nil {
+		klog.Warningf("Failed to create symlink: %v", err)
+	}
+
+	for {
+		if validateAndExitOnSuccess(ctx, nvidiaDriverRoot, attempt) {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			// DS pods may get deleted (terminated with SIGTERM) and re-created when the GPU
+			// Operator driver container creates a mount at /run/nvidia. Make that explicit.
+			fmt.Printf("%s: received SIGTERM\n", time.Now().UTC().Format("2006-01-02T15:04:05.000Z"))
+			return nil
+		case <-time.After(waitS):
+			attempt++
+		}
+	}
+}
+
+func emitCommonErr(nvidiaDriverRoot string) {
+	fmt.Printf("Check failed. Has the NVIDIA GPU driver been set up? "+
+		"It is expected to be installed under "+
+		"NVIDIA_DRIVER_ROOT (currently set to '%s') "+
+		"in the host filesystem. If that path appears to be unexpected: "+
+		"review the DRA driver's 'nvidiaDriverRoot' Helm chart variable. "+
+		"Otherwise, review if the GPU driver has "+
+		"actually been installed under that path.\n", nvidiaDriverRoot)
+}
+
+func validateAndExitOnSuccess(ctx context.Context, nvidiaDriverRoot string, attempt int) bool {
+	fmt.Printf("%s  /driver-root (%s on host): ", time.Now().UTC().Format("2006-01-02T15:04:05Z"), nvidiaDriverRoot)
+
+	// Search specific set of directories (not recursively: not required, and
+	// /driver-root may be a big tree). Limit to first result (multiple results
+	// are a bit of a pathological state, but continue with validation logic).
+	nvPath := findFirstFile(
+		"nvidia-smi",
+		"/driver-root/opt/bin",
+		"/driver-root/usr/bin",
+		"/driver-root/usr/sbin",
+		"/driver-root/bin",
+		"/driver-root/sbin",
+	)
+
+	// Follow symlinks (-L), because `libnvidia-ml.so.1` is typically a link.
+	nvLibPath := findFirstFile(
+		"libnvidia-ml.so.1",
+		"/driver-root/usr/lib64",
+		"/driver-root/usr/lib/x86_64-linux-gnu",
+		"/driver-root/usr/lib/aarch64-linux-gnu",
+		"/driver-root/lib64",
+		"/driver-root/lib/x86_64-linux-gnu",
+		"/driver-root/lib/aarch64-linux-gnu",
+	)
+
+	if nvPath == "" {
+		fmt.Printf("nvidia-smi: not found, ")
+	} else {
+		fmt.Printf("nvidia-smi: '%s', ", nvPath)
+	}
+
+	if nvLibPath == "" {
+		fmt.Printf("libnvidia-ml.so.1: not found, ")
+	} else {
+		fmt.Printf("libnvidia-ml.so.1: '%s', ", nvLibPath)
+	}
+
+	// Log top-level entries in /driver-root (this may be valuable debug info).
+	entries, _ := os.ReadDir("/driver-root")
+	var entryNames string
+	for i, e := range entries {
+		if i > 0 {
+			entryNames += " "
+		}
+		entryNames += e.Name()
+	}
+	fmt.Printf("current contents: [%s].\n", entryNames)
+
+	if nvPath != "" && nvLibPath != "" {
+		// Run with clean environment (only LD_PRELOAD; nvidia-smi has only this
+		// dependency). Emit message before invocation (nvidia-smi may be slow or
+		// hang).
+		fmt.Printf("invoke: env -i LD_PRELOAD=%s %s\n", nvLibPath, nvPath)
+
+		cmd := exec.CommandContext(ctx, nvPath)
+		cmd.Env = []string{"LD_PRELOAD=" + nvLibPath}
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		err := cmd.Run()
+		// For checking GPU driver health: rely on nvidia-smi's exit code. Rely
+		// on code 0 signaling that the driver is properly set up. See section
+		// 'RETURN VALUE' in the nvidia-smi man page for meaning of error codes.
+		if err == nil {
+			fmt.Printf("nvidia-smi returned with code 0: success, leave\n")
+			return true
+		}
+
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			fmt.Printf("exit code: %d\n", exitErr.ExitCode())
+		} else {
+			fmt.Printf("execution failed: %v, exit code: -1\n", err)
+		}
+	}
+
+	// Reduce log volume: log hints only every Nth attempt.
+	if attempt%6 != 0 {
+		return false
+	}
+
+	// nvidia-smi binaries not found, or execution failed. First, provide generic
+	// error message. Then, try to provide actionable hints for common problems.
+	fmt.Println()
+	emitCommonErr(nvidiaDriverRoot)
+
+	// For host-provided driver not at / provide feedback for two special cases.
+	if nvidiaDriverRoot != "/" {
+		if len(entries) == 0 {
+			fmt.Printf("Hint: Directory %s on the host is empty\n", nvidiaDriverRoot)
+		} else {
+			// Not empty, but at least one of the binaries not found: this is a
+			// rather pathological state.
+			if nvPath == "" || nvLibPath == "" {
+				fmt.Printf("Hint: Directory %s is not empty but at least one of the binaries wasn't found.\n", nvidiaDriverRoot)
+			}
+		}
+	}
+
+	// Common mistake: driver container, but forgot `--set nvidiaDriverRoot`
+	if nvidiaDriverRoot == "/" {
+		if _, err := os.Stat("/driver-root/run/nvidia/driver/usr/bin/nvidia-smi"); err == nil {
+			fmt.Printf("Hint: '/run/nvidia/driver/usr/bin/nvidia-smi' exists on the host, you " +
+				"may want to re-install the DRA driver Helm chart with " +
+				"--set nvidiaDriverRoot=/run/nvidia/driver\n")
+		}
+	}
+
+	if nvidiaDriverRoot == "/run/nvidia/driver" {
+		fmt.Printf("Hint: NVIDIA_DRIVER_ROOT is set to '/run/nvidia/driver' " +
+			"which typically means that the NVIDIA GPU Operator " +
+			"manages the GPU driver. Make sure that the GPU Operator " +
+			"is deployed and healthy.\n")
+	}
+	fmt.Println()
+
+	return false
+}
+
+func findFirstFile(filename string, dirs ...string) string {
+	for _, dir := range dirs {
+		path := filepath.Join(dir, filename)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path
+		}
+	}
+	return ""
+}

--- a/cmd/gpu-kubelet-plugin/prestart.go
+++ b/cmd/gpu-kubelet-plugin/prestart.go
@@ -29,11 +29,9 @@ import (
 
 // Main intent: help users to self-troubleshoot when the GPU driver is not set up
 // properly before installing this DRA driver. In that case, the log of the init
-// container running this script is meant to yield an actionable error message.
+// container running the prestart code is meant to yield an actionable error message.
 // For now, rely on k8s to implement a high-level retry with back-off.
-func runPrestartInit(ctx context.Context) error {
-	// Design goal: long-running init container that retries at constant frequency,
-	// and leaves only upon success (with code 0).
+func runPrestart(ctx context.Context) error {
 	waitS := 10 * time.Second
 	attempt := 0
 
@@ -45,7 +43,7 @@ func runPrestartInit(ctx context.Context) error {
 	}
 
 	driverRootParent := "/driver-root-parent"
-	// Remove trailing slash (if existing) and get last path element.
+	// filepath.Base removes trailing slash (if existing) and get last path element.
 	driverRootPath := filepath.Join(driverRootParent, filepath.Base(nvidiaDriverRoot))
 
 	// Ensure the /driver-root-parent directory exists
@@ -58,7 +56,7 @@ func runPrestartInit(ctx context.Context) error {
 	// once the driver becomes mounted (e.g., once GPU operator provides the driver
 	// on the host at /run/nvidia/driver).
 	fmt.Printf("create symlink: /driver-root -> %s\n", driverRootPath)
-	_ = os.Remove("/driver-root")
+
 	if err := os.Symlink(driverRootPath, "/driver-root"); err != nil {
 		klog.Warningf("Failed to create symlink: %v", err)
 	}
@@ -96,6 +94,10 @@ func validateAndExitOnSuccess(ctx context.Context, nvidiaDriverRoot string, atte
 	// Search specific set of directories (not recursively: not required, and
 	// /driver-root may be a big tree). Limit to first result (multiple results
 	// are a bit of a pathological state, but continue with validation logic).
+
+	// original script does not follow symlink for nvpath but since symlinkm
+	// can also execute so reuse findFirstFile to avoid new func that's largely
+	// duplicative.
 	nvPath := findFirstFile(
 		"nvidia-smi",
 		"/driver-root/opt/bin",
@@ -105,7 +107,6 @@ func validateAndExitOnSuccess(ctx context.Context, nvidiaDriverRoot string, atte
 		"/driver-root/sbin",
 	)
 
-	// Follow symlinks (-L), because `libnvidia-ml.so.1` is typically a link.
 	nvLibPath := findFirstFile(
 		"libnvidia-ml.so.1",
 		"/driver-root/usr/lib64",
@@ -145,6 +146,7 @@ func validateAndExitOnSuccess(ctx context.Context, nvidiaDriverRoot string, atte
 		// hang).
 		fmt.Printf("invoke: env -i LD_PRELOAD=%s %s\n", nvLibPath, nvPath)
 
+		// override default env to just LD_PRELOAD
 		cmd := exec.CommandContext(ctx, nvPath)
 		cmd.Env = []string{"LD_PRELOAD=" + nvLibPath}
 		cmd.Stdout = os.Stdout
@@ -162,6 +164,7 @@ func validateAndExitOnSuccess(ctx context.Context, nvidiaDriverRoot string, atte
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			fmt.Printf("exit code: %d\n", exitErr.ExitCode())
 		} else {
+			// nvidia-smi fails to start. e.g. permission denied etc.
 			fmt.Printf("execution failed: %v, exit code: -1\n", err)
 		}
 	}
@@ -209,6 +212,9 @@ func validateAndExitOnSuccess(ctx context.Context, nvidiaDriverRoot string, atte
 	return false
 }
 
+// findFirstFile finds the first occurrence of filename in the provided
+// directories not recursively.
+// It follows symlinks (similar to find -L).
 func findFirstFile(filename string, dirs ...string) string {
 	for _, dir := range dirs {
 		path := filepath.Join(dir, filename)

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -31,19 +32,17 @@ import (
 )
 
 const (
-	kernelIommuGroupPath   = "/sys/kernel/iommu_groups"
-	vfioPciModule          = "vfio_pci"
-	vfioPciDriver          = "vfio-pci"
-	nvidiaDriver           = "nvidia"
-	hostRoot               = "/host-root"
-	sysModulesRoot         = "/sys/module"
-	pciDevicesRoot         = "/sys/bus/pci/devices"
-	vfioDevicesRoot        = "/dev/vfio"
-	unbindFromDriverScript = "/usr/bin/unbind_from_driver.sh"
-	bindToDriverScript     = "/usr/bin/bind_to_driver.sh"
-	driverResetRetries     = "5"
-	gpuFreeCheckInterval   = 1 * time.Second
-	gpuFreeCheckTimeout    = 60 * time.Second
+	kernelIommuGroupPath = "/sys/kernel/iommu_groups"
+	vfioPciModule        = "vfio_pci"
+	vfioPciDriver        = "vfio-pci"
+	nvidiaDriver         = "nvidia"
+	hostRoot             = "/host-root"
+	sysModulesRoot       = "/sys/module"
+	pciDevicesRoot       = "/sys/bus/pci/devices"
+	vfioDevicesRoot      = "/dev/vfio"
+	driverResetRetries   = "5"
+	gpuFreeCheckInterval = 1 * time.Second
+	gpuFreeCheckTimeout  = 60 * time.Second
 )
 
 type VfioPciManager struct {
@@ -248,20 +247,92 @@ func (vm *VfioPciManager) changeDriver(pciAddress, driver string) error {
 	return nil
 }
 
+func (vm *VfioPciManager) acquireUnbindLock(gpu string) error {
+	lockRetries := 5
+	unbindLockFile := filepath.Join("/proc/driver/nvidia/gpus", gpu, "unbindLock")
+
+	if _, err := os.Stat(unbindLockFile); err != nil {
+		// If the lock file doesn't exist, we assume no lock is needed.
+		return nil
+	}
+
+	for attempt := 1; attempt <= lockRetries; attempt++ {
+		klog.Infof("[retry %d/%d] Attempting to acquire unbindLock for %s", attempt, lockRetries, gpu)
+
+		// Try to write 1 to acquire the lock
+		err := os.WriteFile(unbindLockFile, []byte("1\n"), 0200)
+		if err != nil {
+			klog.Warningf("failed to write to unbindLock file %s: %v", unbindLockFile, err)
+		}
+
+		// Read the lock file to verify
+		content, err := os.ReadFile(unbindLockFile)
+		if err == nil {
+			val := strings.TrimSpace(string(content))
+			if val == "1" {
+				klog.Infof("UnbindLock acquired for %s", gpu)
+				return nil
+			}
+		}
+
+		time.Sleep(time.Duration(attempt) * time.Second)
+	}
+
+	return fmt.Errorf("cannot obtain unbindLock for %s", gpu)
+}
+
 func (vm *VfioPciManager) unbindFromDriver(pciAddress string) error {
-	out, err := execCommand(unbindFromDriverScript, []string{pciAddress}) //nolint:gosec
+	driverPath := filepath.Join(pciDevicesRoot, pciAddress, "driver")
+	if _, err := os.Stat(driverPath); err != nil {
+		// Not bound to any driver
+		return nil
+	}
+
+	existingDriver, err := filepath.EvalSymlinks(driverPath)
 	if err != nil {
-		klog.Errorf("Attempting to unbind %s from its driver failed; stdout: %s, err: %v", pciAddress, string(out), err)
+		return fmt.Errorf("failed to resolve driver symlink for %s: %v", pciAddress, err)
+	}
+
+	existingDriverName := filepath.Base(existingDriver)
+	if existingDriverName == "nvidia" {
+		if err := vm.acquireUnbindLock(pciAddress); err != nil {
+			return err
+		}
+	}
+
+	unbindFile := filepath.Join(existingDriver, "unbind")
+	if err := os.WriteFile(unbindFile, []byte(pciAddress+"\n"), 0200); err != nil {
+		klog.Errorf("Attempting to unbind %s from its driver failed; err: %v", pciAddress, err)
 		return err
 	}
 	return nil
 }
 
 func (vm *VfioPciManager) bindToDriver(pciAddress, driver string) error {
-	out, err := execCommand(bindToDriverScript, []string{pciAddress, driver}) //nolint:gosec
-	if err != nil {
-		klog.Errorf("Attempting to bind %s to %s driver failed; stdout: %s, err: %v", pciAddress, driver, string(out), err)
-		return err
+	driversPath := "/sys/bus/pci/drivers"
+	driverOverrideFile := filepath.Join(pciDevicesRoot, pciAddress, "driver_override")
+	bindFile := filepath.Join(driversPath, driver, "bind")
+
+	if _, err := os.Stat(driverOverrideFile); err != nil {
+		klog.Errorf("'%s' file does not exist", driverOverrideFile)
+		return fmt.Errorf("driver_override file not found: %v", err)
+	}
+
+	if err := os.WriteFile(driverOverrideFile, []byte(driver+"\n"), 0200); err != nil {
+		klog.Errorf("failed to write '%s' to %s", driver, driverOverrideFile)
+		return fmt.Errorf("failed to write to driver_override: %v", err)
+	}
+
+	if _, err := os.Stat(bindFile); err != nil {
+		klog.Errorf("'%s' file does not exist", bindFile)
+		return fmt.Errorf("bind file not found: %v", err)
+	}
+
+	if err := os.WriteFile(bindFile, []byte(pciAddress+"\n"), 0200); err != nil {
+		klog.Errorf("Attempting to bind %s to %s driver failed; err: %v", pciAddress, driver, err)
+		// attempt to revert driver_override
+		_ = os.WriteFile(driverOverrideFile, []byte("\n"), 0200)
+		return fmt.Errorf("failed to write to bind file: %v", err)
 	}
 	return nil
 }

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -260,7 +260,7 @@ func (vm *VfioPciManager) acquireUnbindLock(gpu string) error {
 		klog.Infof("[retry %d/%d] Attempting to acquire unbindLock for %s", attempt, lockRetries, gpu)
 
 		// Try to write 1 to acquire the lock
-		err := os.WriteFile(unbindLockFile, []byte("1\n"), 0200)
+		err := os.WriteFile(unbindLockFile, []byte("1\n"), 0644)
 		if err != nil {
 			klog.Warningf("failed to write to unbindLock file %s: %v", unbindLockFile, err)
 		}
@@ -300,8 +300,7 @@ func (vm *VfioPciManager) unbindFromDriver(pciAddress string) error {
 		}
 	}
 
-	unbindFile := filepath.Join(existingDriver, "unbind")
-	if err := os.WriteFile(unbindFile, []byte(pciAddress+"\n"), 0200); err != nil {
+	if err := os.WriteFile(filepath.Join(existingDriver, "unbind"), []byte(pciAddress+"\n"), 0644); err != nil {
 		klog.Errorf("Attempting to unbind %s from its driver failed; err: %v", pciAddress, err)
 		return err
 	}
@@ -318,7 +317,7 @@ func (vm *VfioPciManager) bindToDriver(pciAddress, driver string) error {
 		return fmt.Errorf("driver_override file not found: %v", err)
 	}
 
-	if err := os.WriteFile(driverOverrideFile, []byte(driver+"\n"), 0200); err != nil {
+	if err := os.WriteFile(driverOverrideFile, []byte(driver+"\n"), 0644); err != nil {
 		klog.Errorf("failed to write '%s' to %s", driver, driverOverrideFile)
 		return fmt.Errorf("failed to write to driver_override: %v", err)
 	}
@@ -328,10 +327,10 @@ func (vm *VfioPciManager) bindToDriver(pciAddress, driver string) error {
 		return fmt.Errorf("bind file not found: %v", err)
 	}
 
-	if err := os.WriteFile(bindFile, []byte(pciAddress+"\n"), 0200); err != nil {
-		klog.Errorf("Attempting to bind %s to %s driver failed; err: %v", pciAddress, driver, err)
+	if err := os.WriteFile(bindFile, []byte(pciAddress+"\n"), 0644); err != nil {
+		klog.Errorf("failed to write %s to %s; err: %v", pciAddress, bindFile, err)
 		// attempt to revert driver_override
-		_ = os.WriteFile(driverOverrideFile, []byte("\n"), 0200)
+		_ = os.WriteFile(driverOverrideFile, []byte("\n"), 0644)
 		return fmt.Errorf("failed to write to bind file: %v", err)
 	}
 	return nil

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -86,26 +86,6 @@ RUN --mount=type=cache,target=/mc/go/build-cache,id=gocache \
     case "$TARGETARCH" in "$BUILDARCH") cc=gcc;; arm64) cc=aarch64-linux-gnu-gcc;; amd64) cc=x86_64-linux-gnu-gcc;; esac && \
     time make CC=${cc} GOARCH=${TARGETARCH} PREFIX=/artifacts cmds
 
-# Build static bash binary (against musl). Notes: cross-compilation isn't robust
-# (see non-deterministic segfaults tracked in issues/502; source code download
-# instabilities tracked in issues/743) and generally takes signifiant time even
-# on happy path (dominiates CI duration as of the time of writing). Do not build
-# this every time. Instead, consume it from a previous image in a registry -- also,
-# leave machinery (out-commented) in place.
-#
-# Choose: 1) fresh bash build or 2) use binary from previous image
-#
-# option 1:
-ARG BASH_STATIC_GIT_REF=021f5f29f665c92ca16a369d9f27e288c3aed0c6
-ENV BASH_STATIC_GIT_REF=${BASH_STATIC_GIT_REF}
-WORKDIR /bashbuild
-COPY hack/build-bash-static.sh .
-RUN bash /bashbuild/build-bash-static.sh
-RUN cd /bashbuild/bash-static/releases && ./bash*-static --version && mv bash-*-static /bashbuild/bash && file /bashbuild/bash
-
-# option 2:
-# FROM registry.k8s.io/nvidia/nvidia-dra-driver-gpu:v25.12.0-dev-839e966a AS bash
-
 # Pull the nvidia-cdi-hook binary out of the relevant toolkit container
 # (arch: TARGETPLATFORM, set via --platform).
 FROM ${TOOLKIT_CONTAINER_IMAGE} AS toolkit
@@ -114,9 +94,10 @@ FROM ${TOOLKIT_CONTAINER_IMAGE} AS toolkit
 # arg). Note that nvcr.io/nvidia/distroless/cc is based on
 # https://github.com/GoogleContainerTools/distroless; specifically on debian12.
 # For consistency, the build stage above derives from Debian 12 directly. The
-# `-dev` suffic is to get busybox as a shell added. For RUN directives to pick
+# `-dev` suffix is to get busybox as a shell added. For RUN directives to pick
 # that up, use `SHELL ["/busybox/sh", "-c"]`.
-FROM nvcr.io/nvidia/distroless/cc:v4.0.3-dev
+# FROM nvcr.io/nvidia/distroless/cc:v4.0.3-dev
+FROM nvcr.io/nvidia/distroless/cc:v4.0.3
 
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all
@@ -138,12 +119,6 @@ LABEL org.opencontainers.image.source="https://github.com/kubernetes-sigs/nvidia
 # Add top-level license (AL2) file into the container image
 COPY LICENSE /
 
-# option 1: fresh bash build
-COPY --from=build   /bashbuild/bash                           /bin/bash
-
-# option 2: bash from previous image
-# COPY --from=bash    /bin/bash                                 /bin/bash
-
 COPY --from=toolkit /artifacts/rpm/usr/bin/nvidia-cdi-hook    /usr/bin/nvidia-cdi-hook
 COPY --from=build   /artifacts/compute-domain-controller      /usr/bin/compute-domain-controller
 COPY --from=build   /artifacts/compute-domain-kubelet-plugin  /usr/bin/compute-domain-kubelet-plugin
@@ -151,9 +126,6 @@ COPY --from=build   /artifacts/compute-domain-daemon          /usr/bin/compute-d
 COPY --from=build   /artifacts/gpu-kubelet-plugin             /usr/bin/gpu-kubelet-plugin
 COPY --from=build   /artifacts/webhook                        /usr/bin/webhook
 
-COPY /scripts/bind_to_driver.sh                               /usr/bin/bind_to_driver.sh
-COPY /scripts/unbind_from_driver.sh                           /usr/bin/unbind_from_driver.sh
-COPY /hack/kubelet-plugin-prestart.sh                         /usr/bin/kubelet-plugin-prestart.sh
 COPY /templates /templates
 
 # Use root by default (for example, the init container as of now needs
@@ -164,4 +136,3 @@ USER root:root
 
 # Smoke-test executables (provide early build feedback).
 RUN ["/usr/bin/compute-domain-kubelet-plugin", "--version"]
-RUN ["/bin/bash", "--version"]

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -54,7 +54,7 @@ spec:
         image: {{ include "nvidia-dra-driver-gpu.fullimage" . }}
         securityContext:
           privileged: true
-        command: [bash, /usr/bin/kubelet-plugin-prestart.sh]
+        command: [/usr/bin/gpu-kubelet-plugin, prestart-init]
         env:
         - name: NVIDIA_DRIVER_ROOT
           value: "{{ .Values.nvidiaDriverRoot }}"
@@ -87,19 +87,8 @@ spec:
           {{- toYaml .Values.kubeletPlugin.containers.computeDomains.securityContext | nindent 10 }}
         image: {{ include "nvidia-dra-driver-gpu.fullimage" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["bash", "-c"]
-        args:
-        - |-
-          # Conditionally mask the params file to prevent this container from
-          # recreating any missing GPU device nodes. This is necessary, for
-          # example, when running under nvkind to limit the set GPUs governed
-          # by the plugin even though it has cgroup access to all of them.
-          if [ "${MASK_NVIDIA_DRIVER_PARAMS}" = "true" ]; then
-            cp /proc/driver/nvidia/params root/gpu-params
-            sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' root/gpu-params
-            mount --bind root/gpu-params /proc/driver/nvidia/params
-          fi
-          compute-domain-kubelet-plugin -v $(LOG_VERBOSITY)
+        command: ["compute-domain-kubelet-plugin"]
+        args: ["-v", "$(LOG_VERBOSITY)"]
         resources:
           {{- toYaml .Values.kubeletPlugin.containers.computeDomains.resources | nindent 10 }}
         {{/*
@@ -188,19 +177,8 @@ spec:
           {{- end }}
         image: {{ include "nvidia-dra-driver-gpu.fullimage" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["bash", "-c"]
-        args:
-        - |-
-          # Conditionally mask the params file to prevent this container from
-          # recreating any missing GPU device nodes. This is necessary, for
-          # example, when running under nvkind to limit the set GPUs governed
-          # by the plugin even though it has cgroup access to all of them.
-          if [ "${MASK_NVIDIA_DRIVER_PARAMS}" = "true" ]; then
-            cp /proc/driver/nvidia/params root/gpu-params
-            sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' root/gpu-params
-            mount --bind root/gpu-params /proc/driver/nvidia/params
-          fi
-          gpu-kubelet-plugin -v $(LOG_VERBOSITY)
+        command: ["gpu-kubelet-plugin"]
+        args: ["-v", "$(LOG_VERBOSITY)"]
         resources:
           {{- toYaml .Values.kubeletPlugin.containers.gpus.resources | nindent 10 }}
         {{/*

--- a/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/nvidia-dra-driver-gpu/templates/kubeletplugin.yaml
@@ -54,7 +54,7 @@ spec:
         image: {{ include "nvidia-dra-driver-gpu.fullimage" . }}
         securityContext:
           privileged: true
-        command: [/usr/bin/gpu-kubelet-plugin, prestart-init]
+        command: [/usr/bin/gpu-kubelet-plugin, prestart]
         env:
         - name: NVIDIA_DRIVER_ROOT
           value: "{{ .Values.nvidiaDriverRoot }}"

--- a/internal/common/mask_params.go
+++ b/internal/common/mask_params.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// MaskNvidiaDriverParams conditionally masks the params file to prevent this container from
+// recreating any missing GPU device nodes. This is necessary, for example, when running
+// under nvkind to limit the set GPUs governed by the plugin even though it has cgroup
+// access to all of them.
+func MaskNvidiaDriverParams() error {
+	if os.Getenv("MASK_NVIDIA_DRIVER_PARAMS") != "true" {
+		return nil
+	}
+
+	src := "/proc/driver/nvidia/params"
+	dst := "root/gpu-params"
+
+	content, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %v", src, err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	for i, line := range lines {
+		if line == "ModifyDeviceFiles: 1" {
+			lines[i] = "ModifyDeviceFiles: 0"
+		}
+	}
+	newContent := strings.Join(lines, "\n")
+
+	if err := os.WriteFile(dst, []byte(newContent), 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %v", dst, err)
+	}
+
+	if err := syscall.Mount(dst, src, "", syscall.MS_BIND, ""); err != nil {
+		return fmt.Errorf("failed to bind mount %s to %s: %v", dst, src, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Feature proposal: #912 

manually tested:
1. built and deployed to a k8s cluster, devices show up ok in `ResourceSlice`
2. created a pod using such gpu resource and it is successfully scheduled , ran `nvidia-smi` inside its container and exited.

---

This commit aims to faithfully rewrite the shell scripts and bash  in-line pre-start scripts in golang while keeping the error handling and debuggability the same.