### PR TITLE
Add DRA GPU e2e tests and Lambda Cloud CI infrastructure

### DIFF
--- a/hack/ci/lambda/e2e-test.sh
+++ b/hack/ci/lambda/e2e-test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# e2e-test.sh -- DRA GPU e2e tests on Lambda Cloud.
+# Sources shared Lambda CI library from test-infra (available via Prow extra_refs).
+#
+# Required env: LAMBDA_API_KEY_FILE, JOB_NAME, BUILD_ID, ARTIFACTS (set by Prow)
+# Optional env: GPU_TYPE (default: gpu_1x_a10), K8S_VERSION (default: latest stable)
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Locate shared library from test-infra checkout (Prow extra_refs).
+TESTINFRA_DIR="$(go env GOPATH)/src/k8s.io/test-infra"
+source "${TESTINFRA_DIR}/experiment/lambda/lib/lambda-common.sh"
+
+# --- Launch Lambda instance ---
+lambda_init_and_launch
+
+# --- Download k8s binaries ---
+K8S_VERSION="${K8S_VERSION:-}"
+if [ -n "${K8S_VERSION}" ]; then
+  lambda_download_k8s /tmp/k8s-bins "${K8S_VERSION}"
+else
+  lambda_download_k8s /tmp/k8s-bins
+fi
+
+# --- Compute git metadata before transfer ---
+# The remote host needs GIT_COMMIT_SHORT for the BATS runner image tag.
+# Compute it here where we have a real git repo.
+GIT_COMMIT_SHORT="$(git rev-parse --short=8 HEAD)"
+export GIT_COMMIT_SHORT
+
+# --- Transfer artifacts ---
+# Exclude .git (GIT_COMMIT_SHORT is passed explicitly), .claude, dist, _output.
+# vendor/ is included (Dockerfile uses -mod=vendor).
+lambda_rsync_to /tmp/k8s-bins/ "ubuntu@${LAMBDA_INSTANCE_IP}:/tmp/k8s-bins/"
+lambda_rsync_to --exclude=.git --exclude=.claude --exclude=dist --exclude=_output \
+  ./ "ubuntu@${LAMBDA_INSTANCE_IP}:/tmp/dra-driver-nvidia-gpu/"
+
+# --- Setup cluster (generic, from test-infra) ---
+# Pass DRA-specific options as env vars: CDI for device injection, Docker for
+# BATS harness, node label for the Helm chart's DaemonSet affinity.
+# `env VAR=val` is used because `bash -s VAR=val` makes them positional args, not env.
+lambda_remote env \
+  ENABLE_CDI=true \
+  ENABLE_DOCKER=true \
+  NODE_LABELS=nvidia.com/gpu.present=true \
+  bash -s < "${TESTINFRA_DIR}/experiment/lambda/lib/setup-k8s-node.sh"
+
+# --- Build driver image on Lambda and load into containerd ---
+lambda_remote bash -s <<EOF
+set -euxo pipefail
+cd /tmp/dra-driver-nvidia-gpu
+docker buildx use default 2>/dev/null || true
+make -f deployments/container/Makefile build DOCKER_BUILD_OPTIONS="--load" CI=true
+IMAGE_REF=\$(make -f deployments/container/Makefile -s print-IMAGE)
+docker save "\${IMAGE_REF}" | sudo ctr -n k8s.io images import -
+echo "Image loaded: \${IMAGE_REF}"
+EOF
+
+# --- Run BATS tests ---
+# Tests local artifacts: local chart + local image built from the PR.
+# This is a real presubmit -- it validates the repo's code, chart, and specs.
+lambda_remote bash -s <<EOF
+set -euxo pipefail
+cd /tmp/dra-driver-nvidia-gpu
+
+# Build the BATS runner image.
+# GIT_COMMIT_SHORT was computed on the Prow pod; pass it explicitly so
+# versions.mk doesn't need a functional .git directory on the remote host.
+docker buildx use default 2>/dev/null || true
+make -f tests/bats/Makefile runner-image GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT}
+
+export KUBECONFIG=\$HOME/.kube/config
+export CI=true
+export TEST_NVIDIA_DRIVER_ROOT=/
+export TEST_CHART_LOCAL=true
+export SKIP_CLEANUP=true
+export DISABLE_COMPUTE_DOMAINS=true
+# !multi-gpu: skip 2-GPU test on single-GPU instances
+# !version-specific: skip attribute list test (attributes depend on host NVIDIA driver version)
+export TEST_FILTER_TAGS='!multi-gpu,!version-specific'
+export GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT}
+
+make -f tests/bats/Makefile tests-gpu-single GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT}
+EOF
+
+# --- Collect artifacts ---
+# CI=true in the Makefile sets TMPDIR=$(CURDIR), so artifacts land under the repo dir.
+lambda_collect_artifacts /tmp/dra-driver-nvidia-gpu/k8s-dra-driver-gpu-tests-out-ubuntu/
+
+# Cluster debug info
+lambda_remote bash -s <<'DEBUGEOF' > "${ARTIFACTS}/cluster-debug.txt" 2>&1 || true
+export KUBECONFIG=$HOME/.kube/config
+echo "=== nodes ===" && kubectl get nodes -o wide
+echo "=== pods ===" && kubectl get pods -A -o wide
+echo "=== resourceslices ===" && kubectl get resourceslices -A -o yaml
+echo "=== events ===" && kubectl get events -A --sort-by=.lastTimestamp
+echo "=== dra driver logs ===" && kubectl logs -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin --tail=200
+DEBUGEOF

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -103,7 +103,9 @@ DOCKER_ENVS = \
 	--env TEST_GPU_STRESS_DELAY=$(TEST_GPU_STRESS_DELAY) \
 	--env TEST_CRD_UPGRADE_TARGET_GIT_REF=$(TEST_CRD_UPGRADE_TARGET_GIT_REF) \
 	--env TEST_NVIDIA_DRIVER_ROOT=$(TEST_NVIDIA_DRIVER_ROOT) \
-	--env TEST_EXPECTED_IMAGE_SPEC_SUBSTRING=$(TEST_EXPECTED_IMAGE_SPEC_SUBSTRING)
+	--env TEST_EXPECTED_IMAGE_SPEC_SUBSTRING=$(TEST_EXPECTED_IMAGE_SPEC_SUBSTRING) \
+	--env SKIP_CLEANUP=$(SKIP_CLEANUP) \
+	--env DISABLE_COMPUTE_DOMAINS=$(DISABLE_COMPUTE_DOMAINS)
 
 DOCKER_UID := $(shell id -u)
 DOCKER_GID := $(shell id -g)
@@ -126,8 +128,12 @@ define RUN_BATS
 	docker run --rm $(DOCKER_RUN_FLAGS) $(DOCKER_MOUNTS) $(DOCKER_ENVS) \
 	  -u $(DOCKER_USER) --entrypoint /bin/bash $(BATS_IMAGE) \
 	  -c "set -ex; cd /cwd; stat $${_RUNDIR}; cat /kubeconfig | head -n2; kubectl get nodes; \
-	      echo 'Running k8s cluster cleanup (invasive)...'; \
-	      bash tests/bats/cleanup-from-previous-run.sh 2>&1 | tee -a $${_RUNDIR}/cleanup.outerr; \
+	      if [ \"\$${SKIP_CLEANUP:-}\" != 'true' ]; then \
+	          echo 'Running k8s cluster cleanup (invasive)...'; \
+	          bash tests/bats/cleanup-from-previous-run.sh 2>&1 | tee -a $${_RUNDIR}/cleanup.outerr; \
+	      else \
+	          echo 'Skipping cleanup (SKIP_CLEANUP=true, ephemeral instance)'; \
+	      fi; \
 	      set +x; echo '--- STARTING TEST SUITE ---'; set -x; \
 	      TMPDIR="$${_RUNDIR}" bats $(BATS_ARGS) $(1) \
       "
@@ -161,7 +167,15 @@ runner-image:
 # suite/file 'setup' in bats, but we'd lose output on success). During dev, you
 # may want to add --show-output-of-passing-tests (and read bats docs for other
 # cmdline args).
-.PHONY: tests-gpu tests-cd
+.PHONY: tests-gpu tests-gpu-single tests-cd
+
+# Single-GPU-safe subset. Suitable for CI environments with one GPU and no
+# GPU Operator (e.g., Lambda Cloud). Excludes test_basics.bats (expects GPU
+# Operator + clean state), MIG, stress, and upgrade tests.
+tests-gpu-single: runner-image
+	$(call RUN_BATS, \
+		tests/bats/test_gpu_basic.bats \
+		tests/bats/test_gpu_cuda_workloads.bats)
 
 # Run a subset covering mainly the GPU plugin
 tests-gpu: runner-image

--- a/tests/bats/helpers.sh
+++ b/tests/bats/helpers.sh
@@ -83,8 +83,10 @@ iupgrade_wait() {
   kubectl get pods -n dra-driver-nvidia-gpu
 
   # That one should be obvious now, but make that guarantee explicit for
-  # consuming tests.
-  kubectl wait --for=condition=READY pods -A -l dra-driver-nvidia-gpu-component=controller --timeout=10s
+  # consuming tests. Skip when compute domains are disabled (no controller deployment).
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" != "true" ]; then
+    kubectl wait --for=condition=READY pods -A -l dra-driver-nvidia-gpu-component=controller --timeout=10s
+  fi
   # maybe: check version on labels (to confirm that we set labels correctly)
   log "iupgrade_wait: done"
 }

--- a/tests/bats/specs/gpu-cuda-demo-suite.yaml
+++ b/tests/bats/specs/gpu-cuda-demo-suite.yaml
@@ -1,0 +1,42 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-cuda-demo
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-cuda-demo
+  labels:
+    env: batssuite
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.5.0-devel-ubuntu22.04
+    command: ["bash", "-c"]
+    args:
+    - |
+      set -ex
+      nvidia-smi
+      apt-get update -y -o Acquire::Retries=5
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated -o Acquire::Retries=5 cuda-demo-suite-12-5
+      cd /usr/local/cuda-12.5/extras/demo_suite || cd /usr/local/cuda/extras/demo_suite
+      ./deviceQuery
+      ./vectorAdd
+      ./bandwidthTest
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-cuda-demo

--- a/tests/bats/specs/gpu-job-rct.yaml
+++ b/tests/bats/specs/gpu-job-rct.yaml
@@ -1,0 +1,40 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-job-gpu
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gpu-job-rct
+  labels:
+    env: batssuite
+spec:
+  completions: 2
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        env: batssuite
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: worker
+        image: ubuntu:24.04
+        command: ["bash", "-c"]
+        args: ["nvidia-smi -L && echo 'GPU Job completed successfully'"]
+        resources:
+          claims:
+          - name: gpu
+      resourceClaims:
+      - name: gpu
+        resourceClaimTemplateName: rct-job-gpu

--- a/tests/bats/test_gpu_basic.bats
+++ b/tests/bats/test_gpu_basic.bats
@@ -5,6 +5,9 @@ setup_file () {
   load 'helpers.sh'
   _common_setup
   local _iargs=("--set" "logVerbosity=6")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
   iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
 }
 
@@ -43,7 +46,7 @@ bats::on_failure() {
 }
 
 
-# bats test_tags=fastfeedback
+# bats test_tags=fastfeedback,multi-gpu
 @test "GPUs: 2 pod(s), 1 full GPU each" {
   local _specpath="tests/bats/specs/gpu-2pods-2gpus.yaml"
 
@@ -120,7 +123,7 @@ bats::on_failure() {
 
 
 
-# bats test_tags=fastfeedback
+# bats test_tags=fastfeedback,version-specific
 @test "GPUs: inspect device attributes in resource slice (gpu)" {
   local reference=(
     "architecture"

--- a/tests/bats/test_gpu_cuda_workloads.bats
+++ b/tests/bats/test_gpu_cuda_workloads.bats
@@ -1,0 +1,77 @@
+# shellcheck disable=SC2148
+# shellcheck disable=SC2329
+
+setup_file() {
+  load 'helpers.sh'
+  _common_setup
+  local _iargs=("--set" "logVerbosity=6")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+}
+
+setup() {
+  load 'helpers.sh'
+  _common_setup
+  log_objects
+}
+
+bats::on_failure() {
+  echo -e "\n\nFAILURE HOOK START"
+  log_objects
+  show_kubelet_plugin_error_logs
+  show_gpu_plugin_log_tails
+  echo -e "FAILURE HOOK END\n\n"
+}
+
+
+# bats test_tags=fastfeedback,gpu-workloads
+@test "GPUs: single GPU runs CUDA demo suite (deviceQuery, vectorAdd, bandwidthTest)" {
+  local _specpath="tests/bats/specs/gpu-cuda-demo-suite.yaml"
+  local _podname="pod-cuda-demo"
+
+  kubectl apply -f "${_specpath}"
+  # Longer timeout — installs cuda-demo-suite package at runtime
+  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pods "${_podname}" --timeout=600s
+
+  run kubectl logs "${_podname}"
+  assert_output --partial "NVIDIA-SMI"
+  assert_output --partial "Driver Version:"
+  assert_output --partial "CUDA Version:"
+  assert_output --partial "deviceQuery, CUDA Driver"
+  assert_output --partial "Result = PASS"
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=30s
+}
+
+
+# bats test_tags=fastfeedback,gpu-workloads
+@test "GPUs: Job with ResourceClaimTemplate allocates GPUs to completions" {
+  local _specpath="tests/bats/specs/gpu-job-rct.yaml"
+  local _jobname="gpu-job-rct"
+
+  kubectl apply -f "${_specpath}"
+
+  # Wait for job to complete (2 completions, parallelism 1 — safe for single GPU)
+  kubectl wait --for=condition=Complete "job/${_jobname}" --timeout=600s
+
+  # Verify both completions succeeded
+  local succeeded
+  succeeded=$(kubectl get job "${_jobname}" -o jsonpath='{.status.succeeded}')
+  [ "${succeeded}" -eq 2 ]
+
+  local failed
+  failed=$(kubectl get job "${_jobname}" -o jsonpath='{.status.failed}' 2>/dev/null || echo "0")
+  [ "${failed:-0}" -eq 0 ]
+
+  # Verify each pod saw a GPU
+  for pod in $(kubectl get pods -l "job-name=${_jobname}" -o name); do
+    run kubectl logs "${pod}"
+    assert_output --partial "UUID: GPU-"
+  done
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete "job/${_jobname}" --timeout=30s
+}


### PR DESCRIPTION
Add CUDA workload and Job-with-ResourceClaimTemplate BATS tests adapted from the coverage in kubernetes/kubernetes#136693 (which was closed in favor of vendor-owned testing). Add Lambda Cloud CI orchestration that sources the shared library from test-infra ([kubernetes/test-infra#36786](https://github.com/kubernetes/test-infra/pull/36786)) to provision an ephemeral GPU instance and set up a single-node kubeadm cluster with the DRA driver.

## New tests
- CUDA demo suite (deviceQuery, vectorAdd, bandwidthTest)
- Job with ResourceClaimTemplate (parallelism=1, single-GPU safe)

## Test harness changes
- `SKIP_CLEANUP` env var support in `RUN_BATS` (for ephemeral instances)
- `DISABLE_COMPUTE_DOMAINS` env var support (for GPUs without NVLink)
- `tests-gpu-lambda` Makefile target (Lambda-safe subset)
- `multi-gpu` and `version-specific` test tags for Lambda filtering
- Conditional controller readiness wait in `helpers.sh`

xref: kubernetes/test-infra#36786 (shared Lambda CI library) — merged
xref: #1014 (go-nvlib v0.10.0 for NVML 570.x compat) — merged