### PR TITLE
change distroless base image 

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -111,12 +111,11 @@ RUN cd /bashbuild/bash-static/releases && ./bash*-static --version && mv bash-*-
 FROM ${TOOLKIT_CONTAINER_IMAGE} AS toolkit
 
 # Construct production image (arch: TARGETPLATFORM, set via the `--platform` CLI
-# arg). Note that nvcr.io/nvidia/distroless/cc is based on
-# https://github.com/GoogleContainerTools/distroless; specifically on debian12.
-# For consistency, the build stage above derives from Debian 12 directly. The
-# `-dev` suffic is to get busybox as a shell added. For RUN directives to pick
-# that up, use `SHELL ["/busybox/sh", "-c"]`.
-FROM nvcr.io/nvidia/distroless/cc:v4.0.4-dev
+# arg). gcr.io/distroless/cc:debug is distroless/cc plus busybox at /busybox/
+# (PATH includes /busybox). The scripts bundled in this image (kubelet-plugin-
+# prestart.sh, bind_to_driver.sh, unbind_from_driver.sh) require coreutils
+# (ln, find, date, sleep, head, env, readlink, basename) provided by busybox.
+FROM gcr.io/distroless/cc:debug
 
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all

--- a/hack/kubelet-plugin-prestart.sh
+++ b/hack/kubelet-plugin-prestart.sh
@@ -79,7 +79,7 @@ validate_and_exit_on_success () {
     fi
 
     # Log top-level entries in /driver-root (this may be valuable debug info).
-    echo "current contents: [$(/bin/ls -1xAw0 /driver-root 2>/dev/null)]."
+    echo "current contents: [$(ls -1xAw0 /driver-root 2>/dev/null)]."
 
     if [ -n "${NV_PATH}" ] && [ -n "${NV_LIB_PATH}" ]; then
         # Run with clean environment (only LD_PRELOAD; nvidia-smi has only this


### PR DESCRIPTION
- Change from nvcr.io to one from gcr.io
- we already copy the static-bash from build image, so /bin/bash will get executed alright
- this will break any usage of /busybox/sh within the container

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

We need this PR to comply with best practices in community wrt distroless base images

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Fixes #1072 

#### Special notes for your reviewer:
Will break any calls to /busybox/sh as our previous base image used a `-dev` version.

#### Does this PR introduce a user-facing change?
NONE
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note

```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
