### PR TITLE
add memory type for GB10 (UMA)

### DIFF
--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -34,7 +34,7 @@ type GpuInfo struct {
 	migCapable            bool
 	migEnabled            bool
 	vfioEnabled           bool
-	memoryBytes           uint64
+	memoryBytes           *uint64
 	productName           string
 	brand                 string
 	architecture          string

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -474,10 +474,19 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		return nil, fmt.Errorf("error checking if MIG mode enabled for device %d: %w", index, err)
 	}
 
+	var memoryBytes *uint64
 	memory, ret := device.GetMemoryInfo()
-	if ret != nvml.SUCCESS {
+	switch ret {
+	case nvml.SUCCESS:
+		memoryBytes = &(memory.Total)
+	case nvml.ERROR_NOT_SUPPORTED:
+		memoryBytes = nil
+		klog.Warningf("ignoring %v for getting memory info for device %d", ret, index)
+	default:
 		return nil, fmt.Errorf("error getting memory info for device %d: %v", index, ret)
+
 	}
+
 	productName, ret := device.GetName()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting product name for device %d: %v", index, ret)
@@ -592,7 +601,7 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		minor:                 minor,
 		migCapable:            migCapable,
 		migEnabled:            migEnabled,
-		memoryBytes:           memory.Total,
+		memoryBytes:           memoryBytes,
 		productName:           productName,
 		brand:                 brand,
 		architecture:          architecture,

--- a/cmd/gpu-kubelet-plugin/partitions.go
+++ b/cmd/gpu-kubelet-plugin/partitions.go
@@ -32,9 +32,12 @@ type PartCapacityMap map[resourceapi.QualifiedName]resourceapi.DeviceCapacity
 // dispatched separately (feature-gate-gated in publishResources()), so
 // without a shared helper they may silently drift.
 func (d *GpuInfo) fullGpuCapacity() PartCapacityMap {
+	if d.memoryBytes == nil {
+		return nil
+	}
 	return PartCapacityMap{
 		"memory": resourceapi.DeviceCapacity{
-			Value: *resource.NewQuantity(int64(d.memoryBytes), resource.BinarySI),
+			Value: *resource.NewQuantity(int64(*d.memoryBytes), resource.BinarySI),
 		},
 	}
 }


### PR DESCRIPTION

#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
Add memoryType = unified for non-discrete GPUs


#### Which issue(s) this PR is related to:
https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1073
https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1115

#### Special notes for your reviewer:
Still need to check why MPS is failing but it can be a follow-up fix 

#### Does this PR introduce a user-facing change?
Yes, adds a new device attribute 
```
memoryType: 
  string: "unified"
```

```release-note
NONE
```
