### PR TITLE
helm: fix `maskNvidiaDriverParams` path

### DIFF
--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -95,9 +95,9 @@ spec:
           # example, when running under nvkind to limit the set GPUs governed
           # by the plugin even though it has cgroup access to all of them.
           if [ "${MASK_NVIDIA_DRIVER_PARAMS}" = "true" ]; then
-            cp /proc/driver/nvidia/params root/gpu-params
-            sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' root/gpu-params
-            mount --bind root/gpu-params /proc/driver/nvidia/params
+            cp /proc/driver/nvidia/params /root/gpu-params
+            sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' /root/gpu-params
+            mount --bind /root/gpu-params /proc/driver/nvidia/params
           fi
           compute-domain-kubelet-plugin -v $(LOG_VERBOSITY)
         resources:
@@ -203,9 +203,9 @@ spec:
           # example, when running under nvkind to limit the set GPUs governed
           # by the plugin even though it has cgroup access to all of them.
           if [ "${MASK_NVIDIA_DRIVER_PARAMS}" = "true" ]; then
-            cp /proc/driver/nvidia/params root/gpu-params
-            sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' root/gpu-params
-            mount --bind root/gpu-params /proc/driver/nvidia/params
+            cp /proc/driver/nvidia/params /root/gpu-params
+            sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' /root/gpu-params
+            mount --bind /root/gpu-params /proc/driver/nvidia/params
           fi
           gpu-kubelet-plugin -v $(LOG_VERBOSITY)
         resources:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

After the switch to the distroless image, the container working directory changed from `/` to `/app`, but the Helm template still used the relative path `root/gpu-params`.
This specifically broke `demo/clusters/nvkind`, which depends on `maskNvidiaDriverParams=true`.
This PR fixes the issue by using an absolute path `/root/gpu-params`.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

```docs

```
