### PR TITLE
Add TimeSlicing and MPS GPU sharing tests

### DIFF
--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -175,7 +175,8 @@ runner-image:
 tests-gpu-single: runner-image
 	$(call RUN_BATS, \
 		tests/bats/test_gpu_basic.bats \
-		tests/bats/test_gpu_cuda_workloads.bats)
+		tests/bats/test_gpu_cuda_workloads.bats \
+		tests/bats/test_gpu_sharing.bats)
 
 # Run a subset covering mainly the GPU plugin
 tests-gpu: runner-image

--- a/tests/bats/specs/gpu-mps.yaml
+++ b/tests/bats/specs/gpu-mps.yaml
@@ -1,0 +1,51 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-mps-gpu
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+      config:
+      - requests: ["gpu"]
+        opaque:
+          driver: gpu.nvidia.com
+          parameters:
+            apiVersion: resource.nvidia.com/v1beta1
+            kind: GpuConfig
+            sharing:
+              strategy: MPS
+              mpsConfig:
+                defaultActiveThreadPercentage: 50
+                defaultPinnedDeviceMemoryLimit: 10Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-mps
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  - name: ctr1
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-mps-gpu

--- a/tests/bats/specs/gpu-timeslicing.yaml
+++ b/tests/bats/specs/gpu-timeslicing.yaml
@@ -1,0 +1,50 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-timeslicing-gpu
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+      config:
+      - requests: ["gpu"]
+        opaque:
+          driver: gpu.nvidia.com
+          parameters:
+            apiVersion: resource.nvidia.com/v1beta1
+            kind: GpuConfig
+            sharing:
+              strategy: TimeSlicing
+              timeSlicingConfig:
+                interval: Short
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-timeslicing
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr0
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  - name: ctr1
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-timeslicing-gpu

--- a/tests/bats/test_gpu_sharing.bats
+++ b/tests/bats/test_gpu_sharing.bats
@@ -1,0 +1,87 @@
+# shellcheck disable=SC2148
+# shellcheck disable=SC2329
+
+# Tests for GPU sharing strategies: TimeSlicing and MPS.
+# Requires feature gates: TimeSlicingSettings=true, MPSSupport=true.
+# Works on any GPU type.
+
+setup_file() {
+  load 'helpers.sh'
+  _common_setup
+  local _iargs=("--set" "logVerbosity=6"
+    "--set" "featureGates.TimeSlicingSettings=true"
+    "--set" "featureGates.MPSSupport=true")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+}
+
+setup() {
+  load 'helpers.sh'
+  _common_setup
+  log_objects
+}
+
+bats::on_failure() {
+  echo -e "\n\nFAILURE HOOK START"
+  log_objects
+  show_kubelet_plugin_error_logs
+  show_gpu_plugin_log_tails
+  echo -e "FAILURE HOOK END\n\n"
+}
+
+
+# bats test_tags=fastfeedback,gpu-sharing
+@test "GPUs: TimeSlicing — 2 containers share GPU with Short interval" {
+  local _specpath="tests/bats/specs/gpu-timeslicing.yaml"
+  local _podname="pod-timeslicing"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=30s
+
+  # Both containers should see the same GPU
+  run kubectl logs "${_podname}" -c ctr0
+  assert_output --partial "UUID: GPU-"
+  local uid0="${output}"
+
+  run kubectl logs "${_podname}" -c ctr1
+  assert_output --partial "UUID: GPU-"
+  local uid1="${output}"
+
+  # Same GPU shared via TimeSlicing
+  assert_equal "$uid0" "$uid1"
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=30s
+}
+
+
+# bats test_tags=fastfeedback,gpu-sharing
+@test "GPUs: MPS — 2 containers share GPU with MPS config" {
+  local _specpath="tests/bats/specs/gpu-mps.yaml"
+  local _podname="pod-mps"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=60s
+
+  # Both containers should see the same GPU
+  run kubectl logs "${_podname}" -c ctr0
+  assert_output --partial "UUID: GPU-"
+  local uid0="${output}"
+
+  run kubectl logs "${_podname}" -c ctr1
+  assert_output --partial "UUID: GPU-"
+  local uid1="${output}"
+
+  # Same GPU shared via MPS
+  assert_equal "$uid0" "$uid1"
+
+  # Verify MPS control daemon deployment was created by the driver
+  local mps_count
+  mps_count=$(kubectl get deployments -A --no-headers 2>/dev/null | grep "mps-control-daemon" | wc -l)
+  [ "${mps_count}" -ge 1 ]
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=30s
+}


### PR DESCRIPTION
New test file test_gpu_sharing.bats with 2 tests for GPU sharing strategies. Both tests work on any GPU type.

Tests:
- TimeSlicing: 2 containers share a GPU with Short interval via TimeSlicing GpuConfig opaque parameter. Verifies both containers see the same GPU UUID.
- MPS: 2 containers share a GPU with MPS config (50% threads, 10Gi pinned memory). Verifies both containers see the same GPU UUID and the MPS control daemon deployment is created.

Requires featureGates.TimeSlicingSettings=true and featureGates.MPSSupport=true (set in setup_file).