### PR TITLE
add a10 safe gpu tests

### DIFF
--- a/hack/ci/lambda/e2e-test.sh
+++ b/hack/ci/lambda/e2e-test.sh
@@ -17,7 +17,7 @@
 # Sources shared Lambda CI library from test-infra (available via Prow extra_refs).
 #
 # Required env: LAMBDA_API_KEY_FILE, JOB_NAME, BUILD_ID, ARTIFACTS (set by Prow)
-# Optional env: GPU_TYPE (default: gpu_1x_a10), K8S_VERSION (default: latest stable)
+# Optional env: GPU_TYPE (default: gpu_1x_a10), K8S_VERSION (default: latest stable), BATS_TARGET (default: tests-gpu-single)
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -126,6 +126,9 @@ case "${LAMBDA_GPU_TYPE}" in
 esac
 echo "Test filter: ${FILTER}, compute domains disabled: ${DISABLE_CD}"
 
+# Default CI target, overridable by test-infra job config.
+BATS_TARGET="${BATS_TARGET:-tests-gpu-single}"
+
 # --- Pre-cleanup: MIG teardown on host ---
 # Run MIG cleanup directly on the host where nvidia-smi is available.
 # The BATS Docker container uses the lambda nvmm stub (no-op).
@@ -157,10 +160,11 @@ export TEST_CHART_LOCAL=true
 export DISABLE_COMPUTE_DOMAINS=${DISABLE_CD}
 export TEST_FILTER_TAGS='${FILTER}'
 export GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT}
+echo "Running BATS target: ${BATS_TARGET}"
 # Use lambda nvmm stub (no GPU Operator). MIG cleanup handled above.
 export NVMM_PATH=/cwd/tests/bats/lib/lambda
 
-make -f tests/bats/Makefile tests-gpu-single GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT}
+make -f tests/bats/Makefile ${BATS_TARGET} GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT}
 EOF
 
 # --- Collect artifacts ---

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -176,7 +176,7 @@ runner-image:
 # suite/file 'setup' in bats, but we'd lose output on success). During dev, you
 # may want to add --show-output-of-passing-tests (and read bats docs for other
 # cmdline args).
-.PHONY: tests-gpu tests-gpu-single tests-cd
+.PHONY: tests-gpu tests-gpu-single tests-gpu-a10 tests-cd
 
 # Single-GPU-safe subset. Suitable for CI environments with one GPU and no
 # GPU Operator (e.g., Lambda Cloud). Excludes test_basics.bats (expects GPU
@@ -206,6 +206,16 @@ tests-gpu-single: runner-image
 		tests/bats/test_gpu_basic.bats \
 		tests/bats/test_gpu_cuda_workloads.bats \
 		tests/bats/test_gpu_dynmig.bats \
+		tests/bats/test_gpu_sharing.bats \
+		tests/bats/test_gpu_robustness.bats \
+		tests/bats/test_gpu_extres.bats)
+
+# Stable single-GPU subset for pinned A10 Lambda CI. Derived from
+# tests-gpu-single, but excludes DynMIG.
+tests-gpu-a10: runner-image
+	$(call RUN_BATS, \
+		tests/bats/test_gpu_basic.bats \
+		tests/bats/test_gpu_cuda_workloads.bats \
 		tests/bats/test_gpu_sharing.bats \
 		tests/bats/test_gpu_robustness.bats \
 		tests/bats/test_gpu_extres.bats)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- add `tests-gpu-a10`, a deterministic A10-safe subset derived from `tests-gpu-single`
- make `hack/ci/lambda/e2e-test.sh` use `BATS_TARGET` instead of hardcoding `tests-gpu-single`

This is based on the [CI Coverage Map](https://gist.github.com/dims/f7c17059cff4549bde78d253971033f1#file-dra-driver-nvidia-gpu-ci-coverage-md), Table 2 (`BATS test × SUITE selector matrix`): the pinned x86 A10 lane should run the existing Lambda-safe GPU subset without DynMIG so the baseline GPU CI stays stable and deterministic.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
This PR keeps the default `BATS_TARGET` as `tests-gpu-single` for backward compatibility. The x86 Lambda jobs will switch to `tests-gpu-a10` in a follow-up `kubernetes/test-infra` change; GH200 behavior is unchanged by this PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE