### PR TITLE
Skip staging registry replacement in the helm chart for tagged releases

### DIFF
--- a/hack/build-and-publish-chart.sh
+++ b/hack/build-and-publish-chart.sh
@@ -47,17 +47,21 @@ if ! command -v helm >/dev/null 2>&1; then
 	curl -sSfLO --retry 8 --retry-all-errors --connect-timeout 10 --retry-delay 5 \
 		https://get.helm.sh/helm-v3.18.6-linux-amd64.tar.gz
 	tar -zxvf helm-v3*linux-amd64.tar.gz
-	sudo mv linux-amd64/helm /usr/local/bin/helm
+	mv linux-amd64/helm /usr/local/bin/helm
 fi
 
 mkdir -p "${DIST_DIR}"
 rm -f "${DIST_DIR}/${DRIVER_NAME}-"*.tgz
 
-# Staging image registry for charts built in CI / Cloud Build.
+# Staging image registry swap for non-release builds only. Tagged (release) builds
+# keep registry.k8s.io/dra-driver-nvidia in values.yaml for promoted charts.
 VALUES="${REPO_ROOT}/deployments/helm/${DRIVER_NAME}/values.yaml"
-sed -i 's|registry.k8s.io/dra-driver-nvidia|us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia|g' "${VALUES}"
-rm -f "${VALUES}.bak"
-git diff || echo "ignore git diff exit code"
+if git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+	echo "Tagged release build: skipping staging registry rewrite in values.yaml"
+else
+	sed -i 's|registry.k8s.io/dra-driver-nvidia|us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia|g' "${VALUES}"
+	git diff || echo "ignore git diff exit code"
+fi
 
 "${HELM}" package "deployments/helm/${DRIVER_NAME}" \
 	--version "${CHART_VERSION}" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind cleanup
#### What this PR does / why we need it:
This change skips the replacement of staging registry for final release charts as they will be promoted to `registry.k8s.io`. For non-release builds, the registry in the helm chart is replaced with the staging registry.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
/release-note-none

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
