### PR TITLE
cmd/compute-domain-daemon: non-converging CD status due to lost node updates

### DIFF
--- a/cmd/compute-domain-daemon/cdstatus_test.go
+++ b/cmd/compute-domain-daemon/cdstatus_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	nvapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/flags"
+	nvfake "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/nvidia.com/clientset/versioned/fake"
+)
+
+type noopMutationCache struct{}
+
+func (n *noopMutationCache) GetByKey(string) (interface{}, bool, error) {
+	return nil, false, nil
+}
+
+func (n *noopMutationCache) ByIndex(string, string) ([]interface{}, error) {
+	return nil, nil
+}
+
+func (n *noopMutationCache) Mutation(interface{}) {}
+
+var _ cache.MutationCache = &noopMutationCache{}
+
+// This regression test simulates multiple daemon pods updating ComputeDomain
+// status concurrently and verifies that all node entries are preserved in the status.
+func TestSyncNodeInfoToCDPreservesExistingNodesAcrossConcurrentWriters(t *testing.T) {
+	t.Parallel()
+	t.Skip("tracked in GH issue #1050")
+
+	const (
+		namespace = "default"
+		name      = "cd-foo"
+		uid       = "cd-uid"
+		cliqueID  = "clique-1"
+	)
+
+	for _, numWriters := range []int{2, 3, 5} {
+		t.Run(fmt.Sprintf("writers=%d", numWriters), func(t *testing.T) {
+			cd := &nvapi.ComputeDomain{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					UID:       uid,
+				},
+				Spec: nvapi.ComputeDomainSpec{
+					NumNodes: numWriters,
+				},
+			}
+
+			client := nvfake.NewSimpleClientset(cd.DeepCopy())
+
+			newManager := func(nodeName, podIP string) *ComputeDomainStatusManager {
+				return &ComputeDomainStatusManager{
+					config: &ManagerConfig{
+						clientsets: flags.ClientSets{
+							Nvidia: client,
+						},
+						nodeName:               nodeName,
+						podIP:                  podIP,
+						cliqueID:               cliqueID,
+						computeDomainName:      name,
+						computeDomainNamespace: namespace,
+						computeDomainUUID:      uid,
+						maxNodesPerIMEXDomain:  8,
+					},
+					mutationCache: &noopMutationCache{},
+				}
+			}
+
+			managers := make([]*ComputeDomainStatusManager, 0, numWriters)
+			staleSnapshots := make([]*nvapi.ComputeDomain, 0, numWriters)
+			// Managers read the same initial snapshot before updating the CD status.
+			for i := 0; i < numWriters; i++ {
+				managers = append(managers, newManager(
+					fmt.Sprintf("node-%d", i),
+					fmt.Sprintf("10.0.0.%d", i+1),
+				))
+
+				staleCD, err := client.ResourceV1beta1().ComputeDomains(namespace).Get(context.Background(), name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("get stale snapshot %d: %v", i, err)
+				}
+				staleSnapshots = append(staleSnapshots, staleCD)
+			}
+
+			for i, manager := range managers {
+				if _, err := manager.syncNodeInfoToCD(context.Background(), staleSnapshots[i]); err != nil {
+					t.Fatalf("sync manager %d: %v", i, err)
+				}
+			}
+
+			finalCD, err := client.ResourceV1beta1().ComputeDomains(namespace).Get(context.Background(), name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get final ComputeDomain: %v", err)
+			}
+
+			if got := len(finalCD.Status.Nodes); got != numWriters {
+				t.Fatalf("expected all %d node updates to be present, got %d nodes: %#v", numWriters, got, finalCD.Status.Nodes)
+			}
+
+			nodesByName := make(map[string]*nvapi.ComputeDomainNode, len(finalCD.Status.Nodes))
+			for _, node := range finalCD.Status.Nodes {
+				nodesByName[node.Name] = node
+			}
+
+			for i := 0; i < numWriters; i++ {
+				name := fmt.Sprintf("node-%d", i)
+				if _, exists := nodesByName[name]; !exists {
+					t.Fatalf("expected node %q to survive concurrent updates, got nodes: %#v", name, finalCD.Status.Nodes)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When multiple compute-domain daemon pods update ComputeDomain status from their own view of the object, syncNodeInfoToCD rewrites the full status.nodes list and can drop a peer node entry. The CD status fails to converge.

Add a unit test that reproduces this lost-update behavior by simulating two daemon instances reading the same initial ComputeDomain object and then writing their node info sequentially.

Snippets from a real cluster deployment highlighting the bug -

```
Status:
  Nodes:
    Clique Id: 9f410827-489f-46fd-8203-51266ca08eb7.32766
    Index: 0
    Ip Address: 10.42.3.138
    Name: cluster1-mgx-00011
    Status: NotReady
    Clique Id: 9f410827-489f-46fd-8203-51266ca08eb7.32766
    Index: 1
    Ip Address: 10.42.1.100
    Name: cluster1-mgx-00017
    Status: NotReady
  Status: NotReady
Events: <none>

I0415 16:14:28.038085 1 cdstatus.go:276] Successfully inserted/updated node in CD (nodeinfo: &{cluster1-mgx-00011 10.42.3.138 9f410827-489f-46fd-8203-51266ca08eb7.32766 0 NotReady})
I0415 16:14:28.038098 1 cdstatus.go:339] numNodes: 2, nodes seen: 1
I0415 16:14:28.044285 1 cdstatus.go:239] syncNodeInfoToCD noop: pod IP unchanged (10.42.3.138)
I0415 16:14:28.044300 1 cdstatus.go:339] numNodes: 2, nodes seen: 1
I0415 16:14:28.053413 1 cdstatus.go:239] syncNodeInfoToCD noop: pod IP unchanged (10.42.3.138)
I0415 16:14:28.053424 1 cdstatus.go:354] IP set for clique did not change

I0415 16:14:30.033811 1 cdstatus.go:259] CD status does not contain node name 'cluster1-mgx-00011' yet, try to insert myself: &{cluster1-mgx-00011 9f410827-489f-46fd-8203-51266ca08eb7.32766 0 NotReady}
I0415 16:14:30.037427 1 round_trippers.go:632] "Response" verb="PUT" url="https://10.43.0.1:443/apis/resource.nvidia.com/v1beta1/namespaces/default/computedomains/imex-channel-injection/status" status="200 OK" milliseconds=3
I0415 16:14:30.037620 1 cdstatus.go:276] Successfully inserted/updated node in CD (nodeinfo: &{cluster1-mgx-00011 10.42.3.138 9f410827-489f-46fd-8203-51266ca08eb7.32766 0 NotReady})
I0415 16:14:30.037656 1 cdstatus.go:339] numNodes: 2, nodes seen: 1
I0415 16:14:30.042979 1 cdstatus.go:239] syncNodeInfoToCD noop: pod IP unchanged (10.42.3.138)
I0415 16:14:30.042995 1 cdstatus.go:339] numNodes: 2, nodes seen: 1
I0415 16:14:30.052870 1 cdstatus.go:239] syncNodeInfoToCD noop: pod IP unchanged (10.42.3.138)
I0415 16:14:30.052888 1 cdstatus.go:354] IP set for clique did not change

```