### PR TITLE
docs: add minimal docs and Netlify build config

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,33 @@
+# Architecture
+
+This repo ships two independent Kubernetes DRA drivers from one codebase:
+
+- **`gpu.nvidia.com`** — allocates GPUs, MIG slices, and VFIO passthrough.
+- **`compute-domain.nvidia.com`** — allocates IMEX daemons and channels for Multi-Node NVLink.
+
+Both are delivered by the Helm chart in [`deployments/helm/dra-driver-nvidia-gpu/`](../deployments/helm/dra-driver-nvidia-gpu).
+
+## Binaries ([`cmd/`](../cmd))
+
+| Binary | Runs as | What it does |
+|---|---|---|
+| `gpu-kubelet-plugin` | DaemonSet, per node | Publishes GPU / MIG / VFIO `ResourceSlice`s and injects CDI on Prepare. |
+| `compute-domain-kubelet-plugin` | Same DaemonSet, per node | Publishes IMEX daemon + channel devices and injects the IMEX mount on Prepare. |
+| `compute-domain-controller` | Cluster Deployment | Watches `ComputeDomain` CRs; spawns a per-CD DaemonSet and the matching `ResourceClaimTemplate`s. |
+| `compute-domain-daemon` | Per-CD DaemonSet, per node | Wraps and supervises `nvidia-imex`; reports peers. |
+| `webhook` | Cluster Deployment | Validates opaque config on `ResourceClaim`s. |
+
+## GPU request
+
+Pod → `ResourceClaim` with a `GpuConfig` / `MigDeviceConfig` / `VfioDeviceConfig` → webhook validates → scheduler binds a device advertised by the GPU plugin → kubelet calls Prepare → plugin writes a CDI spec → runtime injects the GPU into the container.
+
+## ComputeDomain
+
+User creates a `ComputeDomain` → controller creates a per-CD DaemonSet → each daemon pod runs `nvidia-imex` → daemons publish their IP and clique through `ComputeDomainClique` CRs → workload pods claim a channel from the `compute-domain-default-channel.nvidia.com` DeviceClass → the CD kubelet plugin asserts readiness and injects `/dev/nvidia-caps-imex-channels/chan*` plus `/imexd` into the container.
+
+## Reference
+
+- CRD and opaque-config types: [`api/nvidia.com/resource/v1beta1`](../api/nvidia.com/resource/v1beta1).
+- Feature gates: [`pkg/featuregates/featuregates.go`](../pkg/featuregates/featuregates.go).
+- DeviceClasses shipped by the chart: [`deployments/helm/dra-driver-nvidia-gpu/templates/deviceclass-*.yaml`](../deployments/helm/dra-driver-nvidia-gpu/templates).
+- Example workloads: [`demo/specs/quickstart/`](../demo/specs/quickstart).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,39 @@
+# Development
+
+**Tooling:** Go (version per [`go.mod`](../go.mod)), Docker + Buildx, Helm v3, kind, golangci-lint. Codegen tools are installed by `make -C deployments/devel install-tools`.
+
+## Make targets
+
+```
+make build         # go build ./...
+make cmds          # build the five binaries in cmd/
+make test          # race-enabled unit tests
+make generate      # CRDs, deepcopy, clientset, listers, informers
+make check         # golangci-lint + check-generate  (the CI gate)
+make helm-lint     # lint the Helm chart
+make bats          # BATS integration tests  (needs a live cluster)
+```
+
+Prefix any target with `docker-` to run it in the devel container (requires `BUILD_DEVEL_IMAGE=yes`).
+
+## Local cluster
+
+```sh
+export KIND_CLUSTER_NAME=kind-dra-1
+./demo/clusters/kind/build-dra-driver-gpu.sh     # build & load driver image
+./demo/clusters/kind/create-cluster.sh           # create the cluster
+./demo/clusters/kind/install-dra-driver-gpu.sh   # helm install
+```
+
+Iterate: edit → rerun the build script → rerun the install script.
+
+GPU-aware variant: [`demo/clusters/nvkind/`](../demo/clusters/nvkind). GKE recipes: [`demo/clusters/gke/`](../demo/clusters/gke).
+
+## Tests
+
+- **Unit**: `make test`.
+- **BATS**: [`tests/bats/`](../tests/bats) — invasive, runs against a real cluster. Read [`tests/bats/README.md`](../tests/bats/README.md) first.
+
+## CI
+
+GitHub Actions in [`.github/workflows/`](../.github/workflows) run lint, codegen check, unit tests, build, chart lint, and CodeQL. End-to-end GPU tests run on Prow / Lambda Cloud — see [`hack/ci/lambda/e2e-test.sh`](../hack/ci/lambda/e2e-test.sh).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# Documentation
+
+The DRA Driver for NVIDIA GPUs is a Kubernetes Dynamic Resource Allocation driver that lets workloads request GPUs, MIG slices, and VFIO passthrough devices (`gpu.nvidia.com`), and provisions ephemeral Multi-Node NVLink fabrics via IMEX (`compute-domain.nvidia.com`) so pods on different nodes can share GPU memory over NVLink. It targets Kubernetes 1.32+ with DRA enabled.
+
+- [`architecture.md`](architecture.md) — components and request flows.
+- [`development.md`](development.md) — build, test, and local-cluster loop.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,2 @@
+site_name: DRA Driver for NVIDIA GPUs
+docs_dir: docs

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+publish = "site"
+command = "pip install mkdocs && mkdocs build"


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds a minimal `docs/` tree (index, architecture, development) plus the MkDocs + Netlify wiring needed to publish them:

- `mkdocs.yml` — minimal MkDocs config pointing at `docs/`
- `netlify.toml` — installs MkDocs and runs `mkdocs build` into `site/`

Once the GitHub repo is connected to a Netlify site (e.g. `kubernetes-sigs-dra-driver-nvidia-gpu.netlify.app`), every push will rebuild and publish the docs.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Companion PR against `kubernetes/k8s.io` adds the DNS CNAME (`dra-driver-nvidia-gpu.sigs.k8s.io` → Netlify) so the published site is reachable under a friendly hostname: https://github.com/kubernetes/k8s.io/pull/9357.

The documents deliberately stay small — `docs/architecture.md` sketches the five binaries plus the GPU and ComputeDomain request flows, and `docs/development.md` captures the Make targets, local-cluster loop, and tests. They can grow over time.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

```docs
docs/index.md
docs/architecture.md
docs/development.md
```

#### Checklist

- [ ] `make check test` passes locally
- [ ] `make generate` re-run if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make vendor` re-run if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
