### PR TITLE
Helm: Include upstream NFD GPU labels for scheduling kubelet plugin

### DIFF
--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -290,19 +290,31 @@ kubeletPlugin:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          # On discrete-GPU based systems NFD adds the following label where 10de is the NVIDIA PCI vendor ID
+          # NFD: On discrete-GPU based systems NFD adds the following label where 10de is the NVIDIA PCI vendor ID
           - key: feature.node.kubernetes.io/pci-10de.present
             operator: In
             values:
             - "true"
         - matchExpressions:
-          # On some Tegra-based systems NFD detects the CPU vendor ID as NVIDIA
+          # NFD: NVIDIA PCI 3D controller (class 0302) present
+          - key: feature.node.kubernetes.io/pci-0302_10de.present
+            operator: In
+            values:
+            - "true"
+        - matchExpressions:
+          # NFD: NVIDIA PCI VGA compatible controller (class 0300) present
+          - key: feature.node.kubernetes.io/pci-0300_10de.present
+            operator: In
+            values:
+            - "true"
+        - matchExpressions:
+          # NFD: On some Tegra-based systems NFD detects the CPU vendor ID as NVIDIA
           - key: feature.node.kubernetes.io/cpu-model.vendor_id
             operator: In
             values:
             - "NVIDIA"
         - matchExpressions:
-          # We allow a GPU deployment to be forced by setting the following label to "true"
+          # GPU Operator: Label added by NVIDIA GPU Operator when it detects a GPU
           - key: "nvidia.com/gpu.present"
             operator: In
             values:


### PR DESCRIPTION
Fixes #1084

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind cleanup

#### What this PR does / why we need it:
This change includes node labels added by the upstream NFD Helm chart to indicate the presence of NVIDIA GPUs for kubelet plugin deployment.. More details in the issue #1084 

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
#1084 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->

/release-note-none

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
