### PR TITLE
tests/bats, hack/ci: gate cuda-busgrind on x86_64

### DIFF
--- a/hack/ci/lambda/e2e-test.sh
+++ b/hack/ci/lambda/e2e-test.sh
@@ -97,7 +97,11 @@ FILTER='!version-specific'
 if [ "${GPU_COUNT}" -lt 2 ]; then
   FILTER="${FILTER},!multi-gpu"
 fi
-# busGrind is slow and can hang on V100/A10/GH200 — only run on H100+.
+# busGrind ships only in NVIDIA's cuda-demo-suite-* apt package, which is
+# published for x86_64 but not for sbsa/arm64 (confirmed against NVIDIA's
+# public CUDA apt repo). On V100/A10 it is also prone to hang. Gate
+# accordingly; revisit the gh200 entry if NVIDIA ever publishes
+# cuda-demo-suite for sbsa.
 case "${LAMBDA_GPU_TYPE}" in
   *v100*|*a10|*gh200*) FILTER="${FILTER},!gpu-busgrind" ;;
 esac

--- a/tests/bats/specs/gpu-cuda-busgrind.yaml
+++ b/tests/bats/specs/gpu-cuda-busgrind.yaml
@@ -29,9 +29,19 @@ spec:
       set -ex
       nvidia-smi
       apt-get update -y -o Acquire::Retries=5
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated -o Acquire::Retries=5 cuda-demo-suite-12-5
-      cd /usr/local/cuda-12.5/extras/demo_suite || cd /usr/local/cuda/extras/demo_suite
-      ./busGrind
+      if [ "$(uname -m)" = "x86_64" ]; then
+        DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated -o Acquire::Retries=5 cuda-demo-suite-12-5
+        cd /usr/local/cuda-12.5/extras/demo_suite || cd /usr/local/cuda/extras/demo_suite
+        ./busGrind
+      else
+        # busGrind ships only in NVIDIA's cuda-demo-suite-* apt package,
+        # which is published for x86_64 only (no sbsa/arm64 build). The
+        # NVIDIA/cuda-samples repo also does not contain an equivalent,
+        # so there is no source-build fallback. hack/ci/lambda/e2e-test.sh
+        # filters this test off non-x86_64 instances; this branch is
+        # defense-in-depth in case the spec is ever applied on arm64.
+        echo "busGrind is amd64-only; skipping on $(uname -m)."
+      fi
     resources:
       claims:
       - name: gpu


### PR DESCRIPTION
NVIDIA publishes `cuda-demo-suite-*` for x86_64 but not for sbsa/arm64, and `busGrind` has no source equivalent in `NVIDIA/cuda-samples`. The `gpu-cuda-busgrind` spec therefore fails at `apt-get install` on GH200.

Gate the install on `uname -m`; echo a `busGrind is amd64-only` no-op on non-x86_64 (the lambda CI already filters this test off GH200/V100/A10, so this is defense-in-depth). Also rewrite the adjacent comment in `hack/ci/lambda/e2e-test.sh` to name the real cause instead of "slow / can hang".

No behavior change on x86_64 or on any instance type already in the filter.

```release-note
NONE
```
