### PR TITLE
Add enhancement proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thank you for suggesting a feature. Please describe the problem you're trying to solve and your proposed solution.
 
-        > **Note:** Large features that introduce new feature gates or significant behavioral changes require a formal proposal. TBD
+        > **Note:** Large features that introduce new feature gates or significant behavioral changes require a formal proposal. See [docs/proposals/README.md](../../docs/proposals/README.md) for when and how to file one.
 
   - type: dropdown
     id: component

--- a/docs/proposals/NNNN-template.md
+++ b/docs/proposals/NNNN-template.md
@@ -1,0 +1,220 @@
+# NNNN — <Short descriptive title>
+
+<!--
+Before writing this, pause and check:
+
+- Does this change really belong in this driver? A common outcome for
+  proposals here is "wrong layer" — the change really belonged in upstream
+  Kubernetes, in the device plugin, or in the GPU operator. If you're not
+  sure, open a discussion issue first and link it here.
+- If you can't yet write a one-paragraph release note for this change, you
+  aren't ready to propose it.
+- Small changes (a flag, a config knob, a local refactor) go straight to
+  a PR. See docs/proposals/README.md for when a proposal is actually
+  needed.
+-->
+
+| Field          | Value         |
+|----------------|---------------|
+| Status         | provisional   |
+| Authors        | @your-handle  |
+| Created        | YYYY-MM-DD    |
+| Related issues | #…            |
+
+## Summary
+
+<!--
+One paragraph. Should read like the release note users will see on merge —
+write this first. If you can't, you don't understand the change yet.
+-->
+
+## Motivation
+
+### Who is asking for this, and why?
+
+<!--
+Name a concrete workload, a named downstream consumer (for example
+KubeVirt, LWS, JobSet, Slurm, DCGM-Exporter), or a specific user class.
+Abstract motivation without a named use case is a common reason proposals
+stall.
+-->
+
+### Goals
+
+<!--
+Each goal should be measurable enough to imply a test. "How will we know
+this has succeeded?" is the question reviewers will ask.
+-->
+
+### Non-goals
+
+<!--
+Explicit fence. What are you NOT proposing, even if related? This is where
+you prevent scope creep during review.
+-->
+
+## Why this belongs in the NVIDIA DRA driver
+
+<!--
+Required. State why this change lives here and not in:
+- upstream Kubernetes / DRA core
+- the device plugin
+- the GPU operator
+- a CLI or external tool
+If any part of this requires an upstream Kubernetes change, link the
+blocking issue or discussion.
+-->
+
+## Proposal
+
+### User-facing example
+
+<!--
+Required. Show the concrete surface users will touch: a ResourceClaim
+manifest, a CRD sample, a CLI invocation, a Helm values snippet. If this
+feels verbose or repetitive, that's a signal the UX needs rework before
+the internals do.
+-->
+
+```yaml
+# example
+```
+
+### Affected components
+
+<!-- Check all that apply. Matches the components dropdown on the feature request issue form. -->
+
+- [ ] `api/` — CRDs, CRD fields, or ResourceClaim shape
+- [ ] `gpu-kubelet-plugin`
+- [ ] `compute-domain-kubelet-plugin`
+- [ ] `compute-domain-controller`
+- [ ] `compute-domain-daemon`
+- [ ] admission webhook
+- [ ] Helm chart (`deployments/helm`)
+- [ ] CDI spec generation
+- [ ] Metrics
+- [ ] Kubelet-plugin checkpoint schema
+- [ ] Documentation
+- [ ] CI / testing
+
+### Authoritative state owner
+
+<!--
+For any new persistent or runtime state: which single component is
+authoritative for writes? How do the others read it? Reviewers will push
+back on state split across plugin + controller + daemon without a clear
+owner.
+
+If you haven't worked in this codebase before, the top-level README and
+the directories under `cmd/` describe what each component does.
+-->
+
+### Smallest valuable slice
+
+<!--
+What is the smallest piece that could ship first and still be useful?
+Large PRs routinely get asked to split — plan the decomposition now.
+-->
+
+## Design
+
+### API changes
+
+<!--
+List new or changed CRD fields, flags, annotations, Helm values. For each
+new field, explicitly label it "user-facing" or "implementation detail."
+Default to NOT exposing speculative fields — once users depend on them,
+removal is painful.
+-->
+
+### Feature gate & graduation
+
+<!--
+Does this introduce a feature gate? If yes:
+- Target stability at ship time (Alpha / Beta / Stable).
+- If not Stable, what does graduation to the next level require? Use the
+  project's three criteria (see docs/proposals/README.md): feature
+  completeness, interoperability (name the adjacent features), stability
+  and soak time.
+- Which existing feature gates is this mutually exclusive with, or does it
+  compose with?
+If no gate, state what the change is guarded by (flag, config, chart
+value) or "none — ships on by default."
+-->
+
+### Upgrade & downgrade
+
+<!--
+What happens if a cluster upgrades (or rolls back) the driver while claims
+are in flight?
+- If the kubelet-plugin checkpoint schema changes: use `omitempty` on new
+  fields and describe the upgrade test.
+- Helm value migrations, CRD conversion, RBAC changes.
+- Rolling restart of controller replicas — does anything get lost?
+-->
+
+### Environment floor
+
+<!--
+- Minimum NVIDIA driver version.
+- GPU generations supported (A100 / H100 / B200 / GB200 / L40 / …).
+- MIG / NVLink / IMEX / fabric requirements.
+- Minimum Kubernetes version.
+- Required or assumed kubelet/controller feature gates.
+-->
+
+### Test plan
+
+<!--
+Reviewers will not approve without a concrete plan across more than unit
+tests. Name the specific files/jobs where you can.
+- Unit: …
+- Integration / controller tests: …
+- BATS (`tests/bats`): …
+- Mock NVML CI (`hack/ci/mock-nvml`): can this be exercised on CPU-only
+  runners? If no, why not?
+- Lambda e2e on real GPUs: which `pull-dra-driver-nvidia-gpu-*` job, and
+  which scenario (MIG / time-slicing / ComputeDomain / …)?
+-->
+
+## Risks
+
+<!--
+Think broadly. Concerns reviewers consistently raise here:
+
+- Races between kubelet prepare/unprepare and controller/daemon state.
+- Force-deleted pods, node reboots, or daemon restarts mid-claim.
+- Multi-node coordination for ComputeDomains (SSA mutation cache, DNS
+  index collisions, leader election under partition).
+- Privilege surface: privileged containers, /dev mounts, NVML access,
+  nvidia-container-runtime interactions.
+- Fail-fast preservation: does the process still exit non-zero on
+  well-defined fatal conditions after this change?
+-->
+
+## Alternatives
+
+<!--
+What did you rule out, and why? Include at minimum:
+
+- What you tried with existing primitives (CEL selectors, `matchAttribute`,
+  current CRD knobs, Helm values) and why they were insufficient.
+- Adjacent prior art in NVIDIA repos — go-nvlib, dra-example-driver,
+  sandbox-device-plugin, nvml-mock — and whether any of it can be reused.
+- Relevant upstream Kubernetes work, even if only to state "considered,
+  not applicable because …".
+-->
+
+## Drawbacks
+
+<!--
+Steelman the case against this change. If you can't find one, the proposal
+isn't ready.
+-->
+
+## Open questions
+
+<!--
+Anything you want explicit maintainer input on before implementation.
+These are the conversations worth having here rather than in code review.
+-->

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,84 @@
+# Enhancement proposals
+
+This directory holds lightweight design proposals for the NVIDIA DRA driver.
+
+A proposal is a short markdown document that answers a few high-signal
+questions *before* code is written, so reviewers and authors are aligned
+on scope, user-facing surface, component ownership, upgrade impact, and
+test plan.
+
+## When to file a proposal
+
+**A proposal is required if the change:**
+
+- Introduces a new feature gate, or graduates an existing gate to a new
+  stability level.
+- Makes a significant behavioral change to an existing feature.
+- Adds or modifies a user-facing API: CRDs, CRD fields, CLI flags,
+  Helm chart values, ResourceSlice attributes, or the kubelet-plugin
+  checkpoint schema.
+- Adds or modifies an external dependency (DCGM, NVSentinel, virtualization
+  stack, etc.).
+- Depends on a change in upstream Kubernetes, or requires coordination with
+  work that is landing there.
+- Touches the ComputeDomain / IMEX coordination layer in a way that affects
+  multi-node behavior.
+
+**A proposal is NOT required for:**
+
+- Bug fixes to existing behavior.
+- Documentation-only changes.
+- Internal refactoring with no observable behavior change.
+- Dependency version bumps with no API impact.
+- Incremental additions under an existing feature gate that don't change
+  the design.
+
+If you're unsure, open an issue describing what you want to do and ask —
+it's cheap to find out early.
+
+## How to file one
+
+1. Look at existing files in this directory and pick the next unused
+   4-digit number (e.g., if `0001-foo.md` exists, name your file
+   `0002-short-title.md`).
+2. Copy `NNNN-template.md`, rename it, and fill it in. Start with
+   `Status: provisional`.
+3. Open a PR with the new document. You do not need to open an issue
+   first, but feel free to if you want a quick gut-check on whether a
+   proposal is needed.
+4. Iterate on the PR with maintainers. A proposal is ready to merge when
+   OWNERS from this repo approve — the same review flow as any code PR.
+5. Once implementation lands, bump `Status` to `implemented` in a
+   follow-up PR.
+
+Proposals are typically a few hundred lines of markdown, not a novel.
+Optimize for the reviewer's time: write the summary first, show a
+concrete user-facing example, and don't dwell on sections that don't
+apply to your change.
+
+For questions or quick discussion, see the chat venues listed in
+[CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Status lifecycle
+
+- `provisional` — under discussion; design not yet agreed.
+- `implementable` — design agreed; ready for implementation.
+- `implemented` — shipped. Note the release in the document's header table.
+- `withdrawn` — author or maintainers decided not to proceed. Leave the
+  document in place as a decision record.
+
+## Feature gate graduation
+
+If your proposal introduces a feature gate, graduation to the next
+stability level is evaluated against three criteria. Proposals that do
+not involve a feature gate can skip this section.
+
+- **Feature completeness** — the implementation aligns with the intended
+  design goals.
+- **Interoperability** — the feature works reliably alongside adjacent
+  features (name the ones you tested against).
+- **Stability and soak time** — the feature has been exercised in
+  production-like environments for long enough to surface issues.
+
+Constraints and caveats that accompany a feature gate should be captured
+in release notes, not just in the proposal document.


### PR DESCRIPTION
Adds docs/proposals/ with a README describing when a proposal is required and a NNNN-template.md that prompts authors through summary, motivation, why-this-belongs-here, affected components, authoritative state owner, smallest valuable slice, API changes, feature gate and graduation criteria, upgrade/downgrade, environment floor, test plan, risks, alternatives, drawbacks, and open questions.

Also replaces the "TBD" pointer in the feature request issue form with a link to the new docs/proposals/README.md.

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
Create a new enhancement proposal template for future DRA Driver for NVIDIA GPU work.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
