### PR TITLE
gpu plugin: add missing return in unpreparePartiallyPrepairedClaim when DynamicMIG is disabled

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -494,6 +494,7 @@ func (s *DeviceState) unpreparePartiallyPrepairedClaim(cuid string, pc PreparedC
 	// For now, there's nothing to do when DynamicMIG is not enabled.
 	if !featuregates.Enabled(featuregates.DynamicMIG) {
 		klog.Infof("unprepare noop: preparation started but not completed for claim %s (devices: %v)", PreparedClaimToString(&pc, cuid), pc.Status.Allocation.Devices.Results)
+		return nil
 	}
 
 	// When DynamicMIG is enabled, try to identify an orphaned MIG device


### PR DESCRIPTION
Fixes #1056

## What this PR does
Adds a missing `return nil` in `unpreparePartiallyPrepairedClaim()` when the DynamicMIG feature gate is disabled.

The existing comment says "For now, there's nothing to do when DynamicMIG is not enabled" and the function logs a noop message, but then falls through to the DynamicMIG-specific cleanup code below.

## Impact
For regular GPU claims, the fall-through is functionally harmless — `NewMigSpecTupleFromCanonicalName("gpu-0")` fails to parse and the loop continues. However:

- **Static MIG claims**: If a static MIG device name (e.g., `gpu-0-mig-1g5gb-19-0`) reaches this path, it matches the MIG regex and enters `deleteMigDevIfExistsAndNotUsedByCompletedClaim()` with an unset `ParentPCIBusID`, causing a spurious NVML error that fails the entire unprepare operation.
- **Unnecessary work**: Even for non-MIG devices, the fall-through iterates all prepared claims building `completedClaims` and runs regex parsing on each device — wasted CPU in a path that should be a no-op.

This condition arises when a claim is in `PrepareStarted` state (the plugin crashed between checkpoint write and prepare completion), which is rare but possible.

## Fix
Add `return nil` after the log statement, consistent with the comment's stated intent and the early-return pattern used elsewhere for DynamicMIG checks (e.g., `nvlib.go:844`).

```release-note
Fix gpu-kubelet-plugin cleanup for partially prepared claims when DynamicMIG is disabled.
```