### PR TITLE
Set proper path for MPS shm dir mount

### DIFF
--- a/cmd/gpu-kubelet-plugin/sharing.go
+++ b/cmd/gpu-kubelet-plugin/sharing.go
@@ -54,7 +54,23 @@ const (
 	MpsControlFilesDirName       = "mps"
 	MpsControlDaemonTemplatePath = "/templates/mps-control-daemon.tmpl.yaml"
 	MpsControlDaemonNameFmt      = "mps-control-daemon-%v" // Fill with ClaimUID
+	MpsDefaultShmMountPath       = "/dev/shm"
+
+	// driverRootMountDir is the directory where the driver root is mounted inside the kubelet plugin container.
+	driverRootMountDir = "/driver-root"
 )
+
+// fileChecker checks whether a file exists at the given path.
+type fileChecker interface {
+	Stat(path string) error
+}
+
+type osFileChecker struct{}
+
+func (osFileChecker) Stat(path string) error {
+	_, err := os.Stat(path)
+	return err
+}
 
 type TimeSlicingManager struct {
 	nvdevlib *deviceLib
@@ -95,6 +111,18 @@ type MpsControlDaemonTemplateData struct {
 	MpsLogDirectory                 string
 	MpsImageName                    string
 	FeatureGates                    map[string]bool
+	MpsShmMountPath                 string
+}
+
+// setMpsShmMountPath returns the container path at which the MPS shm should be mounted in the MPS control daemon pod.
+// If <driverRootMountDir>/dev/shm exists, the MPS daemon runs inside a chroot and shm must be mounted there.
+// Otherwise (e.g. GKE COS) the daemon runs directly in the container namespace and expects /dev/shm.
+func setMpsShmMountPath(checker fileChecker) string {
+	chrootShmPath := filepath.Join(driverRootMountDir, "dev", "shm")
+	if checker.Stat(chrootShmPath) == nil {
+		return chrootShmPath
+	}
+	return MpsDefaultShmMountPath
 }
 
 func NewTimeSlicingManager(deviceLib *deviceLib) *TimeSlicingManager {
@@ -210,6 +238,7 @@ func (m *MpsControlDaemon) Start(ctx context.Context, config *configapi.MpsConfi
 		MpsLogDirectory:                 m.logDir,
 		MpsImageName:                    m.manager.config.flags.imageName,
 		FeatureGates:                    featuregates.ToMap(),
+		MpsShmMountPath:                 setMpsShmMountPath(osFileChecker{}),
 	}
 
 	if config != nil && config.DefaultActiveThreadPercentage != nil {

--- a/cmd/gpu-kubelet-plugin/sharing_test.go
+++ b/cmd/gpu-kubelet-plugin/sharing_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 The Kubernetes Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockFileChecker implements fileChecker for tests.
+// existingPath is the single path Stat should report as existing; empty means nothing exists.
+type mockFileChecker struct {
+	existingPath string
+}
+
+func (m *mockFileChecker) Stat(path string) error {
+	if path == m.existingPath {
+		return nil
+	}
+	return errors.New("not found")
+}
+
+func TestSetMpsShmMountPath(t *testing.T) {
+	testCases := map[string]struct {
+		existingPath      string
+		expectedMountPath string
+	}{
+		// /dev/shm exists under the driver root → daemon uses chroot → shm at <driverRootMountDir>/dev/shm.
+		"dev/shm exists under driver root": {
+			existingPath:      filepath.Join(driverRootMountDir, "dev", "shm"),
+			expectedMountPath: filepath.Join(driverRootMountDir, "dev", "shm"),
+		},
+		// /dev/shm not present under driver root (e.g. GKE COS) → daemon runs directly
+		// in the container namespace → shm at /dev/shm.
+		"dev/shm does not exist under driver root — case for GKE COS": {
+			existingPath:      "",
+			expectedMountPath: MpsDefaultShmMountPath,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			checker := &mockFileChecker{existingPath: tc.existingPath}
+			require.Equal(t, tc.expectedMountPath, setMpsShmMountPath(checker))
+		})
+	}
+}

--- a/templates/mps-control-daemon.tmpl.yaml
+++ b/templates/mps-control-daemon.tmpl.yaml
@@ -74,7 +74,7 @@ spec:
         - name: driver-root
           mountPath: /driver-root
         - name: mps-shm-directory
-          mountPath: /driver-root/dev/shm
+          mountPath: {{ .MpsShmMountPath }}
         - name: mps-pipe-directory
           mountPath: /driver-root/tmp/nvidia-mps
         - name: mps-log-directory


### PR DESCRIPTION
Fixes #974 

This unblocks usage of MPS on GPUs which support pre-Volta MPS (e.g. NVIDIA P4) on GKE clusters and it doesn't change default configuration.

The MPS control daemon template hardcoded /driver-root/dev/shm as the container mount path for the MPS  `shm` directory.  This works when the daemon runs inside a chroot (standard NVIDIA DRA driver install, GPU Operator), 
but fails on GKE COS where the daemon runs directly in the container namespace, expecting /dev/shm.        

Change was also tested on NVIDIA T4 which supports Volta MPS.

1.  volumeMounts on EKS, MPS control daemon uses chroot 

```
      volumeMounts:
        - name: driver-root
          mountPath: /driver-root
        - name: mps-shm-directory
          mountPath: /driver-root/dev/shm
        - name: mps-pipe-directory
          mountPath: /driver-root/tmp/nvidia-mps
        - name: mps-log-directory
          mountPath: /driver-root/var/log/nvidia-mps
        - name: kube-api-access-b7kx9
          readOnly: true
          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
```


2. volumeMounts on GKE, MPS control daemon doesn't use chroot 

```
      volumeMounts:
        - name: driver-root
          mountPath: /driver-root
        - name: mps-shm-directory
          mountPath: /dev/shm
        - name: mps-pipe-directory
          mountPath: /driver-root/tmp/nvidia-mps
        - name: mps-log-directory
          mountPath: /driver-root/var/log/nvidia-mps
        - name: kube-api-access-7pbnm
          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
          readOnly: true
          recursiveReadOnly: Disabled
```




