### PR TITLE
Use correct cross-compiler for bash static build

### DIFF
--- a/hack/build-bash-static.sh
+++ b/hack/build-bash-static.sh
@@ -41,6 +41,10 @@ case "${ARCH}" in
     STRIP=aarch64-linux-gnu-strip
     CC=aarch64-linux-gnu-gcc
     ;;
+  x86_64)
+    STRIP=x86_64-linux-gnu-strip
+    CC=x86_64-linux-gnu-gcc
+    ;;
 esac
 
 echo "detected arch: ${ARCH}"


### PR DESCRIPTION
 Fixes #977  
 
When building bash for `amd64` on `arm64` host, `CC=gcc` resolved to the native `arm64` compiler, producing `arm64` binary placed into the `amd64` image. 

This caused exec format error at runtime when the kubelet plugin init container tried to execute /bin/bash.

Add the `x86_64` case to explicitly select `x86_64-linux-gnu-gcc` and `x86_64-linux-gnu-strip` when cross-compiling for `x86_64`.

Issue was introduced in https://github.com/NVIDIA/k8s-dra-driver-gpu/commit/ac433f1b078725980c3067470b68995ee7aa5984