### PR TITLE
Pin GitHub Actions to commit SHAs for supply-chain protection

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -24,7 +24,7 @@ jobs:
   helm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         name: checkout
         with:
           fetch-depth: 2
@@ -48,7 +48,7 @@ jobs:
           git diff || echo "ignore git diff exit code"
           helm package deployments/helm/dra-driver-nvidia-gpu
       - name: Upload chart package
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: helm-chart
           path: dra-driver-nvidia-gpu-*.tgz

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -37,7 +37,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Add labels and handle backport
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const run = require('./.github/scripts/add-labels-from-comment.js');
@@ -65,7 +65,7 @@ jobs:
     
     steps:
       - name: Checkout base branch repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.base.ref }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Extract target branches from PR labels
         id: extract-branches
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const run = require('./.github/scripts/extract-branches.js');
@@ -88,7 +88,7 @@ jobs:
       - name: Backport to release branches
         id: backport
         if: steps.extract-branches.outputs.result != '[]'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           BRANCHES_JSON: ${{ steps.extract-branches.outputs.result }}
         with:

--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -30,15 +30,15 @@ jobs:
       contents: read
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ${{ inputs.golang_version }}
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
       with:
         languages: go
         build-mode: manual
@@ -48,6 +48,6 @@ jobs:
         make build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
       with:
         category: "/language:go"

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -25,16 +25,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       name: Checkout code
 
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ${{ inputs.golang_version }}
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
       with:
         version: latest
         args: -v --timeout 5m
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ inputs.golang_version }}
       - run: make test
@@ -67,9 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ inputs.golang_version }}
       - run: make build

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -25,16 +25,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         name: Check out code
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           image: tonistiigi/binfmt:qemu-v10.0.4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
       # TODO: This will be moved to Prow where image publishing is configured and credentials are available.
       # For now, we want to test multi-arch builds in GitHub Actions as well, but without pushing to the registry.
       - name: Multi-arch build

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,7 +11,7 @@ jobs:
   label-by-component:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
   skipped:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Bats run on Prow
         run: |
           echo "Bats suites (make bats) are executed from Prow against the test GPU cluster."

--- a/.github/workflows/variables.yaml
+++ b/.github/workflows/variables.yaml
@@ -30,7 +30,7 @@ jobs:
       golang_version: ${{ steps.golang_version.outputs.golang_version }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Get Version with Commit Short SHA
       id: version


### PR DESCRIPTION
Pin all GitHub Action references to immutable commit SHAs instead of
mutable version tags across all 9 workflow files (25 action references).
Version comments (e.g., `# v6`) are preserved for Dependabot compatibility.

Actions pinned:
- actions/checkout, actions/setup-go, actions/github-script
- github/codeql-action/init, github/codeql-action/analyze
- docker/setup-qemu-action, docker/setup-buildx-action
- golangci/golangci-lint-action
- actions/stale, actions/upload-artifact

Fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1015

## Testing

Each commit SHA was resolved from the corresponding version tag via the
GitHub API (`gh api repos/{owner}/{action}/git/ref/tags/{tag}`). For
annotated tags (e.g., `github/codeql-action@v4`), the tag object was
dereferenced to obtain the underlying commit SHA. The following was
verified:

- No workflow files contain bare version-tag references (`@vN` without a
  SHA) — confirmed via `grep -r 'uses:.*@v[0-9]+$' .github/workflows/`
  returning zero matches.
- All 25 action references use the `@<40-char-sha> # vN` format —
  confirmed via `grep -r 'uses:.*@[a-f0-9]\{40\}' .github/workflows/`
  returning exactly 25 matches.
- Workflow YAML syntax remains valid (no indentation or quoting changes
  beyond the action ref substitution).

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).