### PR TITLE
Fix VFIO discovery and Unconfigure for pre-bound GPUs

### DIFF
--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -98,6 +98,7 @@ type VfioDeviceInfo struct {
 	iommuFDEnabled         bool
 	addressableMemoryBytes uint64
 	vfioModule             string
+	preConfigureDriver     string
 }
 
 // CanonicalName returns the nameused for device announcement (in ResourceSlice

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -644,8 +644,8 @@ func (l deviceLib) enumerateGpuVfioDevices(perGPUAllocatable *PerGPUAllocatableD
 			klog.Warningf("Skipping VFIO device %s: unable to read driver: %v", pci.Address, err)
 			continue
 		}
-		if driver != vfioPciDriver {
-			klog.Infof("Skipping VFIO device %s: bound to %q, not %q", pci.Address, driver, vfioPciDriver)
+		if !strings.Contains(driver, "vfio") {
+			klog.Infof("Skipping VFIO device %s: bound to %q, not a vfio driver", pci.Address, driver)
 			continue
 		}
 

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -639,6 +639,16 @@ func (l deviceLib) enumerateGpuVfioDevices(perGPUAllocatable *PerGPUAllocatableD
 	for idx, pci := range gpuPciDevices {
 		klog.Infof("Adding VFIO device for discovered GPU PCI device: %s", pci.Address)
 
+		driver, err := getDriver(pciDevicesPath, pci.Address)
+		if err != nil {
+			klog.Warningf("Skipping VFIO device %s: unable to read driver: %v", pci.Address, err)
+			continue
+		}
+		if driver != vfioPciDriver {
+			klog.Infof("Skipping VFIO device %s: bound to %q, not %q", pci.Address, driver, vfioPciDriver)
+			continue
+		}
+
 		parent := perGPUAllocatable.GetGPUDeviceByPCIBusID(pci.Address)
 		if parent != nil && !parent.Gpu.vfioEnabled {
 			klog.Infof("Skipping VFIO device for discovered GPU PCI device: %s, vfio is not enabled", pci.Address)

--- a/cmd/gpu-kubelet-plugin/vfio-cdi.go
+++ b/cmd/gpu-kubelet-plugin/vfio-cdi.go
@@ -92,8 +92,7 @@ func (h *vfioCDIHandler) GetDeviceSpecsByPCIBusID(pciBusID string, preferIommuFD
 	devNodes := make([]*cdispec.DeviceNode, 0)
 
 	if preferIommuFD && h.iommuFDEnabled {
-		nvpci := nvpci.New()
-		pciDeviceInfo, err := nvpci.GetGPUByPciBusID(pciBusID)
+		pciDeviceInfo, err := h.deviceLib.nvpci.GetGPUByPciBusID(pciBusID)
 		if err != nil {
 			return nil, fmt.Errorf("error getting PCI device info for GPU %q: %w", pciBusID, err)
 		}

--- a/cmd/gpu-kubelet-plugin/vfio-cdi.go
+++ b/cmd/gpu-kubelet-plugin/vfio-cdi.go
@@ -77,10 +77,6 @@ func (h *vfioCDIHandler) GetCommonEdits(enableAPIDevice bool, preferIommuFD bool
 		edits.DeviceNodes = append(edits.DeviceNodes, &cdispec.DeviceNode{
 			Path: iommuDevicePath,
 		})
-	} else {
-		edits.DeviceNodes = append(edits.DeviceNodes, &cdispec.DeviceNode{
-			Path: filepath.Join(vfioDevicesRoot, "vfio"),
-		})
 	}
 
 	return edits, nil

--- a/cmd/gpu-kubelet-plugin/vfio-cdi.go
+++ b/cmd/gpu-kubelet-plugin/vfio-cdi.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -60,7 +61,13 @@ func (h *vfioCDIHandler) GetCommonEdits(enableAPIDevice bool, preferIommuFD bool
 		},
 	}
 
-	// IOMMU API device is not requested. Exit early.
+	// Always include /dev/vfio/vfio for legacy VFIO — it's required by
+	// libvirt to detect VFIO support. enableAPIDevice controls whether the
+	// preferred IOMMU backend device is also added.
+	edits.DeviceNodes = append(edits.DeviceNodes, &cdispec.DeviceNode{
+		Path: filepath.Join(vfioDevicesRoot, "vfio"),
+	})
+
 	if !enableAPIDevice {
 		return edits, nil
 	}
@@ -86,17 +93,14 @@ func (h *vfioCDIHandler) GetCommonEdits(enableAPIDevice bool, preferIommuFD bool
 // We automatically assume we want the legacy device if PreferIommuFD policy is not selected.
 // If more policies are added in the future, the handler needs to be enhanced to support them.
 func (h *vfioCDIHandler) GetDeviceSpecsByPCIBusID(pciBusID string, preferIommuFD bool) ([]cdispec.Device, error) {
-	pciDeviceInfo, err := h.deviceLib.nvpci.GetGPUByPciBusID(pciBusID)
-	if err != nil {
-		return nil, fmt.Errorf("error getting PCI device info for GPU %q: %w", pciBusID, err)
-	}
-
 	devNodes := make([]*cdispec.DeviceNode, 0)
 
 	if preferIommuFD && h.iommuFDEnabled {
-		// The IOMMUFD cdev is located at /dev/vfio/devices/<vfioX> and is
-		// expected to be available if IOMMUFD is enabled on the node and the GPU is
-		// bound to the vfio driver.
+		nvpci := nvpci.New()
+		pciDeviceInfo, err := nvpci.GetGPUByPciBusID(pciBusID)
+		if err != nil {
+			return nil, fmt.Errorf("error getting PCI device info for GPU %q: %w", pciBusID, err)
+		}
 		if !strings.HasPrefix(pciDeviceInfo.IommuFD, "vfio") {
 			return nil, fmt.Errorf("missing iommufd cdev for GPU %q", pciDeviceInfo.Address)
 		}
@@ -104,8 +108,14 @@ func (h *vfioCDIHandler) GetDeviceSpecsByPCIBusID(pciBusID string, preferIommuFD
 			Path: filepath.Join(vfioDevicesPath, pciDeviceInfo.IommuFD),
 		})
 	} else {
+		// Read IOMMU group directly from sysfs — works for GPUs on any
+		// driver including vfio-pci (nvpci may not find vfio-bound GPUs).
+		iommuGroup, err := getIommuGroupFromSysfs(pciBusID)
+		if err != nil {
+			return nil, fmt.Errorf("error getting IOMMU group for GPU %q: %w", pciBusID, err)
+		}
 		devNodes = append(devNodes, &cdispec.DeviceNode{
-			Path: filepath.Join(vfioDevicesRoot, fmt.Sprintf("%d", pciDeviceInfo.IommuGroup)),
+			Path: filepath.Join(vfioDevicesRoot, iommuGroup),
 		})
 	}
 	devSpecs := []cdispec.Device{
@@ -116,4 +126,13 @@ func (h *vfioCDIHandler) GetDeviceSpecsByPCIBusID(pciBusID string, preferIommuFD
 		},
 	}
 	return devSpecs, nil
+}
+
+func getIommuGroupFromSysfs(pciBusID string) (string, error) {
+	iommuLink := filepath.Join(pciDevicesPath, pciBusID, "iommu_group")
+	target, err := os.Readlink(iommuLink)
+	if err != nil {
+		return "", fmt.Errorf("failed to read IOMMU group symlink for %s: %w", pciBusID, err)
+	}
+	return filepath.Base(target), nil
 }

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -210,7 +210,7 @@ func (vm *VfioPciManager) Unconfigure(ctx context.Context, info *VfioDeviceInfo)
 	// If the GPU was already on vfio-pci before Configure (pre-bound at
 	// boot), leave it on vfio-pci. Rebinding to nvidia on NVLink systems
 	// hangs indefinitely during fabric reconfiguration.
-	if info.preConfigureDriver == vfioPciDriver {
+	if info.preConfigureDriver == getVfioDriverName(info.vfioModule) {
 		klog.Infof("GPU %s was pre-bound to vfio-pci, leaving on vfio-pci", info.PciBusID)
 		return nil
 	}

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -140,6 +140,7 @@ func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) e
 	if err != nil {
 		return fmt.Errorf("error getting driver details for GPU %q: %w", info.PciBusID, err)
 	}
+	info.preConfigureDriver = driver
 
 	vfioDriver := getVfioDriverName(info.vfioModule)
 
@@ -203,6 +204,14 @@ func getVfioDriverName(vfioModule string) string {
 func (vm *VfioPciManager) Unconfigure(ctx context.Context, info *VfioDeviceInfo) error {
 	// Do nothing if we dont expect to switch to nvidia driver.
 	if !vm.nvidiaEnabled {
+		return nil
+	}
+
+	// If the GPU was already on vfio-pci before Configure (pre-bound at
+	// boot), leave it on vfio-pci. Rebinding to nvidia on NVLink systems
+	// hangs indefinitely during fabric reconfiguration.
+	if info.preConfigureDriver == vfioPciDriver {
+		klog.Infof("GPU %s was pre-bound to vfio-pci, leaving on vfio-pci", info.PciBusID)
 		return nil
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes two bugs in the VFIO passthrough lifecycle:

1. **VFIO discovery advertises non-vfio GPUs** — `enumerateGpuVfioDevices` treats any GPU not on the nvidia driver as a VFIO candidate, including GPUs still bound to nvidia. On a system with 2 A40s (one on nvidia, one on vfio-pci), both are advertised as VFIO devices. If the scheduler allocates the nvidia-bound GPU, Configure has to unbind and rebind at runtime, which can hang on NVLink systems. The fix adds a `getDriver()` check — only GPUs actually bound to `vfio-pci` are advertised.

2. **Unconfigure rebinds pre-bound GPUs** — When a GPU was already on `vfio-pci` before `Configure` ran (pre-bound at boot), `Unconfigure` tries to rebind it to nvidia, which hangs indefinitely on NVLink systems during fabric reconfiguration. The fix tracks the pre-Configure driver binding and skips the rebind if the GPU was already on `vfio-pci`.

#### Changes from v1:

Reworked based on @varunrsekar's feedback:
- **Dropped** `/dev/vfio/vfio` CDI change — use DeviceClass config with `enableAPIDevice: true` instead
- **Dropped** sysfs fallback for vfio_pci/IOMMU checks — helm chart deployment mounts `/host-root` correctly
- **Dropped** `vfio-pci.ids` kernel cmdline detection — will file as separate feature request
- **Kept** VFIO discovery driver filter (issue 2) and `preConfigureDriver` tracking (issue 3)

#### How to verify it:

On a multi-GPU system with some GPUs on nvidia and some on vfio-pci:
- Before fix: all GPUs appear as `gpu-vfio-*` in ResourceSlice regardless of driver binding
- After fix: only GPUs bound to `vfio-pci` appear as `gpu-vfio-*`

**Which issue(s) this PR fixes:**

Fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1089 (issues 2 and 3)

```release-note
Fix VFIO device discovery to only advertise GPUs bound to vfio-pci, and skip Unconfigure rebind for pre-bound GPUs.
```