### PR TITLE
build: drop --version check for bash in cross-compiled build stage

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -101,7 +101,7 @@ ENV BASH_STATIC_GIT_REF=${BASH_STATIC_GIT_REF}
 WORKDIR /bashbuild
 COPY hack/build-bash-static.sh .
 RUN bash /bashbuild/build-bash-static.sh
-RUN cd /bashbuild/bash-static/releases && ./bash*-static --version && mv bash-*-static /bashbuild/bash && file /bashbuild/bash
+RUN cd /bashbuild/bash-static/releases && mv bash-*-static /bashbuild/bash && file /bashbuild/bash
 
 # option 2:
 # FROM registry.k8s.io/nv-dra-driver-gpu/nvidia-dra-driver-gpu:v25.12.0-dev-839e966a AS bash
@@ -161,7 +161,3 @@ COPY /templates /templates
 COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /etc/group /etc/group
 USER root:root
-
-# Smoke-test executables (provide early build feedback).
-RUN ["/usr/bin/compute-domain-kubelet-plugin", "--version"]
-RUN ["/bin/bash", "--version"]


### PR DESCRIPTION
Follow-up to #1003.

With the cross-compilation fix in #1003, the bash binary is now correctly built for the target arch. But the build stage runs on `$BUILDPLATFORM`, so it cannot execute the cross-compiled binary:

```
#67 [linux/amd64->arm64 build 19/19] RUN cd /bashbuild/bash-static/releases && ./bash*-static --version && ...
#67 0.332 /bin/sh: 1: ./bash-5.2-static: Exec format error
```

Remove the `./bash*-static --version` call from the build stage. The final stage (line 167) already runs `RUN ["/bin/bash", "--version"]` on the target platform, which serves as the smoke test. The build stage retains `file` to log the binary type.