### PR TITLE
GPU plugin: fix upgrade errors as of newly added fields, add tests

### DIFF
--- a/cmd/gpu-kubelet-plugin/checkpointv.go
+++ b/cmd/gpu-kubelet-plugin/checkpointv.go
@@ -17,10 +17,44 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
+
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 )
+
+// CheckpointedDevice shares kubeletplugin.Device's layout, i.e.
+// kubeletplugin.Device(c) can be done as a no-op cast. We can't serialize
+// `kubeletplugin.Device` directly anymore for creating a checkpoint or for
+// deserializing from a checkpoint: a field added upstream to `Device` without
+// `omitempty` causes re-serialization of an older checkpoint to include that
+// field with an empty value. That changes the newly computed checksum compared
+// to the one encoded in the checkpoint, resulting in the old checkpoint being
+// rejected by the new binary. Circumvent that by adding the `omitempty`
+// annotations here for `ShareID` and `Metadata` which were added as part of the
+// k8s 1.36 release cycle. Also see issue 1080.
+type CheckpointedDevice kubeletplugin.Device
+
+func (c CheckpointedDevice) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Requests     []string                      `json:"Requests"`
+		PoolName     string                        `json:"PoolName"`
+		DeviceName   string                        `json:"DeviceName"`
+		CDIDeviceIDs []string                      `json:"CDIDeviceIDs"`
+		ShareID      *types.UID                    `json:"ShareID,omitempty"`
+		Metadata     *kubeletplugin.DeviceMetadata `json:"Metadata,omitempty"`
+	}{
+		Requests:     c.Requests,
+		PoolName:     c.PoolName,
+		DeviceName:   c.DeviceName,
+		CDIDeviceIDs: c.CDIDeviceIDs,
+		ShareID:      c.ShareID,
+		Metadata:     c.Metadata,
+	})
+}
 
 type ClaimCheckpointState string
 

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -17,19 +17,26 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/pmezard/go-difflib/difflib"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	cperrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 
 	"github.com/sirupsen/logrus"
@@ -591,11 +598,45 @@ func (s *DeviceState) getCheckpoint(ctx context.Context) (*Checkpoint, error) {
 
 	checkpoint := &Checkpoint{}
 	if err := s.checkpointManager.GetCheckpoint(DriverPluginCheckpointFileBasename, checkpoint); err != nil {
+		if errors.Is(err, cperrors.CorruptCheckpointError{}) {
+			logCheckpointDiff(s.config.DriverPluginPath(), checkpoint)
+		}
 		return nil, err
 	}
 
 	klog.V(7).Info("checkpoint read")
 	return checkpoint.ToLatestVersion(), nil
+}
+
+// logCheckpointDiff is invoked when GetCheckpoint returns
+// CorruptCheckpointError: the on-disk JSON deserialized cleanly but the
+// checksum recomputed at verification time disagrees with the one encoded in
+// the file. The typical cause is a backward-incompatible field addition
+// somewhere in the checkpoint type graph (see issue 1080). Emit a unified diff
+// between the on-disk bytes and what the current binary would re-marshal, so an
+// operator can spot the offending fields immediately.
+func logCheckpointDiff(driverPluginPath string, deserialized *Checkpoint) {
+	ondisk, rerr := os.ReadFile(filepath.Join(driverPluginPath, DriverPluginCheckpointFileBasename))
+	remarshaled, merr := json.Marshal(deserialized)
+	if rerr != nil || merr != nil {
+		klog.Errorf("checkpoint failed checksum verification; diagnostic dump unavailable (readErr=%v, marshalErr=%v)", rerr, merr)
+		return
+	}
+	var a, b bytes.Buffer
+	_ = json.Indent(&a, ondisk, "", "  ")
+	_ = json.Indent(&b, remarshaled, "", "  ")
+	diff, derr := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        strings.SplitAfter(a.String(), "\n"),
+		B:        strings.SplitAfter(b.String(), "\n"),
+		FromFile: "on-disk",
+		ToFile:   "re-marshaled",
+		Context:  3,
+	})
+	if derr != nil {
+		klog.Errorf("checkpoint failed checksum verification; diff computation failed: %v. on-disk: %s. re-marshaled: %s", derr, ondisk, remarshaled)
+		return
+	}
+	klog.Errorf("checkpoint failed checksum verification; unified diff (on-disk vs re-marshaled by current binary):\n%s", diff)
 }
 
 // Read checkpoint from store, perform mutation, and write checkpoint back. Any
@@ -784,7 +825,7 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 				cdiDevices = append(cdiDevices, d)
 			}
 
-			device := &kubeletplugin.Device{
+			device := &CheckpointedDevice{
 				Requests:     []string{result.Request},
 				PoolName:     result.Pool,
 				DeviceName:   result.Device,

--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -82,13 +82,15 @@ type MigDeviceInfo struct {
 }
 
 type VfioDeviceInfo struct {
-	UUID                   string `json:"uuid"`
-	deviceID               string
-	vendorID               string
-	index                  int
-	parent                 *GpuInfo
-	productName            string
-	PciBusID               string `json:"pciBusID"`
+	UUID        string `json:"uuid"`
+	deviceID    string
+	vendorID    string
+	index       int
+	parent      *GpuInfo
+	productName string
+	// `omitempty`: postdates 25.12.0; emitting "pciBusID":"" would trip
+	// CorruptCheckpointError on upgrade. See issue 1080.
+	PciBusID               string `json:"pciBusID,omitempty"`
 	pciBusIDAttr           *deviceattribute.DeviceAttribute
 	pcieRootAttr           *deviceattribute.DeviceAttribute
 	numaNode               int

--- a/cmd/gpu-kubelet-plugin/mig.go
+++ b/cmd/gpu-kubelet-plugin/mig.go
@@ -72,8 +72,10 @@ type MigLiveTuple struct {
 	MigUUID     string   `json:"migUUID"`
 
 	// Not orthogonal to `ParentMinor`, but convenient for consumers.
-	ParentUUID     string   `json:"parentUUID"`
-	ParentPCIBusID PCIBusID `json:"parentPCIBusID"`
+	ParentUUID string `json:"parentUUID"`
+	// `omitempty`: postdates 25.12.0; emitting "parentPCIBusID":"" would
+	// trip CorruptCheckpointError on upgrade. See issue 1080.
+	ParentPCIBusID PCIBusID `json:"parentPCIBusID,omitempty"`
 }
 
 // MigSpec is similar to `MigSpecTuple` as it also fundamentally encodes the

--- a/cmd/gpu-kubelet-plugin/prepared.go
+++ b/cmd/gpu-kubelet-plugin/prepared.go
@@ -41,8 +41,8 @@ type PreparedDevice struct {
 }
 
 type PreparedGpu struct {
-	Info   *GpuInfo              `json:"info"`
-	Device *kubeletplugin.Device `json:"device"`
+	Info   *GpuInfo            `json:"info"`
+	Device *CheckpointedDevice `json:"device"`
 }
 
 type PreparedMigDevice struct {
@@ -50,13 +50,13 @@ type PreparedMigDevice struct {
 	// Note that this is either created via the 'static MIG' flow or the
 	// 'dynamic MIG' flow -- in any case, it represents a MIG device that
 	// currently exists (incarnated, concrete).
-	Concrete *MigLiveTuple         `json:"concrete"`
-	Device   *kubeletplugin.Device `json:"device"`
+	Concrete *MigLiveTuple       `json:"concrete"`
+	Device   *CheckpointedDevice `json:"device"`
 }
 
 type PreparedVfioDevice struct {
-	Info   *VfioDeviceInfo       `json:"info"`
-	Device *kubeletplugin.Device `json:"device"`
+	Info   *VfioDeviceInfo     `json:"info"`
+	Device *CheckpointedDevice `json:"device"`
 }
 
 type PreparedDeviceGroup struct {
@@ -141,11 +141,11 @@ func (g *PreparedDeviceGroup) GetDevices() []kubeletplugin.Device {
 	for _, device := range g.Devices {
 		switch device.Type() {
 		case GpuDeviceType:
-			devices = append(devices, *device.Gpu.Device)
+			devices = append(devices, kubeletplugin.Device(*device.Gpu.Device))
 		case PreparedMigDeviceType:
-			devices = append(devices, *device.Mig.Device)
+			devices = append(devices, kubeletplugin.Device(*device.Mig.Device))
 		case VfioDeviceType:
-			devices = append(devices, *device.Vfio.Device)
+			devices = append(devices, kubeletplugin.Device(*device.Vfio.Device))
 		}
 	}
 	return devices

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/controller.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/controller.yaml
@@ -35,6 +35,7 @@ spec:
       labels:
         {{- include "dra-driver-nvidia-gpu.templateLabels" . | nindent 8 }}
         {{- include "dra-driver-nvidia-gpu.selectorLabels" (dict "context" . "componentName" "controller") | nindent 8 }}
+        nvidia-dra-driver-gpu-component: controller
     spec:
       {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}
@@ -81,7 +82,7 @@ spec:
               fieldPath: metadata.name
         - name: NAMESPACE
           valueFrom:
-            fieldRef: 
+            fieldRef:
               fieldPath: metadata.namespace
         - name: IMAGE_NAME
           value: {{ include "dra-driver-nvidia-gpu.fullimage" . }}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -38,6 +38,7 @@ spec:
       labels:
         {{- include "dra-driver-nvidia-gpu.templateLabels" . | nindent 8 }}
         {{- include "dra-driver-nvidia-gpu.selectorLabels" (dict "context" . "componentName" "kubelet-plugin") | nindent 8 }}
+        nvidia-dra-driver-gpu-component: kubelet-plugin
     spec:
       {{- if .Values.kubeletPlugin.priorityClassName }}
       priorityClassName: {{ .Values.kubeletPlugin.priorityClassName }}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/pflag v1.0.10
@@ -62,7 +63,6 @@ require (
 	github.com/opencontainers/runc v1.4.0 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/opencontainers/runtime-tools v0.9.1-0.20251114084447-edf4cb3d2116 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -20,7 +20,7 @@ TEST_CHART_REPO ?= "oci://gcr.io/k8s-staging-nvidia/charts/dra-driver-nvidia-gpu
 TEST_CHART_VERSION ?= "$(VERSION_STAGING_CHART)"
 
 # The baseline Helm chart to test upgrades from and downgrades to.
-TEST_CHART_LASTSTABLE_REPO ?= "oci://gcr.io/k8s-staging-nvidia/charts/dra-driver-nvidia-gpu"
+TEST_CHART_LASTSTABLE_REPO ?= "oci://ghcr.io/nvidia/k8s-dra-driver-gpu"
 TEST_CHART_LASTSTABLE_VERSION ?= "25.12.0-0882da87-chart"
 
 # If not "false": the to-be-tested Helm chart is installed from the local

--- a/tests/bats/helpers.sh
+++ b/tests/bats/helpers.sh
@@ -85,8 +85,10 @@ iupgrade_wait() {
   # not natively supported by `kubectl wait`, hence this must be something of
   # the shape
   # `kubectl get pods ... | xargs -I{} kubectl wait --for=condition=Ready pod/{} `
+  # TODO: change `nvidia-dra-driver-gpu-component` when last stable supports both, the
+  # new and the old label key
   sleep 1
-  kubectl wait --for=condition=READY pods -A -l dra-driver-nvidia-gpu-component=kubelet-plugin --timeout=15s
+  kubectl wait --for=condition=READY pods -A -l nvidia-dra-driver-gpu-component=kubelet-plugin --timeout=15s
 
   # Again, log current state.
   kubectl get pods -n dra-driver-nvidia-gpu
@@ -94,7 +96,7 @@ iupgrade_wait() {
   # That one should be obvious now, but make that guarantee explicit for
   # consuming tests. Skip when compute domains are disabled (no controller deployment).
   if [ "${DISABLE_COMPUTE_DOMAINS:-}" != "true" ]; then
-    kubectl wait --for=condition=READY pods -A -l dra-driver-nvidia-gpu-component=controller --timeout=10s
+    kubectl wait --for=condition=READY pods -A -l nvidia-dra-driver-gpu-component=controller --timeout=10s
   fi
   # maybe: check version on labels (to confirm that we set labels correctly)
   log "iupgrade_wait: done"

--- a/tests/bats/test_gpu_updowngrade.bats
+++ b/tests/bats/test_gpu_updowngrade.bats
@@ -26,8 +26,8 @@ bats::on_failure() {
 
 
 # bats test_tags=fastfeedback
-@test "GPUs: upgrade: wipe-state, install-last-stable, upgrade-to-current-dev" {
-  if [ "${MOCK_NVML:-}" = "true" ]; then skip "requires last-stable image from registry"; fi
+@test "GPUs: upgrade: wipe-state, install-last-stable, upgrade-to-current-dev (simple GPU)" {
+  if [ "${MOCK_NVML:-}" = "true" ]; then skip "MOCK_NVML is set"; fi
   # Stage 1: clean slate
   helm uninstall "${TEST_HELM_RELEASE_NAME}" -n dra-driver-nvidia-gpu --wait --timeout=30s
   kubectl wait --for=delete pods -A -l app.kubernetes.io/name=dra-driver-nvidia-gpu --timeout=10s
@@ -48,6 +48,21 @@ bats::on_failure() {
   assert_output --partial "UUID: GPU-"
   echo "${output}" | wc -l | grep 1
 
+  # Capture the checkpoint content written by last-stable (valuable debug input
+  # if the checkpoint upgrade breaks).
+  local _node _kpod
+  _node=$(kubectl get pod "${_podname}" -o jsonpath='{.spec.nodeName}')
+  log "workload runs on node: ${_node}"
+  _kpod=$(kubectl get pods -n dra-driver-nvidia-gpu \
+    -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+    --field-selector spec.nodeName="${_node}" \
+    -o jsonpath='{.items[0].metadata.name}')
+  log "kubelet-plugin pod on that node: ${_kpod}"
+  log "checkpoint.json written by last-stable:"
+  kubectl exec -n dra-driver-nvidia-gpu "${_kpod}" -c gpus -- \
+    cat /var/lib/kubelet/plugins/gpu.nvidia.com/checkpoint.json
+  echo
+
   # Stage 4: update CRD, as a user would do.
   kubectl apply -f "${CRD_UPGRADE_URL}"
 
@@ -65,4 +80,155 @@ bats::on_failure() {
   assert_output --partial "UUID: GPU-"
   kubectl delete -f  "${_specpath}"
   kubectl wait --for=delete pods "${_podname}" --timeout=15s
+}
+
+
+# bats test_tags=fastfeedback
+@test "GPUs: upgrade: wipe-state, install-last-stable, upgrade-to-current-dev (DynMIG)" {
+  if [ "${MOCK_NVML:-}" = "true" ]; then skip "MOCK_NVML is set"; fi
+
+  # DynamicMIG must be enabled in both last-stable and current dev installs.
+  local _iargs=("--set" "featureGates.DynamicMIG=true")
+
+  mig_confirm_disabled_on_all_nodes
+
+  # Stage 1: clean slate
+  helm uninstall "${TEST_HELM_RELEASE_NAME}" -n dra-driver-nvidia-gpu --wait --timeout=30s
+  kubectl wait --for=delete pods -A -l app.kubernetes.io/name=dra-driver-nvidia-gpu --timeout=10s
+  bash tests/bats/clean-state-dirs-all-nodes.sh
+  kubectl get crd computedomains.resource.nvidia.com
+  timeout -v 10 kubectl delete crd computedomains.resource.nvidia.com
+
+  # Stage 2: install last-stable (this guarantees to install the "old" CRD)
+  iupgrade_wait "${TEST_CHART_LASTSTABLE_REPO}" "${TEST_CHART_LASTSTABLE_VERSION}" _iargs
+
+  # Stage 3: apply workload, do not delete (users care about old workloads to
+  # ideally still run, but at the very least be deletable after upgrade).
+  local _specpath="tests/bats/specs/gpu-simple-mig.yaml"
+  local _podname="pod-mig1g"
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=15s
+  run kubectl logs "${_podname}"
+  assert_output --partial "UUID: MIG-"
+  assert_output --partial "UUID: GPU-"
+  echo "${output}" | wc -l | grep 2
+
+  # Capture the checkpoint content written by last-stable (valuable debug input
+  # if the checkpoint upgrade breaks).
+  local _node _kpod
+  _node=$(kubectl get pod "${_podname}" -o jsonpath='{.spec.nodeName}')
+  log "workload runs on node: ${_node}"
+  _kpod=$(kubectl get pods -n dra-driver-nvidia-gpu \
+    -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+    --field-selector spec.nodeName="${_node}" \
+    -o jsonpath='{.items[0].metadata.name}')
+  log "kubelet-plugin pod on that node: ${_kpod}"
+  log "checkpoint.json written by last-stable:"
+  kubectl exec -n dra-driver-nvidia-gpu "${_kpod}" -c gpus -- \
+    cat /var/lib/kubelet/plugins/gpu.nvidia.com/checkpoint.json
+  echo
+
+  # Stage 4: update CRD, as a user would do.
+  kubectl apply -f "${CRD_UPGRADE_URL}"
+
+  # Stage 5: install target version (as users would do).
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+
+  # Stage 6: confirm deleting old workload works (critical, see above).
+  kubectl delete -f  "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=15s
+
+  # After unprepare by the new binary: the GI/CI created by last-stable must be
+  # destroyed and MIG mode disabled.
+  mig_confirm_disabled_on_all_nodes
+
+  # Stage 7: fresh create-confirm-delete workload cycle.
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=15s
+  run kubectl logs "${_podname}"
+  assert_output --partial "UUID: MIG-"
+  assert_output --partial "UUID: GPU-"
+  kubectl delete -f  "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=15s
+
+  # Confirm cleanup.
+  mig_confirm_disabled_on_all_nodes
+}
+
+
+# bats test_tags=fastfeedback
+@test "GPUs: corrupted checkpoint leads to diff being logged" {
+  if [ "${MOCK_NVML:-}" = "true" ]; then skip "MOCK_NVML is set"; fi
+
+  # Stage 1: clean slate, install current dev. The plugin creates an empty
+  # checkpoint at first startup.
+  helm uninstall "${TEST_HELM_RELEASE_NAME}" -n dra-driver-nvidia-gpu --wait --timeout=30s
+  kubectl wait --for=delete pods -A -l app.kubernetes.io/name=dra-driver-nvidia-gpu --timeout=10s
+  bash tests/bats/clean-state-dirs-all-nodes.sh
+  kubectl get crd computedomains.resource.nvidia.com
+  timeout -v 10 kubectl delete crd computedomains.resource.nvidia.com
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" NOARGS
+
+  # Stage 2: pick any kubelet plugin pod.
+  local _kpod _node
+  _kpod=$(kubectl get pods -n dra-driver-nvidia-gpu \
+    -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+    -o jsonpath='{.items[0].metadata.name}')
+  _node=$(kubectl get pod -n dra-driver-nvidia-gpu "${_kpod}" -o jsonpath='{.spec.nodeName}')
+  log "targeting plugin pod ${_kpod} on node ${_node}"
+
+  # Stage 3: two independent mutations to v2, both in one sed:
+  #   1) Zero v2's checksum -- this trips the error.
+  #   2) Insert a dummy unknown field -- this shows up in the diff. We
+  #      want to confirm that the diff shows a field that is not
+  #      contained in both JSON documents.
+  # Inserting only an unknown field passes verification (the deserializer
+  # drops it, so the recomputed checksum still matches), so the checksum
+  # mutation is also required to exercise the diagnostic path.
+  kubectl exec -n dra-driver-nvidia-gpu "${_kpod}" -c gpus -- sh -c '
+    set -ex
+    CP=/var/lib/kubelet/plugins/gpu.nvidia.com/checkpoint.json
+    echo "BEFORE:" && cat "$CP" && echo
+    sed -i "s/\"v2\":{\"checksum\":[0-9]*/\"v2\":{\"checksum\":0,\"dummy\":\"this-should-show-in-diff\"/" "$CP"
+    echo "AFTER:" && cat "$CP" && echo
+  '
+
+  # Stage 4: bounce the plugin pod so it re-reads the corrupted file at
+  # startup. The daemonset creates a replacement with a new name.
+  kubectl delete pod -n dra-driver-nvidia-gpu "${_kpod}"
+
+  local _newkpod="" _deadline=$((SECONDS + 60))
+  while true; do
+    _newkpod=$(kubectl get pods -n dra-driver-nvidia-gpu \
+      -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+      --field-selector spec.nodeName="${_node}" \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || true
+    if [ -n "${_newkpod}" ] && [ "${_newkpod}" != "${_kpod}" ]; then
+      break
+    fi
+    (( SECONDS > _deadline )) && { echo "timeout waiting for replacement pod"; return 1; }
+    sleep 1
+  done
+  log "replacement kubelet-plugin pod: ${_newkpod}"
+
+  # Stage 5: poll for the diagnostic log line in the new pod's logs.
+  _deadline=$((SECONDS + 60))
+  while ! kubectl logs -n dra-driver-nvidia-gpu "${_newkpod}" -c gpus 2>/dev/null \
+      | grep -q "checkpoint failed checksum verification; unified diff"; do
+    if (( SECONDS > _deadline )); then
+      echo "timeout waiting for unified diff log line"
+      kubectl logs -n dra-driver-nvidia-gpu "${_newkpod}" -c gpus | tail -100 || true
+      return 1
+    fi
+    sleep 2
+  done
+
+  run kubectl logs -n dra-driver-nvidia-gpu "${_newkpod}" -c gpus
+  assert_output --partial "checkpoint failed checksum verification; unified diff"
+  assert_output --partial "dummy"
+
+  # Stage 6: cleanup. Wipe kubelet plugin state dirs to delete the corrupted
+  # checkpoint, then helm uninstall.
+  bash tests/bats/clean-state-dirs-all-nodes.sh
+  helm uninstall "${TEST_HELM_RELEASE_NAME}" -n dra-driver-nvidia-gpu --wait --timeout=30s || true
 }


### PR DESCRIPTION
Fixes #1080.

* We introduced `ShareID` and `Metadata` on `kubeletplugin.Device` via a library bump in #994. This broke upgrades from 25.12.0 for all non-empty checkpoints. As a fix, this patch proposes a lightweight wrapper for us to be able to annotate the offending fields with `omitempty`. This specific upgrade breakage was caught by the test suite, and I've confirmed that with the patch applied the [simple GPU workload upgrade test](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/0840788ddbf439cdd60783045d7c4dcb2eb09744/tests/bats/test_gpu_updowngrade.bats#L29) once again passes.
* We introduced `ParentPCIBusID` and `PciBusID` in #994. This breaks upgrades from 25.12.0 when running a DynamicMIG or VfioDevice workload. This patch proposes to fix that by also adding corresponding `omitempty` annotations. I also added a new test that covers upgrading under dynamic MIG workload and confirmed that this new test failed without the fix, and succeeds with the patch applied.
* To make checkpoint upgrade failures faster to debug, I've enriched the log output showing a useful diff emitted just before the otherwise hard-to-interpret message `Error: error creating driver: unable to get checkpoint: checkpoint is corrupted`. Below you can see an example for when `"parentPCIBusID": ""` would break checksum verification.
* I also added a test that covers the emit-diff-via-logging logic.
* Took liberty to act on #1079, I still don't see a downside and this makes it easy to test the general upgradeability by virtue of covering the `downstream-25-12-0-on-NGC->upstream-0-4-0-dev` upgrade path.


The new log output for better upgrade failure debuggability:
```
E0511 14:24:30.306830       1 device_state.go:640] checkpoint failed checksum verification; unified diff (on-disk vs re-marshaled by current binary):
--- on-disk
+++ re-marshaled
@@ -51,7 +51,8 @@
                     "giId": 7,
                     "ciId": 0,
                     "migUUID": "GPU-df52ace4-7143-c242-81d8-819a6b3819b4",
-                    "parentUUID": "GPU-df52ace4-7143-c242-81d8-819a6b3819b4"
+                    "parentUUID": "GPU-df52ace4-7143-c242-81d8-819a6b3819b4",
+                    "parentPCIBusID": ""
                   },
                   "device": {
                     "Requests": [
@@ -127,7 +128,8 @@
                     "giId": 7,
                     "ciId": 0,
                     "migUUID": "GPU-df52ace4-7143-c242-81d8-819a6b3819b4",
-                    "parentUUID": "GPU-df52ace4-7143-c242-81d8-819a6b3819b4"
+                    "parentUUID": "GPU-df52ace4-7143-c242-81d8-819a6b3819b4",
+                    "parentPCIBusID": ""
                   },
                   "device": {
                     "Requests": [
I0511 14:24:30.307024       1 main.go:224] shutdown
Error: error creating driver: unable to get checkpoint: checkpoint is corrupted
```