### PR TITLE
Prevent mig toggle on A100s

### DIFF
--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -198,11 +198,7 @@ func (d *GpuInfo) GetDevice() resourceapi.Device {
 	device := resourceapi.Device{
 		Name:       d.CanonicalName(),
 		Attributes: d.Attributes(),
-		Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
-			"memory": {
-				Value: *resource.NewQuantity(int64(d.memoryBytes), resource.BinarySI),
-			},
-		},
+		Capacity:   d.fullGpuCapacity(),
 	}
 	return device
 }

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -202,19 +202,33 @@ func (d *driver) generateSplitResourceSlices(nodeName string) resourceslice.Driv
 	for _, pciBusID := range slices.Sorted(maps.Keys(d.state.perGPUAllocatable.allocatablesMap)) {
 		allocatable := d.state.perGPUAllocatable.allocatablesMap[pciBusID]
 		var deviceSlice resourceslice.Slice
+		var gpuInfo *GpuInfo
 
 		// Stable sort order by devicename
 		for _, devname := range slices.Sorted(maps.Keys(allocatable)) {
 			device := allocatable[devname]
 			klog.V(4).Infof("About to announce device %s", devname)
 
-			// Full GPU: collect its counter sets for the `sharedCountersSlice`.
-			if device.Gpu != nil {
-				allCounterSets = append(allCounterSets, device.Gpu.PartSharedCounterSets()...)
+			// Remember this GPU so we can emit exactly one shared counter
+			// set for it below. MIG partitions reference the parent GPU's
+			// counter set by name, so the counter set must be emitted even
+			// when the full GPU itself is not announced (e.g. on Ampere
+			// with MIG mode enabled, where MIG cannot be toggled without a
+			// GPU reset and so only MIG partitions are allocatable).
+			if gpuInfo == nil {
+				switch {
+				case device.Gpu != nil:
+					gpuInfo = device.Gpu
+				case device.MigDynamic != nil:
+					gpuInfo = device.MigDynamic.Parent
+				}
 			}
 
 			// Add device/partition to the device-only slice for this GPU.
 			deviceSlice.Devices = append(deviceSlice.Devices, device.PartGetDevice())
+		}
+		if gpuInfo != nil {
+			allCounterSets = append(allCounterSets, gpuInfo.PartSharedCounterSets()...)
 		}
 		gpuslices = append(gpuslices, deviceSlice)
 	}
@@ -244,7 +258,7 @@ func (d *driver) generateCombinedResourceSlices(nodeName string) resourceslice.D
 	for _, pciBusID := range slices.Sorted(maps.Keys(d.state.perGPUAllocatable.allocatablesMap)) {
 		allocatable := d.state.perGPUAllocatable.allocatablesMap[pciBusID]
 		var slice resourceslice.Slice
-		countersets := []resourceapi.CounterSet{}
+		var gpuInfo *GpuInfo
 
 		// Stable sort order by devicename -- makes the order of devices
 		// presented in a resource slice reproducible. Good for debuggability /
@@ -254,10 +268,19 @@ func (d *driver) generateCombinedResourceSlices(nodeName string) resourceslice.D
 			device := allocatable[devname]
 			klog.V(4).Infof("About to announce device %s", devname)
 
-			// Full GPU: take note of countersets, indicating absolute capacity.
-			// For now this is expected to be one counter set.
-			if device.Gpu != nil {
-				countersets = append(countersets, device.Gpu.PartSharedCounterSets()...)
+			// Remember this GPU so we can emit exactly one shared counter
+			// set for it below. MIG partitions reference the parent GPU's
+			// counter set by name, so the counter set must be emitted even
+			// when the full GPU itself is not announced (e.g. on Ampere
+			// with MIG mode enabled, where MIG cannot be toggled without a
+			// GPU reset and so only MIG partitions are allocatable).
+			if gpuInfo == nil {
+				switch {
+				case device.Gpu != nil:
+					gpuInfo = device.Gpu
+				case device.MigDynamic != nil:
+					gpuInfo = device.MigDynamic.Parent
+				}
 			}
 
 			// Add all allocatable devices for this physical GPU to this slice.
@@ -265,7 +288,10 @@ func (d *driver) generateCombinedResourceSlices(nodeName string) resourceslice.D
 			// GPU itself.
 			slice.Devices = append(slice.Devices, device.PartGetDevice())
 		}
-		slice.SharedCounters = countersets
+
+		if gpuInfo != nil {
+			slice.SharedCounters = gpuInfo.PartSharedCounterSets()
+		}
 		gpuslices = append(gpuslices, slice)
 	}
 

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -229,38 +229,63 @@ func (l deviceLib) GetPerGpuAllocatableDevices(indices ...int) (*PerGPUAllocatab
 		l.gpuUUIDbyPCIBusID[gpuInfo.pciBusID] = gpuInfo.UUID
 
 		if featuregates.Enabled(featuregates.DynamicMIG) {
-			// Best-effort handle cache warmup: store mapping between full-GPU
-			// UUID and NVML device handle in a map. Ignore failures.
-			if _, ret := l.DeviceGetHandleByUUID(gpuInfo.UUID); ret != nvml.SUCCESS {
-				klog.Warningf("DeviceGetHandleByUUIDCached failed: %s", ret)
-			}
-
-			// For this full device, inspect all MIG profiles and their possible
-			// placements. Side effect: this enriches `gpuInfo` with additional
-			// properties (such as the memory slice count, and the maximum
-			// capacities as reported by individual MIG profiles).
-			migspecs, err := l.inspectMigProfilesAndPlacements(gpuInfo, d)
+			dynamicMIGCapable, err := isDynamicMIGCapable(gpuInfo, d)
 			if err != nil {
-				return fmt.Errorf("error getting MIG info for GPU %v: %w", i, err)
+				return fmt.Errorf("error determining DynamicMIG support for GPU %v: %w", i, err)
 			}
 
-			// Announce the full physical GPU.
-			thisGPUAllocatable[gpuInfo.CanonicalName()] = parentdev
-
-			for _, migspec := range migspecs {
-				dev := &AllocatableDevice{
-					MigDynamic: migspec,
+			// gpuInfo.migEnabled is captured once during enumeration and is
+			// never re-read. The branches below rely on this snapshot:
+			// toggling MIG mode on Ampere requires a GPU reset that this
+			// plugin does not initiate, so within a single plugin lifetime
+			// the value cannot change underneath us. A future refactor that
+			// moves the migEnabled read past enumeration (or starts
+			// re-reading it) must reconsider these branches.
+			if dynamicMIGCapable {
+				// Best-effort handle cache warmup: store mapping between full-GPU
+				// UUID and NVML device handle in a map. Ignore failures.
+				if _, ret := l.DeviceGetHandleByUUID(gpuInfo.UUID); ret != nvml.SUCCESS {
+					klog.Warningf("DeviceGetHandleByUUID failed: %s", ret)
 				}
-				thisGPUAllocatable[migspec.CanonicalName()] = dev
-			}
 
-			err = perGPUAllocatable.AddGPUAllocatables(gpuInfo.pciBusID, thisGPUAllocatable)
-			if err != nil {
-				return fmt.Errorf("error adding allocatables for PCI bus ID %q: %w", gpuInfo.pciBusID, err)
-			}
+				// For this full device, inspect all MIG profiles and their possible
+				// placements. Side effect: this enriches `gpuInfo` with additional
+				// properties (such as the memory slice count, and the maximum
+				// capacities as reported by individual MIG profiles).
+				migspecs, err := l.inspectMigProfilesAndPlacements(gpuInfo, d)
+				if err != nil {
+					return fmt.Errorf("error getting MIG info for GPU %v: %w", i, err)
+				}
 
-			// Terminate this function -- this is mutually exclusive with static MIG and vfio/passthrough.
-			return nil
+				// When migEnabled is true, parentdev is intentionally NOT added
+				// to thisGPUAllocatable — the full GPU is not allocatable on
+				// Ampere when MIG cannot be toggled without a GPU reset. The
+				// per-GPU shared CounterSet that MIG partitions reference by
+				// name is still emitted by the ResourceSlice generators in
+				// driver.go, which derive the parent GpuInfo from
+				// MigDynamic.Parent when no full-GPU entry exists.
+
+				// We're inside the dynamicMIGCapable=true branch, which already excludes
+				// vGPUs masquerading as full GPUs, so supportsMIGModeToggle(d) here precisely means
+				// "non-vGPU Hopper+".
+				if !gpuInfo.migEnabled || supportsMIGModeToggle(d) {
+					thisGPUAllocatable[gpuInfo.CanonicalName()] = parentdev
+				}
+				for _, migspec := range migspecs {
+					dev := &AllocatableDevice{
+						MigDynamic: migspec,
+					}
+					thisGPUAllocatable[migspec.CanonicalName()] = dev
+				}
+
+				err = perGPUAllocatable.AddGPUAllocatables(gpuInfo.pciBusID, thisGPUAllocatable)
+				if err != nil {
+					return fmt.Errorf("error adding allocatables for PCI bus ID %q: %w", gpuInfo.pciBusID, err)
+				}
+
+				// Terminate this function -- this is mutually exclusive with static MIG and vfio/passthrough.
+				return nil
+			}
 		}
 
 		migdevs, err := l.discoverMigDevicesByGPU(gpuInfo)
@@ -1129,6 +1154,13 @@ func (l deviceLib) maybeDisableMigMode(uuid string, nvmldev nvml.Device) error {
 		return nil
 	}
 
+	// On Ampere/A100, SetMigMode sets a pending mode that requires a GPU reset to activate — leave MIG enabled.
+	if !supportsMIGModeToggle(nvmldev) {
+		klog.Infof("GPU %s (%s): skipping MIG mode disable (architecture does not support reset-less MIG toggling)",
+			gpu.String(), gpu.architecture)
+		return nil
+	}
+
 	klog.V(6).Infof("Attempting to disable MIG mode for device %s", gpu.String())
 	t0 := time.Now()
 	ret, activationStatus := nvmldev.SetMigMode(nvml.DEVICE_MIG_DISABLE)
@@ -1398,4 +1430,55 @@ func (l deviceLib) enableGPUPersistenceMode(pciAddress string) error {
 	klog.V(4).Infof("Enabled persistence mode for GPU PCI device %s", pciAddress)
 
 	return nil
+}
+
+// For testing on non-Ampere hardware, set the environment variable
+// NVIDIA_DRA_TEST_FORCE_GPU_ARCH=ampere to force GPU arch to be Ampere.
+// This exercises the prevent-MIG-toggle code paths on any
+// MIG-capable GPU, which is otherwise only reachable on A100.
+var forceToBeAmpere = strings.EqualFold(strings.TrimSpace(os.Getenv("NVIDIA_DRA_TEST_FORCE_GPU_ARCH")), "ampere")
+
+// supportsMIGModeToggle reports whether the GPU supports toggling MIG mode
+// without requiring a GPU reset. Hopper (H100) and newer support reset-less
+// MIG mode toggling. Ampere (A100) does not.
+func supportsMIGModeToggle(dev nvml.Device) bool {
+	if forceToBeAmpere {
+		return false
+	}
+	arch, ret := dev.GetArchitecture()
+	if ret != nvml.SUCCESS {
+		return false
+	}
+	return arch >= nvml.DEVICE_ARCH_HOPPER
+}
+
+func isDynamicMIGCapable(gpuInfo *GpuInfo, dev nvdev.Device) (bool, error) {
+	vMode, vret := dev.GetVirtualizationMode()
+	if vret != nvml.SUCCESS {
+		return false, fmt.Errorf("error getting GPU virtualization mode: %v", vret)
+	}
+
+	// In a vGPU guest the MIG mode and partition size are fixed by the vGPU
+	// profile assigned to the VM — a guest cannot dynamically repartition a
+	// vGPU. Skip DynamicMIG.
+	if vMode == nvml.GPU_VIRTUALIZATION_MODE_VGPU {
+		klog.Warningf("GPU %s: vGPU guest detected — skipping DynamicMIG", gpuInfo.String())
+		return false, nil
+	}
+
+	// Hopper+ supports reset-less MIG mode toggling, so advertise both the full
+	// GPU and the dynamic MIG profiles irrespective of current MIG state.
+	if supportsMIGModeToggle(dev) {
+		return true, nil
+	}
+
+	// On Ampere/A100, once MIG is enabled we can still advertise the dynamic MIG
+	// profiles, but not the full GPU because disabling MIG would require a GPU reset.
+	if gpuInfo.migEnabled {
+		klog.Infof("GPU %s: MIG mode is enabled and cannot be toggled without GPU reset", gpuInfo.String())
+		return true, nil
+	}
+
+	klog.Infof("GPU %s: MIG mode is disabled and cannot be toggled without GPU reset", gpuInfo.String())
+	return false, nil
 }

--- a/cmd/gpu-kubelet-plugin/partitions.go
+++ b/cmd/gpu-kubelet-plugin/partitions.go
@@ -26,10 +26,32 @@ import (
 
 type PartCapacityMap map[resourceapi.QualifiedName]resourceapi.DeviceCapacity
 
+// This is the single source of truth for the non-MIG full-GPU capacity
+// field and MUST be used by both the GetDevice() path and the
+// partitions PartCapacities(). The two publish paths are
+// dispatched separately (feature-gate-gated in publishResources()), so
+// without a shared helper they may silently drift.
+func (d *GpuInfo) fullGpuCapacity() PartCapacityMap {
+	return PartCapacityMap{
+		"memory": resourceapi.DeviceCapacity{
+			Value: *resource.NewQuantity(int64(d.memoryBytes), resource.BinarySI),
+		},
+	}
+}
+
 // KEP 4815 device announcement: return the full device capacity for this device
 // (uses information from looking at all MIG profiles beforehand).
+//
+// When MIG profiles have not been inspected for Full GPU (e.g. on Ampere
+// with MIG disabled), maxCapacities is empty. Fall back to advertising
+// at least the GPU's total memory, matching the
+// legacy non-DynamicMIG GetDevice() path so that the full GPU device is
+// announced with quantitative capacity in both paths.
 func (d *GpuInfo) PartCapacities() PartCapacityMap {
-	return d.maxCapacities
+	if len(d.maxCapacities) > 0 {
+		return d.maxCapacities
+	}
+	return d.fullGpuCapacity()
 }
 
 // KEP 4815 device announcement: return the name for the shared counter
@@ -43,6 +65,14 @@ func (d *GpuInfo) GetSharedCounterSetName() string {
 // define one counter per device capacity dimension, and add one counter
 // (capacity 1) per memory slice.
 func (d *GpuInfo) PartSharedCounterSets() []resourceapi.CounterSet {
+	// Returns nil when no MIG profile data has been collected for this GPU
+	// (e.g. on Ampere with MIG disabled, or for vGPU guests). Such GPUs have
+	// no partitions, so a per-GPU CounterSet has no consumers and the
+	// Kubernetes API would reject an empty Counters map.
+	// error: spec.sharedCounters[0].counters: Required value
+	if len(d.maxCapacities) == 0 {
+		return nil
+	}
 	return []resourceapi.CounterSet{{
 		Name:     d.GetSharedCounterSetName(),
 		Counters: addCountersForMemSlices(capacitiesToCounters(d.maxCapacities), 0, d.memSliceCount),
@@ -54,6 +84,11 @@ func (d *GpuInfo) PartSharedCounterSets() []resourceapi.CounterSet {
 // allocated, all available counters drop to zero. 2) when the smallest
 // partition gets allocated, the full device cannot be allocated anymore.
 func (d *GpuInfo) PartConsumesCounters() []resourceapi.DeviceCounterConsumption {
+	// Returns nil when no MIG profile data has been collected for this GPU
+	// (matches PartSharedCounterSets — there is no CounterSet to consume from).
+	if len(d.maxCapacities) == 0 {
+		return nil
+	}
 	return []resourceapi.DeviceCounterConsumption{{
 		CounterSet: d.GetSharedCounterSetName(),
 		Counters:   addCountersForMemSlices(capacitiesToCounters(d.maxCapacities), 0, d.memSliceCount),


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/883


Based on discussion on https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1006#issuecomment-4226993371

When on Ampere or A100s, disable toggling MIG mode as either enable, disable or both will fail and rely on pre-configured mode 

```release-note
Fixed an issue where the GPU DRA driver attempted to toggle MIG mode on Ampere
(A100) GPUs, where toggling requires a GPU reset. The driver now respects the
pre-configured MIG state on these architectures: GPUs with MIG disabled are
advertised as a full GPU only, and GPUs with MIG enabled are advertised as
their MIG profiles only. Hopper and newer GPUs continue to support reset-less
MIG mode toggling at allocation time.
```