### PR TITLE
Add GPU-aware test filtering, multi-GPU deployment test, and busGrind

### DIFF
--- a/hack/ci/lambda/e2e-test.sh
+++ b/hack/ci/lambda/e2e-test.sh
@@ -71,6 +71,21 @@ docker save "\${IMAGE_REF}" | sudo ctr -n k8s.io images import -
 echo "Image loaded: \${IMAGE_REF}"
 EOF
 
+# --- Detect GPU capabilities for dynamic test filtering ---
+GPU_COUNT=$(lambda_remote nvidia-smi -L | wc -l)
+echo "Detected ${GPU_COUNT} GPU(s) on Lambda instance (type: ${LAMBDA_GPU_TYPE})"
+
+# Build filter tags based on what the instance can handle.
+FILTER='!version-specific'
+if [ "${GPU_COUNT}" -lt 2 ]; then
+  FILTER="${FILTER},!multi-gpu"
+fi
+# busGrind is slow and can hang on V100/A10 — only run on faster GPUs.
+case "${LAMBDA_GPU_TYPE}" in
+  *v100*|*a10) FILTER="${FILTER},!gpu-busgrind" ;;
+esac
+echo "Test filter: ${FILTER}"
+
 # --- Run BATS tests ---
 # Tests local artifacts: local chart + local image built from the PR.
 # This is a real presubmit -- it validates the repo's code, chart, and specs.
@@ -90,9 +105,7 @@ export TEST_NVIDIA_DRIVER_ROOT=/
 export TEST_CHART_LOCAL=true
 export SKIP_CLEANUP=true
 export DISABLE_COMPUTE_DOMAINS=true
-# !multi-gpu: skip 2-GPU test on single-GPU instances
-# !version-specific: skip attribute list test (attributes depend on host NVIDIA driver version)
-export TEST_FILTER_TAGS='!multi-gpu,!version-specific'
+export TEST_FILTER_TAGS='${FILTER}'
 export GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT}
 
 make -f tests/bats/Makefile tests-gpu-single GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT}
@@ -105,9 +118,18 @@ lambda_collect_artifacts /tmp/dra-driver-nvidia-gpu/k8s-dra-driver-gpu-tests-out
 # Cluster debug info
 lambda_remote bash -s <<'DEBUGEOF' > "${ARTIFACTS}/cluster-debug.txt" 2>&1 || true
 export KUBECONFIG=$HOME/.kube/config
+echo "=== nvidia-smi ===" && nvidia-smi
+echo "=== nvidia driver version ===" && cat /sys/module/nvidia/version
 echo "=== nodes ===" && kubectl get nodes -o wide
-echo "=== pods ===" && kubectl get pods -A -o wide
+echo "=== pods (all namespaces) ===" && kubectl get pods -A -o wide
+echo "=== pod describe (driver namespace) ===" && kubectl describe pods -n dra-driver-nvidia-gpu
 echo "=== resourceslices ===" && kubectl get resourceslices -A -o yaml
+echo "=== deviceclasses ===" && kubectl get deviceclass -o yaml
+echo "=== resourceclaims ===" && kubectl get resourceclaims -A -o yaml
 echo "=== events ===" && kubectl get events -A --sort-by=.lastTimestamp
-echo "=== dra driver logs ===" && kubectl logs -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin --tail=200
+echo "=== kubelet-plugin logs (gpus) ===" && kubectl logs -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin -c gpus --tail=500
+echo "=== kubelet-plugin logs (compute-domains) ===" && kubectl logs -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin -c compute-domains --tail=200
+echo "=== controller logs ===" && kubectl logs -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=controller --tail=200
+echo "=== containerd config ===" && sudo grep -E "enable_cdi|default_runtime|nvidia" /etc/containerd/config.toml
+echo "=== kubelet logs (last 100 lines) ===" && sudo journalctl -u kubelet --no-pager -n 100
 DEBUGEOF

--- a/tests/bats/specs/gpu-cuda-busgrind.yaml
+++ b/tests/bats/specs/gpu-cuda-busgrind.yaml
@@ -1,0 +1,40 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-cuda-busgrind
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-cuda-busgrind
+  labels:
+    env: batssuite
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.5.0-devel-ubuntu22.04
+    command: ["bash", "-c"]
+    args:
+    - |
+      set -ex
+      nvidia-smi
+      apt-get update -y -o Acquire::Retries=5
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated -o Acquire::Retries=5 cuda-demo-suite-12-5
+      cd /usr/local/cuda-12.5/extras/demo_suite || cd /usr/local/cuda/extras/demo_suite
+      ./busGrind
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-cuda-busgrind

--- a/tests/bats/specs/gpu-job-rct-parallel.yaml
+++ b/tests/bats/specs/gpu-job-rct-parallel.yaml
@@ -1,0 +1,42 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-deploy-gpu
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-deploy-parallel
+  labels:
+    env: batssuite
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gpu-deploy-parallel
+  template:
+    metadata:
+      labels:
+        app: gpu-deploy-parallel
+        env: batssuite
+    spec:
+      containers:
+      - name: worker
+        image: ubuntu:24.04
+        command: ["bash", "-c"]
+        args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+        resources:
+          claims:
+          - name: gpu
+      resourceClaims:
+      - name: gpu
+        resourceClaimTemplateName: rct-deploy-gpu

--- a/tests/bats/test_gpu_cuda_workloads.bats
+++ b/tests/bats/test_gpu_cuda_workloads.bats
@@ -32,8 +32,9 @@ bats::on_failure() {
   local _podname="pod-cuda-demo"
 
   kubectl apply -f "${_specpath}"
-  # Longer timeout — installs cuda-demo-suite package at runtime
-  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pods "${_podname}" --timeout=600s
+  # Longer timeout — installs cuda-demo-suite package at runtime.
+  # arm64 (GH200) apt mirrors can be significantly slower than amd64.
+  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pods "${_podname}" --timeout=900s
 
   run kubectl logs "${_podname}"
   assert_output --partial "NVIDIA-SMI"
@@ -74,4 +75,56 @@ bats::on_failure() {
 
   kubectl delete -f "${_specpath}"
   kubectl wait --for=delete "job/${_jobname}" --timeout=30s
+}
+
+
+# bats test_tags=gpu-workloads,multi-gpu
+@test "GPUs: Deployment with 2 replicas gets distinct GPUs simultaneously" {
+  local _specpath="tests/bats/specs/gpu-job-rct-parallel.yaml"
+  local _deployname="gpu-deploy-parallel"
+
+  kubectl apply -f "${_specpath}"
+
+  # Deployment Available condition proves 2 replicas are Running simultaneously,
+  # each holding a distinct GPU via its own ResourceClaimTemplate instance.
+  kubectl wait --for=condition=Available "deployment/${_deployname}" --timeout=60s
+
+  # Verify 2 ready replicas
+  local ready
+  ready=$(kubectl get deployment "${_deployname}" -o jsonpath='{.status.readyReplicas}')
+  [ "${ready}" -eq 2 ]
+
+  # Collect GPU UUIDs from each pod and verify they are different
+  local -a uuids=()
+  for pod in $(kubectl get pods -l "app=${_deployname}" -o name); do
+    local logs
+    logs=$(kubectl logs "${pod}")
+    echo "${logs}" | grep -q "UUID: GPU-"
+    local uid
+    uid=$(echo "${logs}" | grep -o "GPU-[a-f0-9-]*")
+    uuids+=("${uid}")
+  done
+  [ "${#uuids[@]}" -eq 2 ]
+  assert_not_equal "${uuids[0]}" "${uuids[1]}"
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods -l "app=${_deployname}" --timeout=30s
+}
+
+
+# bats test_tags=gpu-workloads,gpu-busgrind
+@test "GPUs: busGrind memory bandwidth stress test" {
+  local _specpath="tests/bats/specs/gpu-cuda-busgrind.yaml"
+  local _podname="pod-cuda-busgrind"
+
+  kubectl apply -f "${_specpath}"
+  # busGrind can take several minutes on slower GPUs
+  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pods "${_podname}" --timeout=900s
+
+  run kubectl logs "${_podname}"
+  assert_output --partial "NVIDIA-SMI"
+  assert_output --partial "busGrind"
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=30s
 }


### PR DESCRIPTION
Make best use of the GPUs we get from lambda and test more!

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExaHhlMGw4Nzc3eXM1eHlhbmNpODd3dzZhbjd0Y3BxNmZhNTVndzl2OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SYKPTDru6lWnfeovnI/giphy.gif)

`e2e-test.sh` now detects the Lambda instance's GPU count and type after launch and adjusts test filters automatically:
- **1 GPU**: skips `multi-gpu` tagged tests (2-replica deployment, distinct GPU assertion)
- **V100/A10**: skips `gpu-busgrind` (slow, can hang on older GPUs)
- **2+ GPUs on H100/A100/B200**: runs the full suite

New tests:
- **Deployment with 2 replicas holding distinct GPUs** (`multi-gpu` tag): A `Deployment` with `replicas: 2`, each replica claiming a GPU via `ResourceClaimTemplate`. Deployment `Available` condition proves both replicas are Running simultaneously. UUID comparison proves distinct GPU allocation.
- **busGrind memory bandwidth stress test** (`gpu-busgrind` tag): Runs the CUDA `busGrind` benchmark. Auto-skipped on V100/A10 where it's slow.