### PR TITLE
Initialize DRA request metrics series at startup

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/main.go
+++ b/cmd/compute-domain-kubelet-plugin/main.go
@@ -254,6 +254,8 @@ func RunPlugin(ctx context.Context, config *Config) error {
 	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	defer cancel()
 
+	metrics.InitializeDRARequestMetrics(DriverName)
+
 	if config.flags.httpEndpoint != "" {
 		if err := metrics.RunPrometheusMetricsServer(ctx, config.flags.httpEndpoint, config.flags.metricsPath); err != nil {
 			return fmt.Errorf("setup metrics endpoint: %w", err)

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -269,6 +269,8 @@ func RunPlugin(ctx context.Context, config *Config) error {
 	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	defer cancel()
 
+	metrics.InitializeDRARequestMetrics(DriverName)
+
 	if config.flags.httpEndpoint != "" {
 		if err := metrics.RunPrometheusMetricsServer(ctx, config.flags.httpEndpoint, config.flags.metricsPath); err != nil {
 			return fmt.Errorf("setup metrics endpoint: %w", err)

--- a/pkg/metrics/dra_requests.go
+++ b/pkg/metrics/dra_requests.go
@@ -64,12 +64,12 @@ var (
 		[]string{"node", "driver", "device_type"},
 	)
 
-	// node_prepare_errors_total is scoped to kubelet node prepare failures (GPU DRA plugin).
+	// node_prepare_errors_total is scoped to kubelet node prepare failures.
 	nodePrepareErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "nvidia_dra",
 			Name:      "node_prepare_errors_total",
-			Help:      "Total number of failures during DRA node prepare for the GPU kubelet plugin.",
+			Help:      "Total number of failures during DRA node prepare for kubelet plugins.",
 		},
 		[]string{"driver", "error_type"},
 	)
@@ -78,7 +78,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: "nvidia_dra",
 			Name:      "node_unprepare_errors_total",
-			Help:      "Total number of failures during DRA node unprepare for the GPU kubelet plugin.",
+			Help:      "Total number of failures during DRA node unprepare for kubelet plugins.",
 		},
 		[]string{"driver", "error_type"},
 	)
@@ -97,6 +97,26 @@ func Register() {
 	})
 }
 
+// InitializeDRARequestMetrics pre-creates zero-valued request series for a
+// driver so they are visible on the first Prometheus scrape after process
+// startup.
+func InitializeDRARequestMetrics(driver string) {
+	Register()
+	initializeDRARequestMetrics(driver)
+}
+
+func initializeDRARequestMetrics(driver string) {
+	if driver == "" {
+		return
+	}
+
+	for _, operation := range []string{"prepare", "unprepare"} {
+		draRequestsTotal.WithLabelValues(driver, operation)
+		draRequestDurationSeconds.WithLabelValues(driver, operation)
+		draRequestsInFlight.WithLabelValues(driver, operation)
+	}
+}
+
 func TrackInFlight(driver, operation string) func() {
 	Register()
 	draRequestsInFlight.WithLabelValues(driver, operation).Inc()
@@ -111,13 +131,13 @@ func ObserveRequest(driver, operation string, d time.Duration) {
 	draRequestDurationSeconds.WithLabelValues(driver, operation).Observe(d.Seconds())
 }
 
-// IncNodePrepareError increments node_prepare_errors_total (GPU kubelet plugin).
+// IncNodePrepareError increments node_prepare_errors_total for a kubelet plugin.
 func IncNodePrepareError(driver, errorType string) {
 	Register()
 	nodePrepareErrorsTotal.WithLabelValues(driver, errorType).Inc()
 }
 
-// IncNodeUnprepareError increments node_unprepare_errors_total (GPU kubelet plugin).
+// IncNodeUnprepareError increments node_unprepare_errors_total for a kubelet plugin.
 func IncNodeUnprepareError(driver, errorType string) {
 	Register()
 	nodeUnprepareErrorsTotal.WithLabelValues(driver, errorType).Inc()

--- a/pkg/metrics/dra_requests_test.go
+++ b/pkg/metrics/dra_requests_test.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+func resetDRARequestMetricsForTest() {
+	legacyregistry.Reset()
+	registerOnce = sync.Once{}
+	draRequestsTotal.Reset()
+	draRequestDurationSeconds.Reset()
+	draRequestsInFlight.Reset()
+	draPreparedDevices.Reset()
+	nodePrepareErrorsTotal.Reset()
+	nodeUnprepareErrorsTotal.Reset()
+}
+
+func TestInitializeDRARequestMetricsExposesZeroValuedSeries(t *testing.T) {
+	resetDRARequestMetricsForTest()
+
+	InitializeDRARequestMetrics("gpu.nvidia.com")
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	NewLegacyPrometheusHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: got %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	body := rec.Body.String()
+	for _, expected := range []string{
+		`nvidia_dra_requests_total{driver="gpu.nvidia.com",operation="prepare"} 0`,
+		`nvidia_dra_requests_total{driver="gpu.nvidia.com",operation="unprepare"} 0`,
+		`nvidia_dra_request_duration_seconds_count{driver="gpu.nvidia.com",operation="prepare"} 0`,
+		`nvidia_dra_requests_inflight{driver="gpu.nvidia.com",operation="prepare"} 0`,
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("metrics output missing %s\nfull output:\n%s", expected, body)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes the root cause of the metrics smoke-test failure seen in [#1025](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1025). 

While [#1028](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1028) relaxed the test, the real issue was that the DRA request metrics were not visible on `/metrics` until the first `prepare` or `unprepare` call created labeled series, so a fresh kubelet-plugin scrape could show `nvidia_dra_prepared_devices` but not `nvidia_dra_requests_total` as in the:
[Prow log](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_dra-driver-nvidia-gpu/1025/pull-dra-driver-nvidia-gpu-e2e-lambda-gpu/2043296598573715456/build-log.txt). 

This change initializes the request metric series at startup for both kubelet plugins before the HTTP endpoint is exposed, keeps them visible at `0` on the first scrape, adds a regression test for that behavior, and updates the error-metric descriptions to match current usage.