### PR TITLE
ci: declare contents: read on mock-nvml-e2e and tests

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -24,6 +24,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       name: Checkout code
@@ -53,6 +55,8 @@ jobs:
   test:
     name: Unit test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -65,6 +69,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/mock-nvml-e2e.yaml
+++ b/.github/workflows/mock-nvml-e2e.yaml
@@ -34,6 +34,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   mock-gpu-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,9 @@ name: tests
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   skipped:
     runs-on: ubuntu-latest

--- a/.github/workflows/variables.yaml
+++ b/.github/workflows/variables.yaml
@@ -25,6 +25,8 @@ on:
 jobs:
   variables:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
       golang_version: ${{ steps.golang_version.outputs.golang_version }}


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only on the two CI workflows that hadn't declared scope:

- `mock-nvml-e2e.yaml` — emulates 8× GB200 NVL GPUs with the mock NVML from `nvidia/k8s-test-infra`, spins up a kind cluster with DRA, and runs the BATS suite.
- `tests.yaml` — placeholder workflow that documents the Prow-driven test flow.

Neither writes to GitHub. YAML validated locally.