### PR TITLE
Run init-buildx before container build

### DIFF
--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -34,7 +34,12 @@ IMAGE_TAG ?= $(IMAGE_VERSION)
 IMAGE = $(IMAGE_NAME):$(IMAGE_TAG)
 
 ##### Public rules #####
-.PHONY: build
+INIT_BUILDX_SCRIPT ?= $(CURDIR)/hack/init-buildx.sh
+
+.PHONY: build init-buildx
+
+init-buildx:
+	DOCKER=$(DOCKER) $(INIT_BUILDX_SCRIPT)
 
 # Multi-arch without registry push (e.g. GitHub Actions): BUILD_MULTI_ARCH_GH=true
 # writes an OCI layout tarball. Image push to staging/promotion is done by Prow.
@@ -85,7 +90,7 @@ ifeq ($(CI), true)
 	GOMODCACHE=/go/pkg/mod
 endif
 
-build:
+build: init-buildx
 	mkdir -p $(DIST_DIR)
 	DOCKER_BUILDKIT=1 \
 		$(DOCKER) buildx build --pull \

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -20,11 +20,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+DOCKER="${DOCKER:-docker}"
 BUILDER_NAME="${BUILDER_NAME:-nvidia-dra-driver-gpu-builder}"
 
 # We can skip setup if the current builder already has multi-arch
 # AND if it isn't the docker driver, which doesn't work
-current_builder="$(docker buildx inspect 2>/dev/null || true)"
+current_builder="$("${DOCKER}" buildx inspect 2>/dev/null || true)"
 if ! grep -Eq "^Driver:\s*docker$"  <<<"${current_builder}" && \
      grep -q "linux/amd64" <<<"${current_builder}" && \
      grep -q "linux/arm64" <<<"${current_builder}"; then
@@ -35,9 +36,9 @@ fi
 # Adapted from https://github.com/kubernetes-sigs/kind/blob/main/hack/build/init-buildx.sh
 BINFMT_IMAGE="${BINFMT_IMAGE:-tonistiigi/binfmt:qemu-v7.0.0@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55}"
 if [ "$(uname)" == 'Linux' ]; then
-	docker run --rm --privileged "${BINFMT_IMAGE}" --install all
+	"${DOCKER}" run --rm --privileged "${BINFMT_IMAGE}" --install all
 fi
 
-docker buildx rm "${BUILDER_NAME}" || true
-docker buildx create --use --name="${BUILDER_NAME}"
-docker buildx inspect --bootstrap
+"${DOCKER}" buildx rm "${BUILDER_NAME}" || true
+"${DOCKER}" buildx create --use --name="${BUILDER_NAME}"
+"${DOCKER}" buildx inspect --bootstrap


### PR DESCRIPTION
This PR adds a pre-requisite to the `build` target in `deployments/container/Makefile`, to initialize buildx.