### PR TITLE
Make 'numNodes' field optional in the ComputeDomain API  with the support of IMEXDaemonsWithDNSNames feature

### DIFF
--- a/api/nvidia.com/resource/v1beta1/computedomain.go
+++ b/api/nvidia.com/resource/v1beta1/computedomain.go
@@ -65,7 +65,7 @@ type ComputeDomainSpec struct {
 	// ComputeDomain. Must be zero or greater.
 	//
 	// With `featureGates.IMEXDaemonsWithDNSNames=true` (the default), this is
-	// recommended to be set to zero. Workload must implement and consult its
+	// recommended to be set to zero (default). Workload must implement and consult its
 	// own source of truth for the number of workers online before trying to
 	// share GPU memory (and hence triggering IMEX interaction). When non-zero,
 	// `numNodes` is used only for automatically updating the global
@@ -85,7 +85,10 @@ type ComputeDomainSpec struct {
 	//
 	// The `numNodes` parameter is deprecated and will be removed in the next
 	// API version.
-	NumNodes int                       `json:"numNodes"`
+	// +kubebuilder:default:=0
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Optional
+	NumNodes int                       `json:"numNodes,omitempty"`
 	Channel  *ComputeDomainChannelSpec `json:"channel"`
 }
 

--- a/deployments/helm/dra-driver-nvidia-gpu/crds/resource.nvidia.com_computedomains.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/crds/resource.nvidia.com_computedomains.yaml
@@ -66,12 +66,13 @@ spec:
                 - resourceClaimTemplate
                 type: object
               numNodes:
+                default: 0
                 description: |-
                   Intended number of IMEX daemons (i.e., individual compute nodes) in the
                   ComputeDomain. Must be zero or greater.
 
                   With `featureGates.IMEXDaemonsWithDNSNames=true` (the default), this is
-                  recommended to be set to zero. Workload must implement and consult its
+                  recommended to be set to zero (default). Workload must implement and consult its
                   own source of truth for the number of workers online before trying to
                   share GPU memory (and hence triggering IMEX interaction). When non-zero,
                   `numNodes` is used only for automatically updating the global
@@ -91,10 +92,10 @@ spec:
 
                   The `numNodes` parameter is deprecated and will be removed in the next
                   API version.
+                minimum: 0
                 type: integer
             required:
             - channel
-            - numNodes
             type: object
             x-kubernetes-validations:
             - message: A computeDomain.spec is immutable


### PR DESCRIPTION
Make 'numNodes' field optional in the ComputeDomain API  with the support of IMEXDaemonsWithDNSNames feature

* With the IMEXDaemonsWithDNSNames feature enabled by default, 'numNodes' is optional and only used to set the 'Status' to 'Ready' when set to non-zero value.
* Indicate this in the API as currently it is a **required** field where user will have to set explicitly.
* By default set this value to '0' when missing.

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

fixes https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/364
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
`numNodes` is now an optional field in the `ComputeDomain` API. When `IMEXDaemonsWithDNSNames` feature gate is enabled (default), this field can be omitted. When explicitly set to non-zero value, then those semantics will remain same as before.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs
```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [*] `make check test` passes locally
- [*] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [*] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
