### PR TITLE
fix computedomain unittest failures

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -372,7 +372,7 @@ func TestAssertImexChannelNotAllocated(t *testing.T) {
 }
 
 func TestPrepareReturnsCheckpointedDevicesForCompletedClaim(t *testing.T) {
-	expectedDevice := kubeletplugin.Device{
+	expectedDevice := CheckpointedDevice{
 		Requests:     []string{"request"},
 		PoolName:     "pool",
 		DeviceName:   "channel-0",
@@ -403,7 +403,7 @@ func TestPrepareReturnsCheckpointedDevicesForCompletedClaim(t *testing.T) {
 	got, err := state.Prepare(context.Background(), claim)
 
 	require.NoError(t, err)
-	assert.Equal(t, []kubeletplugin.Device{expectedDevice}, got)
+	assert.Equal(t, []kubeletplugin.Device{kubeletplugin.Device(expectedDevice)}, got)
 }
 
 func TestUnprepareMissingClaimIsNoop(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

/kind bug

#### What this PR does / why we need it:
ComputeDomain DeviceState unittests introduced in https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1133 is failing . 
```
# sigs.k8s.io/dra-driver-nvidia-gpu/cmd/compute-domain-kubelet-plugin [sigs.k8s.io/dra-driver-nvidia-gpu/cmd/compute-domain-kubelet-plugin.test]
cmd/compute-domain-kubelet-plugin/device_state_test.go:390:17: cannot use &expectedDevice (value of type *kubeletplugin.Device) as *CheckpointedDevice value in struct literal
make: *** [Makefile:105: test] Error 1
```

This change fixes the `TestPrepareReturnsCheckpointedDevicesForCompletedClaim` unittest.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
N/A
#### Special notes for your reviewer:
Related PR: https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1129

Test passes now:

```
=== RUN   TestPrepareReturnsCheckpointedDevicesForCompletedClaim
--- PASS: TestPrepareReturnsCheckpointedDevicesForCompletedClaim (0.00s)
```

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note

```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [X] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [X] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
