### PR TITLE
vendor: update github.com/NVIDIA/go-nvlib to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/NVIDIA/go-nvlib v0.9.1-0.20251202135446-d0f42ba016dd
+	github.com/NVIDIA/go-nvlib v0.10.0
 	github.com/NVIDIA/go-nvml v0.13.0-1.0.20260212130905-92cf8c963449
 	github.com/NVIDIA/nvidia-container-toolkit v1.19.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/NVIDIA/go-nvlib v0.9.1-0.20251202135446-d0f42ba016dd h1:MC1w/VYuo9Zt0se4SSx9BVid4a46ai+voN3knRvVWjE=
-github.com/NVIDIA/go-nvlib v0.9.1-0.20251202135446-d0f42ba016dd/go.mod h1:7mzx9FSdO9fXWP9NKuZmWkCwhkEcSWQFe2tmFwtLb9c=
+github.com/NVIDIA/go-nvlib v0.10.0 h1:2jbAFmvLBntIc/4iUChI9DzxyYNI92pohXU4kFuNrg0=
+github.com/NVIDIA/go-nvlib v0.10.0/go.mod h1:7mzx9FSdO9fXWP9NKuZmWkCwhkEcSWQFe2tmFwtLb9c=
 github.com/NVIDIA/go-nvml v0.13.0-1.0.20260212130905-92cf8c963449 h1:UrArFAaPhj9av2yzEN35CvzWw68BeQjp2MaQFUIoJSU=
 github.com/NVIDIA/go-nvml v0.13.0-1.0.20260212130905-92cf8c963449/go.mod h1:ahi2psRYoa+wYUBIrZPRO+wJs9lcvMhxSSkjjvsJJNQ=
 github.com/NVIDIA/nvidia-container-toolkit v1.19.0 h1:iuttW93jclh0+y3RdBw8DR7v6Gfv6h+HjjY87cTyn9M=

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/device.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/device.go
@@ -149,7 +149,11 @@ func (d *device) GetBrandAsString() (string, error) {
 
 // GetAddressingModeAsString returns the Device addressing mode as a string.
 func (d *device) GetAddressingModeAsString() (string, error) {
-	mode, ret := d.GetAddressingMode()
+	if !d.lib.hasSymbol("nvmlDeviceGetAddressingMode") {
+		return "", nil
+	}
+
+	mode, ret := nvml.Device(d).GetAddressingMode()
 
 	switch ret {
 	case nvml.SUCCESS:

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/nvpci_mock.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvpci/nvpci_mock.go
@@ -41,6 +41,9 @@ var _ Interface = &InterfaceMock{}
 //			GetNetworkControllersFunc: func() ([]*NvidiaPCIDevice, error) {
 //				panic("mock out the GetNetworkControllers method")
 //			},
+//			GetNvidiaDeviceByPciBusIDFunc: func(s string) (*NvidiaPCIDevice, error) {
+//				panic("mock out the GetNvidiaDeviceByPciBusID method")
+//			},
 //			GetPciBridgesFunc: func() ([]*NvidiaPCIDevice, error) {
 //				panic("mock out the GetPciBridges method")
 //			},
@@ -78,6 +81,9 @@ type InterfaceMock struct {
 	// GetNetworkControllersFunc mocks the GetNetworkControllers method.
 	GetNetworkControllersFunc func() ([]*NvidiaPCIDevice, error)
 
+	// GetNvidiaDeviceByPciBusIDFunc mocks the GetNvidiaDeviceByPciBusID method.
+	GetNvidiaDeviceByPciBusIDFunc func(s string) (*NvidiaPCIDevice, error)
+
 	// GetPciBridgesFunc mocks the GetPciBridges method.
 	GetPciBridgesFunc func() ([]*NvidiaPCIDevice, error)
 
@@ -114,6 +120,11 @@ type InterfaceMock struct {
 		// GetNetworkControllers holds details about calls to the GetNetworkControllers method.
 		GetNetworkControllers []struct {
 		}
+		// GetNvidiaDeviceByPciBusID holds details about calls to the GetNvidiaDeviceByPciBusID method.
+		GetNvidiaDeviceByPciBusID []struct {
+			// S is the s argument value.
+			S string
+		}
 		// GetPciBridges holds details about calls to the GetPciBridges method.
 		GetPciBridges []struct {
 		}
@@ -121,16 +132,17 @@ type InterfaceMock struct {
 		GetVGAControllers []struct {
 		}
 	}
-	lockGet3DControllers      sync.RWMutex
-	lockGetAllDevices         sync.RWMutex
-	lockGetDPUs               sync.RWMutex
-	lockGetGPUByIndex         sync.RWMutex
-	lockGetGPUByPciBusID      sync.RWMutex
-	lockGetGPUs               sync.RWMutex
-	lockGetNVSwitches         sync.RWMutex
-	lockGetNetworkControllers sync.RWMutex
-	lockGetPciBridges         sync.RWMutex
-	lockGetVGAControllers     sync.RWMutex
+	lockGet3DControllers          sync.RWMutex
+	lockGetAllDevices             sync.RWMutex
+	lockGetDPUs                   sync.RWMutex
+	lockGetGPUByIndex             sync.RWMutex
+	lockGetGPUByPciBusID          sync.RWMutex
+	lockGetGPUs                   sync.RWMutex
+	lockGetNVSwitches             sync.RWMutex
+	lockGetNetworkControllers     sync.RWMutex
+	lockGetNvidiaDeviceByPciBusID sync.RWMutex
+	lockGetPciBridges             sync.RWMutex
+	lockGetVGAControllers         sync.RWMutex
 }
 
 // Get3DControllers calls Get3DControllersFunc.
@@ -356,6 +368,38 @@ func (mock *InterfaceMock) GetNetworkControllersCalls() []struct {
 	mock.lockGetNetworkControllers.RLock()
 	calls = mock.calls.GetNetworkControllers
 	mock.lockGetNetworkControllers.RUnlock()
+	return calls
+}
+
+// GetNvidiaDeviceByPciBusID calls GetNvidiaDeviceByPciBusIDFunc.
+func (mock *InterfaceMock) GetNvidiaDeviceByPciBusID(s string) (*NvidiaPCIDevice, error) {
+	if mock.GetNvidiaDeviceByPciBusIDFunc == nil {
+		panic("InterfaceMock.GetNvidiaDeviceByPciBusIDFunc: method is nil but Interface.GetNvidiaDeviceByPciBusID was just called")
+	}
+	callInfo := struct {
+		S string
+	}{
+		S: s,
+	}
+	mock.lockGetNvidiaDeviceByPciBusID.Lock()
+	mock.calls.GetNvidiaDeviceByPciBusID = append(mock.calls.GetNvidiaDeviceByPciBusID, callInfo)
+	mock.lockGetNvidiaDeviceByPciBusID.Unlock()
+	return mock.GetNvidiaDeviceByPciBusIDFunc(s)
+}
+
+// GetNvidiaDeviceByPciBusIDCalls gets all the calls that were made to GetNvidiaDeviceByPciBusID.
+// Check the length with:
+//
+//	len(mockedInterface.GetNvidiaDeviceByPciBusIDCalls())
+func (mock *InterfaceMock) GetNvidiaDeviceByPciBusIDCalls() []struct {
+	S string
+} {
+	var calls []struct {
+		S string
+	}
+	mock.lockGetNvidiaDeviceByPciBusID.RLock()
+	calls = mock.calls.GetNvidiaDeviceByPciBusID
+	mock.lockGetNvidiaDeviceByPciBusID.RUnlock()
 	return calls
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/Masterminds/semver/v3 v3.4.0
 ## explicit; go 1.21
 github.com/Masterminds/semver/v3
-# github.com/NVIDIA/go-nvlib v0.9.1-0.20251202135446-d0f42ba016dd
+# github.com/NVIDIA/go-nvlib v0.10.0
 ## explicit; go 1.20
 github.com/NVIDIA/go-nvlib/pkg/nvlib/device
 github.com/NVIDIA/go-nvlib/pkg/nvlib/info


### PR DESCRIPTION
Update `github.com/NVIDIA/go-nvlib` from `v0.9.1-0.20251202135446-d0f42ba016dd` to `v0.10.0`.

The kubelet-plugin binary dynamically resolves NVML symbols at runtime via `go-nvml`. The previous version attempted to call `nvmlDeviceGetAddressingMode`, which does not exist in the NVML library shipped with NVIDIA driver 570.x (the current driver on several GPU cloud providers, including Lambda Cloud). This caused the kubelet-plugin container to crash immediately on startup with:

```
gpu-kubelet-plugin: symbol lookup error: gpu-kubelet-plugin: undefined symbol: nvmlDeviceGetAddressingMode
```

go-nvlib v0.10.0 (via [NVIDIA/go-nvlib#87](https://github.com/NVIDIA/go-nvlib/pull/87)) handles the missing NVML symbol gracefully, allowing the driver to operate correctly on hosts with older NVIDIA drivers that lack support for the addressing-mode query.