### PR TITLE
fix mps env var for chroot

### DIFF
--- a/templates/mps-control-daemon.tmpl.yaml
+++ b/templates/mps-control-daemon.tmpl.yaml
@@ -32,6 +32,9 @@ spec:
           if [ -x /driver-root/bin/sh ] || [ -x /driver-root/usr/bin/sh ]; then
             # Use chroot to avoid library mismatch between container and host
             # when driver root is / (default value) or /run/nvidia/driver (default location for driver installation by GPU Operator)
+            # Export the paths explicitly for the chroot environment
+            export CUDA_MPS_PIPE_DIRECTORY=/tmp/nvidia-mps
+            export CUDA_MPS_LOG_DIRECTORY=/var/log/nvidia-mps
             RUN="chroot /driver-root sh -c"
           else
             # No shell in driver root (e.g. GKE COS): run directly with PATH/LD_LIBRARY_PATH


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

#### Special notes for your reviewer:

Found MPS daemon crashlooping because of missing env
```
dra-driver-nvidia-gpu   mps-control-daemon-a0d2f2f3-f0e4-42ff-ab94-eec4b82db2ee-26qs7bc   0/1     CrashLoopBackOff    9 (4m24s ago)   21m
gpu-test-mps            test-pod                                                          0/2     ContainerCreating   0               21m

Startup probe failed: cat: can't open '/driver-root/var/log/nvidia-mps/startup.log': No such file or directory

CUDA_MPS_PIPE_DIRECTORY must be set to start or to communicate with MPS control daemon
```

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation (design docs, usage docs, etc.):

Tested on GB10 and A30.

After setting the env

```
nvidia-smi pmon
# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
# Idx           #    C/G      %      %      %      %      %      %    name 
    0     106525     C     95      0      -      -      -      -    nvidia-cuda-mps
    0     126081   M+C      -      -      -      -      -      -    sample         
    0     126162   M+C      -      -      -      -      -      -    sample         
    0     106525     C     95      0      -      -      -      -    nvidia-cuda-mps
    
 
kubectl logs mps-control-daemon-9512d551-1b8e-45b7-9f2e-2596fd262980-26fq46p  -n dra-driver-nvidia-gpu 
50.0
[2026-05-14 19:17:18.513 Control  1372] Starting control daemon using socket /tmp/nvidia-mps/control
[2026-05-14 19:17:18.513 Control  1372] To connect CUDA applications to this daemon, set env CUDA_MPS_PIPE_DIRECTORY=/tmp/nvidia-mps
[2026-05-14 19:17:18.513 Control  1372] CUDA MPS Control binary version: 13000
[2026-05-14 19:17:18.516 Control  1372] Accepting connection...
[2026-05-14 19:17:18.516 Control  1372] NEW UI
[2026-05-14 19:17:18.516 Control  1372] Cmd:set_default_active_thread_percentage 50
[2026-05-14 19:17:18.516 Control  1372] 50.0
[2026-05-14 19:17:18.516 Control  1372] UI closed
[2026-05-14 19:17:18.518 Control  1372] Accepting connection...
[2026-05-14 19:17:18.518 Control  1372] NEW UI
[2026-05-14 19:17:18.518 Control  1372] Cmd:set_default_device_pinned_mem_limit GPU-a2f2413a-51f3-1b29-11b5-4503f4ad3078 10240M
[2026-05-14 19:17:18.518 Control  1372] set_default_device_pinned_mem_limit GPU-a2f2413a-51f3-1b29-11b5-4503f4ad3078 10240M.
[2026-05-14 19:17:18.518 Control  1372] UI closed
[2026-05-14 19:17:32.347 Control  1372] Accepting connection...
[2026-05-14 19:17:32.347 Control  1372] User did not send valid credentials
[2026-05-14 19:17:32.347 Control  1372] Accepting connection...
[2026-05-14 19:17:32.347 Control  1372] NEW CLIENT 1594 from user 0: Server is not ready, push client to pending list
[2026-05-14 19:17:32.347 Control  1596] Starting new server 1596 for user 0
[2026-05-14 19:17:32.350 Control  1372] Accepting connection...
[2026-05-14 19:17:32.645 Control  1372] NEW SERVER 1596: Ready
[2026-05-14 19:17:32.646 Control  1372] Accepting connection...
[2026-05-14 19:17:32.646 Control  1372] User did not send valid credentials
[2026-05-14 19:17:32.646 Control  1372] Accepting connection...
[2026-05-14 19:17:32.646 Control  1372] NEW CLIENT 1674 from user 0: Server already exists
[2026-05-14 19:17:32.726 Control  1372] Accepting connection...
[2026-05-14 19:17:32.726 Control  1372] NEW CLIENT 1594 from user 0: Server already exists
[2026-05-14 19:17:32.747 Control  1372] Accepting connection...
[2026-05-14 19:17:32.747 Control  1372] NEW CLIENT 1674 from user 0: Server already exists
```