### PR TITLE
Re-use prebuilt bash binary from existing image to avoid flaky builds

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -96,15 +96,15 @@ RUN --mount=type=cache,target=/mc/go/build-cache,id=gocache \
 # Choose: 1) fresh bash build or 2) use binary from previous image
 #
 # option 1:
-ARG BASH_STATIC_GIT_REF=021f5f29f665c92ca16a369d9f27e288c3aed0c6
-ENV BASH_STATIC_GIT_REF=${BASH_STATIC_GIT_REF}
-WORKDIR /bashbuild
-COPY hack/build-bash-static.sh .
-RUN bash /bashbuild/build-bash-static.sh
-RUN cd /bashbuild/bash-static/releases && ./bash*-static --version && mv bash-*-static /bashbuild/bash && file /bashbuild/bash
+#ARG BASH_STATIC_GIT_REF=021f5f29f665c92ca16a369d9f27e288c3aed0c6
+#ENV BASH_STATIC_GIT_REF=${BASH_STATIC_GIT_REF}
+#WORKDIR /bashbuild
+#COPY hack/build-bash-static.sh .
+#RUN bash /bashbuild/build-bash-static.sh
+#RUN cd /bashbuild/bash-static/releases && ./bash*-static --version && mv bash-*-static /bashbuild/bash && file /bashbuild/bash
 
 # option 2:
-# FROM registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu:v25.12.0-dev-839e966a AS bash
+FROM us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia/dra-driver-nvidia-gpu:v0.4.0-dev-b88d6793 AS bash
 
 # Pull the nvidia-cdi-hook binary out of the relevant toolkit container
 # (arch: TARGETPLATFORM, set via --platform).
@@ -138,10 +138,10 @@ LABEL org.opencontainers.image.source="https://github.com/kubernetes-sigs/dra-dr
 COPY LICENSE /
 
 # option 1: fresh bash build
-COPY --from=build   /bashbuild/bash                           /bin/bash
+#COPY --from=build   /bashbuild/bash                           /bin/bash
 
 # option 2: bash from previous image
-# COPY --from=bash    /bin/bash                                 /bin/bash
+COPY --from=bash    /bin/bash                                 /bin/bash
 
 COPY --from=toolkit /artifacts/rpm/usr/bin/nvidia-cdi-hook    /usr/bin/nvidia-cdi-hook
 COPY --from=build   /artifacts/compute-domain-controller      /usr/bin/compute-domain-controller


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

/kind cleanup
#### What this PR does / why we need it:

The builds of bash have become very flakey lately, this PR re-uses pre-built binary from existing driver images in the CI than building it everytime to avoid that.

Build issues seen: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_dra-driver-nvidia-gpu/1101/pull-dra-driver-nvidia-gpu-e2e-gcp-nvkind/2051539919616086016

```
------
 > [build 18/19] RUN bash /bashbuild/build-bash-static.sh:
581.7 Ign:15 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages
582.6 Building dependency tree...
582.7 Reading state information...
582.7 Package autoconf is not available, but is referred to by another package.
582.7 This may mean that the package is missing, has been obsoleted, or
582.7 is only available from another source
582.7 
582.7 E: Package 'autoconf' has no installation candidate
------
ERROR: failed to build: failed to solve: process "/bin/sh -c bash /bashbuild/build-bash-static.sh" did not complete successfully: exit code: 100
make: *** [deployments/container/Makefile:90: build] Error 1
cleanup rc=2
```

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

Relates to https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/912 which avoids using a shell in the container.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note

```

/release-note-none

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [*] `make check test` passes locally
- [*] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [*] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
