### PR TITLE
check if a device is MIG capable

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -1248,3 +1248,14 @@ func (s *DeviceState) AddDeviceTaint(d *AllocatableDevice, taint *resourceapi.De
 	defer s.Unlock()
 	return d.AddOrUpdateTaint(taint)
 }
+
+// Returns false on nodes where GPU hardware is not MIG capable (L4/Ada,T4/Turing)
+// Used by the driver at startup to gate the DynamicMIG-specific code paths.
+func (s *DeviceState) IsMigCapable() bool {
+	for _, gpu := range s.nvdevlib.gpuInfosByUUID {
+		if gpu.migCapable {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -31,6 +31,7 @@ import (
 type GpuInfo struct {
 	UUID                  string `json:"uuid"`
 	minor                 int
+	migCapable            bool
 	migEnabled            bool
 	vfioEnabled           bool
 	memoryBytes           uint64

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -76,42 +76,46 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	useSplitSlices := false
 
 	if featuregates.Enabled(featuregates.DynamicMIG) {
-		// Could be done in NewDeviceState, but I want to make sure that the
-		// checkpoint machinery is ready to use -- that's more obvious here.
-		//
-		// Generally, when `featuregates.DynamicMIG` is enabled, we have to make
-		// difficult but good decisions about incarnated MIG devices found
-		// during program startup. We could
-		//
-		// 1) assume they are under control of an external entity, and not
-		// announce them. That's likely not true. As hard as we try, as part of
-		// dynamic MIG device management, given enough time and circumstances,
-		// we might actually leave a MIG device behind where we shouldn't (as of
-		// bugs, as of aggressive operations / admin intervention, ...).
-		//
-		// 2) not do anythin special: not good; we would still announce the
-		// corresponding abstract MIG device and once the scheduler assigns a
-		// job, a relevant NodePrepareResources() call will try to create that
-		// specific MIG device. And that will fail, because that MIG device
-		// already exists -- users see something like "prepare devices failed:
-		// error creating MIG device: error creating GPU instance for
-		// 'gpu-0-mig-1g24gb-0': Insufficient Resources.
-		//
-		// 3) Use the node-local checkpoint as the source of truth. Any MIG
-		// device that corresponds to "partially prepared" claims should be
-		// destroyed, and any MIG device that is not mentioned in the checkpoint
-		// at all must be destroyed). Both is done below. Only those of
-		// completely prepared claims can stay; assuming that the central
-		// scheduler state is equivalent. TODO: review if this logic is correct;
-		// or if it potentially is too invasive for certain edge cases.
-		state.DestroyUnknownMIGDevices(ctx)
+		if !state.IsMigCapable() {
+			klog.Warningf("DynamicMIG enabled but no MIG capable GPU found on this node; falling back to legacy Full GPU support")
+		} else {
+			// Could be done in NewDeviceState, but I want to make sure that the
+			// checkpoint machinery is ready to use -- that's more obvious here.
+			//
+			// Generally, when `featuregates.DynamicMIG` is enabled, we have to make
+			// difficult but good decisions about incarnated MIG devices found
+			// during program startup. We could
+			//
+			// 1) assume they are under control of an external entity, and not
+			// announce them. That's likely not true. As hard as we try, as part of
+			// dynamic MIG device management, given enough time and circumstances,
+			// we might actually leave a MIG device behind where we shouldn't (as of
+			// bugs, as of aggressive operations / admin intervention, ...).
+			//
+			// 2) not do anythin special: not good; we would still announce the
+			// corresponding abstract MIG device and once the scheduler assigns a
+			// job, a relevant NodePrepareResources() call will try to create that
+			// specific MIG device. And that will fail, because that MIG device
+			// already exists -- users see something like "prepare devices failed:
+			// error creating MIG device: error creating GPU instance for
+			// 'gpu-0-mig-1g24gb-0': Insufficient Resources.
+			//
+			// 3) Use the node-local checkpoint as the source of truth. Any MIG
+			// device that corresponds to "partially prepared" claims should be
+			// destroyed, and any MIG device that is not mentioned in the checkpoint
+			// at all must be destroyed). Both is done below. Only those of
+			// completely prepared claims can stay; assuming that the central
+			// scheduler state is equivalent. TODO: review if this logic is correct;
+			// or if it potentially is too invasive for certain edge cases.
+			state.DestroyUnknownMIGDevices(ctx)
 
-		// Read Kubernetes API server version to determine which ResourceSlice
-		// model to use.
-		var err error
-		useSplitSlices, err = shouldUseSplitResourceSlices(config.clientsets.Core)
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine ResourceSlice model: %w", err)
+			// Read Kubernetes API server version to determine which ResourceSlice
+			// model to use.
+			var err error
+			useSplitSlices, err = shouldUseSplitResourceSlices(config.clientsets.Core)
+			if err != nil {
+				return nil, fmt.Errorf("failed to determine ResourceSlice model: %w", err)
+			}
 		}
 	}
 

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -463,10 +463,17 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting UUID for device %d: %v", index, ret)
 	}
+
+	migCapable, err := device.IsMigCapable()
+	if err != nil {
+		return nil, fmt.Errorf("error checking MIG capability for device %d: %w", index, err)
+	}
+
 	migEnabled, err := device.IsMigEnabled()
 	if err != nil {
 		return nil, fmt.Errorf("error checking if MIG mode enabled for device %d: %w", index, err)
 	}
+
 	memory, ret := device.GetMemoryInfo()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting memory info for device %d: %v", index, ret)
@@ -583,6 +590,7 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 	gpuInfo := &GpuInfo{
 		UUID:                  uuid,
 		minor:                 minor,
+		migCapable:            migCapable,
 		migEnabled:            migEnabled,
 		memoryBytes:           memory.Total,
 		productName:           productName,
@@ -1453,6 +1461,11 @@ func supportsMIGModeToggle(dev nvml.Device) bool {
 }
 
 func isDynamicMIGCapable(gpuInfo *GpuInfo, dev nvdev.Device) (bool, error) {
+	if !gpuInfo.migCapable {
+		klog.Warningf("GPU %s: hardware does not support MIG - skipping DynamicMIG", gpuInfo.String())
+		return false, nil
+	}
+
 	vMode, vret := dev.GetVirtualizationMode()
 	if vret != nvml.SUCCESS {
 		return false, fmt.Errorf("error getting GPU virtualization mode: %v", vret)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
On nodes whose GPUs do not support MIG (L4/Ada, T4/Turing, vGPU guests), the kubelet plugin currently runs the full DynamicMIG code path whenever the cluster-wide DynamicMIG feature gate is on. That produces invalid ResourceSlice objects and noisy NVML errors, leaving the node unable to publish any allocatable GPUs.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1092

#### Special notes for your reviewer:
Per-node decision, not per-cluster: DynamicMIG is a global Helm value; the degradation lives in the kubelet plugin so each node makes its own call.

#### Does this PR introduce a user-facing change?
None

/release-note-none
