### PR TITLE
Retry device enumeration on startup to prevent empty ResourceSlices

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_enumerator.go
+++ b/cmd/gpu-kubelet-plugin/device_enumerator.go
@@ -1,0 +1,155 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+// ErrDeviceEnumerationTimeout is returned by enumerateDevicesWithRetry
+// when the retry budget is exhausted without discovering any devices.
+var ErrDeviceEnumerationTimeout = errors.New("device enumeration timed out before any GPU was discovered")
+
+type deviceEnumerator interface {
+	enumerateAllPossibleDevices() (*PerGPUAllocatableDevices, error)
+}
+
+// enumerateDevices performs a single GPU enumeration attempt and decides whether the result is ready or a retry is needed.
+//
+// The decision tree:
+//   - empty allocatable                                  -> retry
+//   - allocatable has any gpu/mig device                 -> accept
+//   - allocatable is vfio-only, empty checkpoint         -> retry
+//   - allocatable is vfio-only, non-empty checkpoint     -> accept
+func enumerateDevices(nvdevlib deviceEnumerator, cp *Checkpoint) (*PerGPUAllocatableDevices, error) {
+	perGPU, err := nvdevlib.enumerateAllPossibleDevices()
+	if err != nil {
+		if isTransientNVMLError(err) {
+			klog.Infof("Transient NVML error on enumeration attempt, retrying: %v", err)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error enumerating all possible devices: %w", err)
+	}
+
+	if len(perGPU.allocatablesMap) == 0 {
+		// Caveat: we may end up in this state due to unhealthy GPUs. This needs to be revisited in the future
+		klog.Infof("No GPU devices discovered on enumeration attempt, retrying")
+		return nil, nil
+	}
+
+	if featuregates.Enabled(featuregates.PassthroughSupport) {
+		// If allocatable has only vfio devices:
+		//   - empty checkpoint     → retry (GPU may not be fully initialized)
+		//   - non-empty checkpoint → ready
+		if !allocatableHasNonVfio(perGPU) && !checkpointHasPreparedDevices(cp) {
+			klog.Infof("Only vfio devices visible and checkpoint is empty, retrying")
+			return nil, nil
+		}
+	}
+
+	// Any non-vfio device present means enumeration was successful — proceed.
+	return perGPU, nil
+}
+
+// allocatableHasNonVfio reports whether perGPU contains any non-vfio (gpu or mig) device.
+// Returns false for both empty maps and vfio-only maps.
+func allocatableHasNonVfio(perGPU *PerGPUAllocatableDevices) bool {
+	for _, devices := range perGPU.allocatablesMap {
+		for _, dev := range devices {
+			if dev.Type() != VfioDeviceType {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// checkpointHasPreparedDevices reports whether cp contains any prepared device (of any type, in any claim state).
+func checkpointHasPreparedDevices(cp *Checkpoint) bool {
+	if cp == nil || cp.V2 == nil {
+		return false
+	}
+	for _, claim := range cp.V2.PreparedClaims {
+		for _, group := range claim.PreparedDevices {
+			if len(group.Devices) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// enumerateDevicesWithRetry retries until at least one device is found, the context is cancelled, or the retry budget is exhausted.
+// Transient NVML errors are retried, all other errors propagate immediately.
+//
+// Why we retry — see issue #1008: the GPU may not be fully initialised when the gpu kubelet plugin starts.
+// Before this retry was added, a ResourceSlice could be published with no devices and the only fix was to restart the plugin.
+//
+// Retrying lets the plugin start up before the driver is ready and re-publish a populated ResourceSlice once enumeration succeeds.
+// If the retry budget is exhausted, we return ErrDeviceEnumerationTimeout so the caller can fail rather than silently keep the
+// ResourceSlice empty. Transient NVML errors are retried, all other errors propagate immediately.
+func enumerateDevicesWithRetry(ctx context.Context, nvdevlib deviceEnumerator, backoff wait.Backoff, cp *Checkpoint) (*PerGPUAllocatableDevices, error) {
+	totalSteps := backoff.Steps
+	var perGPUAllocatable *PerGPUAllocatableDevices
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		var err error
+		perGPUAllocatable, err = enumerateDevices(nvdevlib, cp)
+		if err != nil {
+			return false, err
+		}
+		return perGPUAllocatable != nil, nil
+	})
+	switch {
+	case err == nil:
+		return perGPUAllocatable, nil
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return nil, fmt.Errorf("context cancelled while waiting for GPU devices: %w", err)
+	case wait.Interrupted(err):
+		klog.Errorf("No GPU devices found after %d attempts; failing startup to avoid publishing an empty ResourceSlice", totalSteps)
+		return nil, ErrDeviceEnumerationTimeout
+	default:
+		return nil, err
+	}
+}
+
+// isTransientNVMLError reports whether err is an NVML "not ready yet" error expected during early driver init.
+// Errors that may indicate real hardware problems are treated as permanent.
+// errors.Is walks the %w-wrap chain and matches by == against the bare nvml.Return at the bottom.
+func isTransientNVMLError(err error) bool {
+	return errors.Is(err, nvml.ERROR_UNINITIALIZED) || errors.Is(err, nvml.ERROR_DRIVER_NOT_LOADED)
+}
+
+// deviceEnumerationBackoff builds the retry cadence for background GPU enumeration.
+func deviceEnumerationBackoff(flags *Flags) wait.Backoff {
+	return wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.2,
+		Cap:      flags.deviceEnumerationRetryMaxInterval,
+		Steps:    flags.deviceEnumerationRetrySteps,
+	}
+}

--- a/cmd/gpu-kubelet-plugin/device_enumerator_test.go
+++ b/cmd/gpu-kubelet-plugin/device_enumerator_test.go
@@ -1,0 +1,421 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+// setPassthrough toggles the PassthroughSupport feature gate on the global featuregates.
+func setPassthrough(t *testing.T, enabled bool) {
+	t.Helper()
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+		string(featuregates.PassthroughSupport): enabled,
+	}))
+	t.Cleanup(func() {
+		require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+			string(featuregates.PassthroughSupport): false,
+		}))
+	})
+}
+
+// fakeEnumerator implements deviceEnumerator for tests.
+// Each call to enumerateAllPossibleDevices consumes the next result in the slice,
+// once exhausted, the last result is repeated.
+type fakeEnumerator struct {
+	results []enumerateResult
+	calls   int
+}
+
+type enumerateResult struct {
+	devices *PerGPUAllocatableDevices
+	err     error
+}
+
+func (f *fakeEnumerator) enumerateAllPossibleDevices() (*PerGPUAllocatableDevices, error) {
+	idx := f.calls
+	if idx >= len(f.results) {
+		idx = len(f.results) - 1
+	}
+	f.calls++
+	return f.results[idx].devices, f.results[idx].err
+}
+
+func emptyDevices() *PerGPUAllocatableDevices {
+	return &PerGPUAllocatableDevices{allocatablesMap: map[PCIBusID]AllocatableDevices{}}
+}
+
+func oneGPUDevice() *PerGPUAllocatableDevices {
+	return &PerGPUAllocatableDevices{
+		allocatablesMap: map[PCIBusID]AllocatableDevices{
+			"0000:00:04.0": {"gpu-0": {Gpu: &GpuInfo{UUID: "GPU-fake-uuid"}}},
+		},
+	}
+}
+
+// vfioOnlyDevices returns a PerGPUAllocatableDevices with a single vfio-type device.
+func vfioOnlyDevices() *PerGPUAllocatableDevices {
+	return &PerGPUAllocatableDevices{
+		allocatablesMap: map[PCIBusID]AllocatableDevices{
+			"0000:00:04.0": {
+				"gpu-vfio-0": {Vfio: &VfioDeviceInfo{
+					UUID:     "vfio-fake-uuid",
+					PciBusID: "0000:00:04.0",
+				}},
+			},
+		},
+	}
+}
+
+// mixedDevices returns a PerGPUAllocatableDevices with two GPUs:
+//   - GPU at 0000:00:04.0: a vfio-type device
+//   - GPU at 0000:00:05.0: a gpu-type device
+func mixedDevices() *PerGPUAllocatableDevices {
+	return &PerGPUAllocatableDevices{
+		allocatablesMap: map[PCIBusID]AllocatableDevices{
+			"0000:00:04.0": {
+				"gpu-vfio-0": {Vfio: &VfioDeviceInfo{
+					UUID:     "vfio-fake-uuid",
+					PciBusID: "0000:00:04.0",
+				}},
+			},
+			"0000:00:05.0": {"gpu-1": {Gpu: &GpuInfo{UUID: "GPU-fake-uuid-2"}}},
+		},
+	}
+}
+
+// nonEmptyCheckpoint builds a Checkpoint with one prepared device.
+func nonEmptyCheckpoint() *Checkpoint {
+	return &Checkpoint{
+		V2: &CheckpointV2{
+			PreparedClaims: PreparedClaimsByUID{
+				"claim-uid-1": {
+					CheckpointState: ClaimCheckpointStatePrepareCompleted,
+					PreparedDevices: PreparedDevices{
+						{Devices: PreparedDeviceList{
+							{Gpu: &PreparedGpu{
+								Info:   &GpuInfo{UUID: "GPU-fake-uuid"},
+								Device: &CheckpointedDevice{DeviceName: "gpu-0"},
+							}},
+						}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestEnumerateDevicesWithRetry(t *testing.T) {
+	// Cases that exercise the vfio-only branch must enable PassthroughSupport, which
+	// manipulates the global featuregates - subtests cannot run in parallel.
+
+	// fastBackoff is a zero-jitter, millisecond-interval backoff used across
+	// test cases so retries are deterministic and tests finish quickly.
+	fastBackoff := func(steps int) wait.Backoff {
+		return wait.Backoff{
+			Duration: 1 * time.Millisecond,
+			Factor:   1.0,
+			Jitter:   0.0,
+			Steps:    steps,
+		}
+	}
+
+	tests := map[string]struct {
+		enumerator         *fakeEnumerator
+		checkpoint         *Checkpoint
+		ctxFn              func() (context.Context, context.CancelFunc)
+		backoff            wait.Backoff
+		passthroughEnabled bool
+		wantErr            error
+		wantDeviceCount    int
+		wantCalls          int
+	}{
+		"devices found on first call": {
+			enumerator:      &fakeEnumerator{results: []enumerateResult{{devices: oneGPUDevice()}}},
+			backoff:         fastBackoff(10),
+			wantDeviceCount: 1,
+			wantCalls:       1,
+		},
+		"devices found after retries": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{
+				{devices: emptyDevices()},
+				{devices: emptyDevices()},
+				{devices: oneGPUDevice()},
+			}},
+			backoff:         fastBackoff(10),
+			wantDeviceCount: 1,
+			wantCalls:       3,
+		},
+		// A pre-cancelled context short-circuits ExponentialBackoffWithContext before the condition
+		// runs, so the enumerator is never invoked regardless of the backoff budget.
+		"context cancelled returns context error": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{{devices: emptyDevices()}}},
+			ctxFn: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, cancel
+			},
+			backoff:   fastBackoff(10),
+			wantErr:   context.Canceled,
+			wantCalls: 0,
+		},
+		"retry budget exhausted returns sentinel error to force crashloop": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{{devices: emptyDevices()}}},
+			backoff:    fastBackoff(3),
+			wantErr:    ErrDeviceEnumerationTimeout,
+			wantCalls:  3,
+		},
+		"transient NVML error retried and then succeeds": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{
+				{err: fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_UNINITIALIZED)},
+				{err: fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_DRIVER_NOT_LOADED)},
+				{devices: oneGPUDevice()},
+			}},
+			backoff:         fastBackoff(10),
+			wantDeviceCount: 1,
+			wantCalls:       3,
+		},
+		"non-transient NVML error fails immediately": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{
+				{err: fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_GPU_IS_LOST)},
+			}},
+			backoff:   fastBackoff(10),
+			wantErr:   nvml.ERROR_GPU_IS_LOST,
+			wantCalls: 1,
+		},
+		"empty then non-transient error propagates mid-retry": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{
+				{devices: emptyDevices()},
+				{err: fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_GPU_IS_LOST)},
+			}},
+			backoff:   fastBackoff(10),
+			wantErr:   nvml.ERROR_GPU_IS_LOST,
+			wantCalls: 2,
+		},
+		"passthrough on: vfio-only with empty checkpoint - retry": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{
+				{devices: vfioOnlyDevices()},
+				{devices: vfioOnlyDevices()},
+				{devices: oneGPUDevice()},
+			}},
+			passthroughEnabled: true,
+			backoff:            fastBackoff(10),
+			wantDeviceCount:    1,
+			wantCalls:          3,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setPassthrough(t, tc.passthroughEnabled)
+
+			ctx := context.Background()
+			if tc.ctxFn != nil {
+				var cancel context.CancelFunc
+				ctx, cancel = tc.ctxFn()
+				defer cancel()
+			}
+
+			cp := tc.checkpoint
+			if cp == nil {
+				cp = &Checkpoint{V2: &CheckpointV2{PreparedClaims: PreparedClaimsByUID{}}}
+			}
+			got, err := enumerateDevicesWithRetry(ctx, tc.enumerator, tc.backoff, cp)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Len(t, got.allocatablesMap, tc.wantDeviceCount)
+			}
+			assert.Equal(t, tc.wantCalls, tc.enumerator.calls, "enumerator call count")
+		})
+	}
+}
+
+func TestAllocatableHasNonVfio(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		perGPU *PerGPUAllocatableDevices
+		want   bool
+	}{
+		"empty allocatable":  {perGPU: emptyDevices(), want: false},
+		"gpu-only":           {perGPU: oneGPUDevice(), want: true},
+		"vfio-only":          {perGPU: vfioOnlyDevices(), want: false},
+		"mixed gpu and vfio": {perGPU: mixedDevices(), want: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, allocatableHasNonVfio(tc.perGPU))
+		})
+	}
+}
+
+func TestCheckpointHasPreparedDevices(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		checkpoint *Checkpoint
+		want       bool
+	}{
+		"nil checkpoint":       {checkpoint: nil, want: false},
+		"nil V2":               {checkpoint: &Checkpoint{}, want: false},
+		"empty PreparedClaims": {checkpoint: &Checkpoint{V2: &CheckpointV2{PreparedClaims: PreparedClaimsByUID{}}}, want: false},
+		"non-empty checkpoint": {checkpoint: nonEmptyCheckpoint(), want: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, checkpointHasPreparedDevices(tc.checkpoint))
+		})
+	}
+}
+
+func TestEnumerateDevices(t *testing.T) {
+	// Cases that exercise the vfio-only branch must enable PassthroughSupport, which
+	// manipulates the global featuregates singleton — subtests cannot run in parallel.
+
+	emptyCheckpoint := &Checkpoint{V2: &CheckpointV2{PreparedClaims: PreparedClaimsByUID{}}}
+
+	tests := map[string]struct {
+		enumerator         *fakeEnumerator
+		checkpoint         *Checkpoint
+		passthroughEnabled bool
+		wantNil            bool
+		wantErr            error
+		wantDeviceCount    int
+	}{
+		"gpu device discovered — accept": {
+			enumerator:      &fakeEnumerator{results: []enumerateResult{{devices: oneGPUDevice()}}},
+			wantDeviceCount: 1,
+		},
+		"empty allocatable — retry": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{{devices: emptyDevices()}}},
+			wantNil:    true,
+		},
+		"transient NVML error — retry": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{
+				{err: fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_UNINITIALIZED)},
+			}},
+			wantNil: true,
+		},
+		"non-transient NVML error — propagates immediately": {
+			enumerator: &fakeEnumerator{results: []enumerateResult{
+				{err: fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_GPU_IS_LOST)},
+			}},
+			wantErr: nvml.ERROR_GPU_IS_LOST,
+		},
+		"passthrough on: vfio-only allocatable, empty checkpoint — retry": {
+			enumerator:         &fakeEnumerator{results: []enumerateResult{{devices: vfioOnlyDevices()}}},
+			checkpoint:         emptyCheckpoint,
+			passthroughEnabled: true,
+			wantNil:            true,
+		},
+		"passthrough on: vfio-only allocatable, non-empty checkpoint — accept": {
+			enumerator:         &fakeEnumerator{results: []enumerateResult{{devices: vfioOnlyDevices()}}},
+			checkpoint:         nonEmptyCheckpoint(),
+			passthroughEnabled: true,
+			wantDeviceCount:    1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setPassthrough(t, tc.passthroughEnabled)
+
+			got, err := enumerateDevices(tc.enumerator, tc.checkpoint)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tc.wantNil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Len(t, got.allocatablesMap, tc.wantDeviceCount)
+			}
+		})
+	}
+}
+
+func TestIsTransientNVMLError(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err         error
+		isTransient bool
+	}{
+		"bare nvml.ERROR_UNINITIALIZED": {
+			err:         nvml.ERROR_UNINITIALIZED,
+			isTransient: true,
+		},
+		"bare nvml.ERROR_DRIVER_NOT_LOADED": {
+			err:         nvml.ERROR_DRIVER_NOT_LOADED,
+			isTransient: true,
+		},
+		"bare nvml.ERROR_GPU_IS_LOST is not transient": {
+			err:         nvml.ERROR_GPU_IS_LOST,
+			isTransient: false,
+		},
+		"single-wrap as ensureNVML returns it": {
+			err:         fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_UNINITIALIZED),
+			isTransient: true,
+		},
+		"double-wrap with nvml.ERROR_UNINITIALIZED": {
+			err: fmt.Errorf("error enumerating allocatable devices: %w",
+				fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_UNINITIALIZED)),
+			isTransient: true,
+		},
+		"double-wrap with ERROR_DRIVER_NOT_LOADED": {
+			err: fmt.Errorf("error enumerating allocatable devices: %w",
+				fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_DRIVER_NOT_LOADED)),
+			isTransient: true,
+		},
+		"double-wrap with non-transient ERROR_GPU_IS_LOST": {
+			err: fmt.Errorf("error enumerating allocatable devices: %w",
+				fmt.Errorf("ensureNVML failed: %w", nvml.ERROR_GPU_IS_LOST)),
+			isTransient: false,
+		},
+		"plain non-NVML error": {
+			err:         fmt.Errorf("some other failure"),
+			isTransient: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.isTransient, isTransientNVMLError(tc.err))
+		})
+	}
+}

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -73,6 +73,10 @@ type DeviceState struct {
 	// (e.g., when announcing one ResourceSlice per physical GPU).
 	perGPUAllocatable *PerGPUAllocatableDevices
 
+	// allocatableReady is closed exactly once when perGPUAllocatable has been populated.
+	allocatableReady     chan struct{}
+	allocatableReadyOnce sync.Once
+
 	nvdevlib          *deviceLib
 	checkpointManager checkpointmanager.CheckpointManager
 
@@ -88,11 +92,6 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	nvdevlib, err := newDeviceLib(containerDriverRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create device library: %w", err)
-	}
-
-	perGPUAllocatable, err := nvdevlib.enumerateAllPossibleDevices()
-	if err != nil {
-		return nil, fmt.Errorf("error enumerating all possible devices: %w", err)
 	}
 
 	hostDriverRoot := config.flags.hostDriverRoot
@@ -128,18 +127,6 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		return nil, fmt.Errorf("unable to create CDI handler: %w", err)
 	}
 
-	var fullGPUuuids []string
-	for _, devices := range perGPUAllocatable.allocatablesMap {
-		for _, dev := range devices {
-			if dev.Gpu != nil {
-				fullGPUuuids = append(fullGPUuuids, dev.Gpu.UUID)
-			}
-		}
-	}
-
-	klog.V(2).Infof("Warming up CDI device spec cache for GPUs %v", fullGPUuuids)
-	cdi.WarmupDevSpecCache(fullGPUuuids)
-
 	var tsManager *TimeSlicingManager
 	if featuregates.Enabled(featuregates.TimeSlicingSettings) {
 		tsManager = NewTimeSlicingManager(nvdevlib)
@@ -170,11 +157,12 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		tsManager:         tsManager,
 		mpsManager:        mpsManager,
 		vfioPciManager:    vfioPciManager,
-		perGPUAllocatable: perGPUAllocatable,
+		perGPUAllocatable: &PerGPUAllocatableDevices{allocatablesMap: map[PCIBusID]AllocatableDevices{}},
 		config:            config,
 		nvdevlib:          nvdevlib,
 		checkpointManager: checkpointManager,
 		cplock:            flock.NewFlock(cpLockPath),
+		allocatableReady:  make(chan struct{}),
 	}
 	state.checkpointCleanupManager = NewCheckpointCleanupManager(state, config.clientsets.Resource)
 
@@ -188,9 +176,10 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		return nil, fmt.Errorf("read node boot id: %w", err)
 	}
 
+	var cp *Checkpoint
 	for _, c := range checkpoints {
 		if c == DriverPluginCheckpointFileBasename {
-			cp, err := state.getCheckpoint(ctx)
+			cp, err = state.getCheckpoint(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("unable to get checkpoint: %w", err)
 			}
@@ -207,22 +196,36 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 					return nil, fmt.Errorf("unable to update checkpoint: %w", err)
 				}
 				syncPreparedDevicesGaugeFromCheckpoint(config.flags.nodeName, cp)
-				return state, nil
+				break
 			} else if storedBootID == currentBootID {
 				syncPreparedDevicesGaugeFromCheckpoint(config.flags.nodeName, cp)
-				return state, nil
+				break
 			} else {
 				klog.Infof("Invalidating checkpoint: checkpoint nodeBootID %q != current %q", storedBootID, currentBootID)
+				cp = nil
 			}
 		}
 	}
 
-	klog.Infof("Create empty checkpoint")
-	newCheckpoint := &Checkpoint{V2: &CheckpointV2{NodeBootID: currentBootID}}
-	if err := state.createCheckpoint(ctx, newCheckpoint); err != nil {
-		return nil, fmt.Errorf("unable to create fresh checkpoint: %v", err)
+	if cp == nil {
+		klog.Infof("Create empty checkpoint")
+		newCheckpoint := &Checkpoint{V2: &CheckpointV2{NodeBootID: currentBootID}}
+		if err := state.createCheckpoint(ctx, newCheckpoint); err != nil {
+			return nil, fmt.Errorf("unable to create fresh checkpoint: %v", err)
+		}
+		cp = newCheckpoint
 	}
 
+	// Try enumerating devices
+	// If nothing is discovered yet, background retries take over via InitAllocatableBackground.
+	perGPUAllocatable, err := enumerateDevices(nvdevlib, cp)
+	if err != nil {
+		return nil, err
+	}
+	if perGPUAllocatable != nil {
+		warmupCDICache(cdi, perGPUAllocatable)
+		state.finalizeAllocatable(perGPUAllocatable)
+	}
 	return state, nil
 }
 
@@ -1316,7 +1319,7 @@ func (s *DeviceState) AddDeviceTaint(d *AllocatableDevice, taint *resourceapi.De
 	return d.AddOrUpdateTaint(taint)
 }
 
-// Returns false on nodes where GPU hardware is not MIG capable (L4/Ada,T4/Turing)
+// IsMigCapable returns false on nodes where GPU hardware is not MIG capable (L4/Ada, T4/Turing).
 // Used by the driver at startup to gate the DynamicMIG-specific code paths.
 func (s *DeviceState) IsMigCapable() bool {
 	for _, gpu := range s.nvdevlib.gpuInfosByUUID {
@@ -1325,4 +1328,59 @@ func (s *DeviceState) IsMigCapable() bool {
 		}
 	}
 	return false
+}
+
+// AllocatableReady reports whether perGPUAllocatable has been populated with at least one device.
+func (s *DeviceState) AllocatableReady() bool {
+	select {
+	case <-s.allocatableReady:
+		return true
+	default:
+		return false
+	}
+}
+
+// InitAllocatableBackground runs the enumeration retry loop, on success populates perGPUAllocatable and closes allocatableReady.
+func (s *DeviceState) InitAllocatableBackground(ctx context.Context) error {
+	if s.AllocatableReady() {
+		return nil
+	}
+
+	cp, err := s.getCheckpoint(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to read checkpoint before background enumeration: %w", err)
+	}
+	backoff := deviceEnumerationBackoff(s.config.flags)
+	perGPU, err := enumerateDevicesWithRetry(ctx, s.nvdevlib, backoff, cp)
+	if err != nil {
+		return err
+	}
+	warmupCDICache(s.cdi, perGPU)
+	s.finalizeAllocatable(perGPU)
+	return nil
+}
+
+// finalizeAllocatable stores the enumeration result and marks the state ready.
+// Safe to call multiple times, only the first call has effect.
+func (s *DeviceState) finalizeAllocatable(perGPU *PerGPUAllocatableDevices) {
+	s.allocatableReadyOnce.Do(func() {
+		s.Lock()
+		s.perGPUAllocatable = perGPU
+		s.Unlock()
+		close(s.allocatableReady)
+	})
+}
+
+// warmupCDICache populates the CDI device spec cache for every full GPU in perGPU.
+func warmupCDICache(cdi *CDIHandler, perGPU *PerGPUAllocatableDevices) {
+	var fullGPUuuids []string
+	for _, devices := range perGPU.allocatablesMap {
+		for _, dev := range devices {
+			if dev.Gpu != nil {
+				fullGPUuuids = append(fullGPUuuids, dev.Gpu.UUID)
+			}
+		}
+	}
+	klog.V(2).Infof("Warming up CDI device spec cache for GPUs %v", fullGPUuuids)
+	cdi.WarmupDevSpecCache(fullGPUuuids)
 }

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -65,6 +65,14 @@ type driver struct {
 	// Devices (required for k8s 1.35+) or combined SharedCounters and Devices
 	// in the same slice (required for k8s 1.34).
 	useSplitResourceSlices bool
+
+	// initErr receives at most one error from backgroundInit on terminal failure.
+	initErr chan error
+}
+
+// InitErrors returns a channel that receives at most one error if background init fails terminally.
+func (d *driver) InitErrors() <-chan error {
+	return d.initErr
 }
 
 func NewDriver(ctx context.Context, config *Config) (*driver, error) {
@@ -107,7 +115,9 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 			// completely prepared claims can stay; assuming that the central
 			// scheduler state is equivalent. TODO: review if this logic is correct;
 			// or if it potentially is too invasive for certain edge cases.
-			state.DestroyUnknownMIGDevices(ctx)
+			if state.AllocatableReady() {
+				state.DestroyUnknownMIGDevices(ctx)
+			}
 
 			// Read Kubernetes API server version to determine which ResourceSlice
 			// model to use.
@@ -126,6 +136,7 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		state:                  state,
 		pulock:                 flock.NewFlock(puLockPath),
 		useSplitResourceSlices: useSplitSlices,
+		initErr:                make(chan error, 1),
 	}
 
 	opts := []kubeletplugin.Option{
@@ -155,20 +166,11 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	driver.healthcheck = healthcheck
 
 	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
-		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
+		if state.AllocatableReady() {
+			if err := driver.startDeviceHealthMonitor(ctx, config); err != nil {
+				return nil, err
+			}
 		}
-		if err := deviceHealthMonitor.Start(ctx); err != nil {
-			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
-		}
-		driver.deviceHealthMonitor = deviceHealthMonitor
-
-		driver.wg.Add(1)
-		go func() {
-			defer driver.wg.Done()
-			driver.deviceHealthEvents(ctx, config.flags.nodeName)
-		}()
 	}
 
 	// Pass `nodeUnprepareResource` function to the cleanup manager.
@@ -180,9 +182,82 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		return nil, err
 	}
 
+	// If no device was found during device enumeration in NewDeviceState (issue #1008),
+	// retry in the background instead of blocking startup.
+	//
+	// Why background — if we block, kubelet may time out while registering the gpu plugin.
+	// Helper.PublishResources can be called more than once, so the plugin starts with an empty ResourceSlice
+	// and updates it from backgroundInit once we have devices.
+	//
+	// backgroundInit also runs the steps that need the device list to be ready:
+	// MIG cleanup, health monitor startup, and republish.
+	if !state.AllocatableReady() {
+		driver.wg.Add(1)
+		go driver.backgroundInit(ctx, config)
+	}
+
 	klog.V(4).Infof("Current kubelet plugin registration status: %s", helper.RegistrationStatus())
 
 	return driver, nil
+}
+
+// startDeviceHealthMonitor wires up the NVML device health monitor, caller must ensure AllocatableReady() is true.
+func (d *driver) startDeviceHealthMonitor(ctx context.Context, config *Config) error {
+	deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, d.state.perGPUAllocatable, d.state.nvdevlib)
+	if err != nil {
+		return fmt.Errorf("failed to create NVML device health monitor: %w", err)
+	}
+	if err := deviceHealthMonitor.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start device health monitor: %w", err)
+	}
+	d.deviceHealthMonitor = deviceHealthMonitor
+
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		d.deviceHealthEvents(ctx, config.flags.nodeName)
+	}()
+	return nil
+}
+
+// backgroundInit runs the deferred enumeration retry, MIG cleanup, health monitor startup, and ResourceSlice re-publish.
+// On terminal failure it signals via initErr so the process exits non-zero and kubelet restarts the pod.
+func (d *driver) backgroundInit(ctx context.Context, config *Config) {
+	defer d.wg.Done()
+
+	if err := d.state.InitAllocatableBackground(ctx); err != nil {
+		d.reportInitErr(fmt.Errorf("background device enumeration: %w", err))
+		return
+	}
+
+	if featuregates.Enabled(featuregates.DynamicMIG) {
+		if !d.state.IsMigCapable() {
+			klog.Warningf("DynamicMIG enabled but no MIG capable GPU found on this node; falling back to legacy Full GPU support")
+		} else {
+			d.state.DestroyUnknownMIGDevices(ctx)
+		}
+	}
+
+	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
+		if err := d.startDeviceHealthMonitor(ctx, config); err != nil {
+			d.reportInitErr(err)
+			return
+		}
+	}
+
+	if err := d.publishResources(ctx, config); err != nil {
+		d.reportInitErr(fmt.Errorf("republish resources after enumeration: %w", err))
+		return
+	}
+	klog.Infof("Background device enumeration complete; ResourceSlice republished with populated devices")
+}
+
+// reportInitErr writes err to the initErr channel if it is still empty.
+func (d *driver) reportInitErr(err error) {
+	select {
+	case d.initErr <- err:
+	default:
+	}
 }
 
 // GenerateDriverResources() returns the set of DRA ResourceSlices announced by

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -46,20 +47,22 @@ const (
 type Flags struct {
 	kubeClientConfig pkgflags.KubeClientConfig
 
-	nodeName                      string
-	namespace                     string
-	httpEndpoint                  string
-	metricsPath                   string
-	cdiRoot                       string
-	containerDriverRoot           string
-	hostDriverRoot                string
-	nvidiaCDIHookPath             string
-	imageName                     string
-	kubeletRegistrarDirectoryPath string
-	kubeletPluginsDirectoryPath   string
-	healthcheckPort               int
-	klogVerbosity                 int
-	additionalXidsToIgnore        string
+	nodeName                          string
+	namespace                         string
+	httpEndpoint                      string
+	metricsPath                       string
+	cdiRoot                           string
+	containerDriverRoot               string
+	hostDriverRoot                    string
+	nvidiaCDIHookPath                 string
+	imageName                         string
+	kubeletRegistrarDirectoryPath     string
+	kubeletPluginsDirectoryPath       string
+	healthcheckPort                   int
+	klogVerbosity                     int
+	additionalXidsToIgnore            string
+	deviceEnumerationRetrySteps       int
+	deviceEnumerationRetryMaxInterval time.Duration
 }
 
 type Config struct {
@@ -161,6 +164,20 @@ func newApp() *cli.App {
 			Value:       "",
 			Destination: &flags.additionalXidsToIgnore,
 			EnvVars:     []string{"ADDITIONAL_XIDS_TO_IGNORE"},
+		},
+		&cli.IntFlag{
+			Name:        "device-enumeration-retry-steps",
+			Usage:       "Maximum number of GPU enumeration attempts.",
+			Value:       5,
+			Destination: &flags.deviceEnumerationRetrySteps,
+			EnvVars:     []string{"DEVICE_ENUMERATION_RETRY_STEPS"},
+		},
+		&cli.DurationFlag{
+			Name:        "device-enumeration-retry-max-interval",
+			Usage:       "Maximum wait between GPU enumeration retries; the interval grows exponentially from 1s and is capped here.",
+			Value:       30 * time.Second,
+			Destination: &flags.deviceEnumerationRetryMaxInterval,
+			EnvVars:     []string{"DEVICE_ENUMERATION_RETRY_MAX_INTERVAL"},
 		},
 		&cli.StringFlag{
 			Name:        "http-endpoint",
@@ -283,11 +300,16 @@ func RunPlugin(ctx context.Context, config *Config) error {
 		return fmt.Errorf("error creating driver: %w", err)
 	}
 
-	<-ctx.Done()
-	if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
-		// A canceled context is the normal case here when the process receives
-		// a signal. Only log the error for more interesting cases.
-		klog.Errorf("error from context: %v", err)
+	var initErr error
+	select {
+	case <-ctx.Done():
+		if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
+			// A canceled context is the normal case here when the process
+			// receives a signal. Only log the error for more interesting cases.
+			klog.Errorf("error from context: %v", err)
+		}
+	case initErr = <-driver.InitErrors():
+		klog.Errorf("fatal background init error: %v", initErr)
 	}
 
 	err = driver.Shutdown()
@@ -295,7 +317,7 @@ func RunPlugin(ctx context.Context, config *Config) error {
 		klog.Errorf("unable to cleanly shutdown driver: %v", err)
 	}
 
-	return nil
+	return initErr
 }
 
 // change to config

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -291,6 +291,14 @@ spec:
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.gpus.healthcheckPort | quote }}
         {{- end }}
+        {{- if .Values.kubeletPlugin.containers.gpus.deviceEnumerationRetrySteps }}
+        - name: DEVICE_ENUMERATION_RETRY_STEPS
+          value: {{ .Values.kubeletPlugin.containers.gpus.deviceEnumerationRetrySteps | quote }}
+        {{- end }}
+        {{- if .Values.kubeletPlugin.containers.gpus.deviceEnumerationRetryMaxInterval }}
+        - name: DEVICE_ENUMERATION_RETRY_MAX_INTERVAL
+          value: {{ .Values.kubeletPlugin.containers.gpus.deviceEnumerationRetryMaxInterval | quote }}
+        {{- end }}
         {{- with .Values.kubeletPlugin.containers.gpus.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -285,6 +285,11 @@ kubeletPlugin:
       # Port running a gRPC health service checked by a livenessProbe.
       # Set to a negative value to disable the service and the probe.
       healthcheckPort: 51516
+      # Maximum number of GPU enumeration attempts made at startup.
+      deviceEnumerationRetrySteps: 5
+      # Maximum wait between GPU enumeration retries; the interval grows
+      # exponentially from 1s and is capped here.
+      deviceEnumerationRetryMaxInterval: 30s
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Fixes #1008

Added a retry loop in `NewDeviceState()`. 
If the first enumeration returns 0 devices, the plugin retries every 5 seconds for up to 5 minutes before proceeding. 
Errors still propagate immediately without retry.

Before the fix, no log was emitted after `Traverse GPU devices` and the empty `ResourceSlice` was published silently.

With the fix (`nvidiaDriverRoot: /home/kubernetes/bin/nvidia/`, GKE COS, Tesla T4):

```
I0410 08:11:16.614833  1 nvlib.go:197] Traverse GPU devices
I0410 08:11:16.779628  1 device_state.go:96] No GPU devices found yet (driver may still be initializing), retrying in 5s...
I0410 08:11:21.780288  1 nvlib.go:197] Traverse GPU devices
I0410 08:11:23.111832  1 nvlib.go:278] Adding device gpu-0 to allocatable devices
I0410 08:11:23.111862  1 allocatable.go:254] Adding allocatables for PCI bus ID: 0000:00:04.0
```

Full logs with the fix from `nvidia-dra-driver-gpu-kubelet-plugin` when GPU initialization needed slightly more time:
https://gist.github.com/kasia-kujawa/1082b48357a0ae80d663f12ee665e34c