### PR TITLE
gpu plugin: fix wrong error variable in getGpuInfo for NVML system calls

### DIFF
--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -464,11 +464,11 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 	}
 	driverVersion, ret := l.nvmllib.SystemGetDriverVersion()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting driver version: %w", err)
+		return nil, fmt.Errorf("error getting driver version: %v", ret)
 	}
 	cudaDriverVersion, ret := l.nvmllib.SystemGetCudaDriverVersion()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting CUDA driver version: %w", err)
+		return nil, fmt.Errorf("error getting CUDA driver version: %v", ret)
 	}
 	pciBusID, err := device.GetPCIBusID()
 	if err != nil {


### PR DESCRIPTION
### What this PR does

Fixes a copy-paste bug in `getGpuInfo()` where error messages for `SystemGetDriverVersion()` and `SystemGetCudaDriverVersion()` wrap the wrong variable.

At lines 467 and 471, `err` (from the preceding `GetCudaComputeCapabilityAsString()` call at line 461) is used instead of `ret` (the actual NVML return code). When the preceding call succeeds (`err == nil`), the error message becomes misleading:

```
error getting driver version: <nil>
error getting CUDA driver version: <nil>
```

The actual NVML error code is silently discarded.

### Root cause

The two `SystemGet*` calls return `(value, nvml.Return)` — the NVML convention — but the error formatting mistakenly follows the Go `(value, error)` pattern used by the preceding lines. This appears to be a copy-paste from the `%w, err` lines above without updating the variable to `ret`.

### Fix

Change `%w, err` → `%v, ret` on both lines, consistent with every other NVML return-code error in the same function (lines 435, 439, 447, 451).

### How to verify

The function has two interleaved error-handling patterns:

| Lines | Call returns | Format | Variable | Correct? |
|-------|------------|--------|----------|----------|
| 435, 439, 447, 451 | `nvml.Return` | `%v` | `ret` | ✅ |
| 443, 455, 459, 463, 475 | `error` | `%w` | `err` | ✅ |
| 467, 471 (before fix) | `nvml.Return` | `%w` | `err` | ❌ |
| 467, 471 (after fix) | `nvml.Return` | `%v` | `ret` | ✅ |
