### PR TITLE
[WIP] Host managed imex

### DIFF
--- a/cmd/compute-domain-controller/computedomain.go
+++ b/cmd/compute-domain-controller/computedomain.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	nvapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/metrics"
 	nvinformers "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/nvidia.com/informers/externalversions"
 	nvlisters "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/nvidia.com/listers/resource/v1beta1"
@@ -252,6 +253,14 @@ func (m *ComputeDomainManager) RemoveFinalizer(ctx context.Context, uid string) 
 }
 
 func (m *ComputeDomainManager) calculateGlobalStatus(cd *nvapi.ComputeDomain) string {
+	// In host-managed IMEX mode the controller does not track per-node daemon
+	// readiness (there are no driver-managed daemons), so Ready means only that
+	// the ComputeDomain was admitted and its workload ResourceClaimTemplate
+	// exists. spec.numNodes and status.nodes are not used.
+	if featuregates.Enabled(featuregates.HostManagedIMEX) {
+		return nvapi.ComputeDomainStatusReady
+	}
+
 	// Mark the ComputeDomain as not ready if not enough nodes are present in the nodes list.
 	if len(cd.Status.Nodes) < cd.Spec.NumNodes {
 		return nvapi.ComputeDomainStatusNotReady
@@ -314,6 +323,10 @@ func (m *ComputeDomainManager) onAddOrUpdate(ctx context.Context, obj any) error
 		return nil
 	}
 
+	if featuregates.Enabled(featuregates.HostManagedIMEX) {
+		return m.onAddOrUpdateHostManaged(ctx, cd)
+	}
+
 	if cd.GetDeletionTimestamp() != nil {
 		if err := m.resourceClaimTemplateManager.Delete(ctx, string(cd.UID)); err != nil {
 			return fmt.Errorf("error deleting ResourceClaimTemplate: %w", err)
@@ -372,6 +385,55 @@ func (m *ComputeDomainManager) onAddOrUpdate(ctx context.Context, obj any) error
 	// Change the global Status to reflect the number of ComputeDomain daemons connected.
 	if err := m.updateGlobalStatus(ctx, cd); err != nil {
 		return fmt.Errorf("error updating global status on ComputeDoimain '%s/%s': %w", cd.Namespace, cd.Name, err)
+	}
+
+	return nil
+}
+
+// onAddOrUpdateHostManaged reconciles a ComputeDomain when the HostManagedIMEX
+// feature gate is enabled. In that mode the cluster operator owns the host
+// nvidia-imex daemon lifecycle, so the controller only manages the workload
+// ResourceClaimTemplate and the ComputeDomain finalizer. It never creates
+// daemon DaemonSets, daemon ResourceClaimTemplates, or ComputeDomain node
+// labels, so the delete path has none of those to clean up.
+func (m *ComputeDomainManager) onAddOrUpdateHostManaged(ctx context.Context, cd *nvapi.ComputeDomain) error {
+	if cd.GetDeletionTimestamp() != nil {
+		if err := m.resourceClaimTemplateManager.Delete(ctx, string(cd.UID)); err != nil {
+			return fmt.Errorf("error deleting ResourceClaimTemplate: %w", err)
+		}
+
+		if err := m.resourceClaimTemplateManager.RemoveFinalizer(ctx, string(cd.UID)); err != nil {
+			return fmt.Errorf("error removing finalizer on ResourceClaimTemplate: %w", err)
+		}
+
+		if err := m.resourceClaimTemplateManager.AssertRemoved(ctx, string(cd.UID)); err != nil {
+			return fmt.Errorf("error asserting removal of ResourceClaimTemplate: %w", err)
+		}
+
+		if err := m.RemoveFinalizer(ctx, string(cd.UID)); err != nil {
+			return fmt.Errorf("error removing finalizer: %w", err)
+		}
+
+		metrics.ForgetComputeDomain(string(cd.UID))
+		return nil
+	}
+
+	// Add the finalizer.
+	if err := m.addFinalizer(ctx, cd); err != nil {
+		return fmt.Errorf("error adding finalizer: %w", err)
+	}
+
+	// Create the workload ResourceClaimTemplate. Its manager adds and tracks
+	// its own finalizer on the template.
+	if _, err := m.resourceClaimTemplateManager.Create(ctx, cd.Namespace, cd.Spec.Channel.ResourceClaimTemplate.Name, cd); err != nil {
+		return fmt.Errorf("error creating ResourceClaimTemplate '%s/%s': %w", cd.Namespace, cd.Spec.Channel.ResourceClaimTemplate.Name, err)
+	}
+
+	// Mark the ComputeDomain Ready. Under HostManagedIMEX this only means the
+	// ComputeDomain was admitted and the workload ResourceClaimTemplate exists;
+	// it says nothing about host nvidia-imex health.
+	if err := m.updateGlobalStatus(ctx, cd); err != nil {
+		return fmt.Errorf("error updating status on ComputeDomain '%s/%s': %w", cd.Namespace, cd.Name, err)
 	}
 
 	return nil

--- a/cmd/compute-domain-controller/computedomain_test.go
+++ b/cmd/compute-domain-controller/computedomain_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	nvapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+func TestCalculateGlobalStatusHostManaged(t *testing.T) {
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{string(featuregates.HostManagedIMEX): true}))
+	t.Cleanup(func() {
+		require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{string(featuregates.HostManagedIMEX): false}))
+	})
+
+	m := &ComputeDomainManager{}
+
+	// In driver-managed mode this would be NotReady (required nodes are
+	// missing). Under HostManagedIMEX the controller does not track per-node
+	// readiness, so it reports Ready once admitted.
+	cd := &nvapi.ComputeDomain{}
+	cd.Spec.NumNodes = 8
+	require.Equal(t, nvapi.ComputeDomainStatusReady, m.calculateGlobalStatus(cd))
+}

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -514,6 +514,11 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, cs *resourceapi.Reso
 	for c := range configResultsMap {
 		switch config := c.(type) {
 		case *configapi.ComputeDomainChannelConfig:
+			// Host-managed mode never adds the ComputeDomain node label, so
+			// there is nothing to remove here.
+			if featuregates.Enabled(featuregates.HostManagedIMEX) {
+				continue
+			}
 			// If a channel type, remove the ComputeDomain label from the node
 			if err := s.computeDomainManager.RemoveNodeLabel(ctx, config.DomainID); err != nil {
 				return fmt.Errorf("error removing Node label for ComputeDomain: %w", err)
@@ -547,6 +552,18 @@ func (s *DeviceState) applyComputeDomainChannelConfig(ctx context.Context, confi
 		return nil, fmt.Errorf("applyComputeDomainChannelConfig: unexpected results %v", results)
 	}
 
+	hostManaged := featuregates.Enabled(featuregates.HostManagedIMEX)
+	if hostManaged {
+		// Host-managed IMEX exposes only channel 0 and supports only the
+		// default (Single) allocation mode. The opaque config the kubelet sees
+		// is not covered by the ComputeDomain CRD enum, so validate it here
+		// explicitly rather than relying on the AllocationModeAll branch below.
+		if config.AllocationMode != "" && config.AllocationMode != configapi.ComputeDomainChannelAllocationModeSingle {
+			return nil, permanentError{fmt.Errorf("host-managed IMEX supports only allocationMode %q (channel 0); got %q",
+				configapi.ComputeDomainChannelAllocationModeSingle, config.AllocationMode)}
+		}
+	}
+
 	// If explicitly requested, inject all channels instead of just one.
 	chancount := 1
 	if config.AllocationMode == configapi.ComputeDomainChannelAllocationModeAll {
@@ -570,15 +587,23 @@ func (s *DeviceState) applyComputeDomainChannelConfig(ctx context.Context, confi
 		return nil, permanentError{fmt.Errorf("error asserting ComputeDomain's namespace: %w", err)}
 	}
 
-	if err := s.computeDomainManager.AddNodeLabel(ctx, config.DomainID); err != nil {
-		return nil, fmt.Errorf("error adding Node label for ComputeDomain: %w", err)
-	}
+	if !hostManaged {
+		if err := s.computeDomainManager.AddNodeLabel(ctx, config.DomainID); err != nil {
+			return nil, fmt.Errorf("error adding Node label for ComputeDomain: %w", err)
+		}
 
-	if err := s.computeDomainManager.AssertComputeDomainReady(ctx, config.DomainID); err != nil {
-		return nil, fmt.Errorf("error asserting ComputeDomain Ready: %w", err)
+		if err := s.computeDomainManager.AssertComputeDomainReady(ctx, config.DomainID); err != nil {
+			return nil, fmt.Errorf("error asserting ComputeDomain Ready: %w", err)
+		}
 	}
 
 	if s.computeDomainManager.cliqueID == "" {
+		if hostManaged {
+			// Without a clique there is no NVLink fabric to join, so a
+			// host-managed channel claim can never work. Fail loudly instead
+			// of silently skipping device-node injection.
+			return nil, permanentError{fmt.Errorf("host-managed IMEX requires an NVLink clique on this node, but NVML reports none")}
+		}
 		// Do not inject IMEX channel device nodes.
 		return &configState, nil
 	}
@@ -592,6 +617,13 @@ func (s *DeviceState) applyComputeDomainChannelConfig(ctx context.Context, confi
 }
 
 func (s *DeviceState) applyComputeDomainDaemonConfig(ctx context.Context, config *configapi.ComputeDomainDaemonConfig, claim *resourceapi.ResourceClaim, results []*resourceapi.DeviceRequestAllocationResult) (*DeviceConfigState, error) {
+	// Host-managed IMEX runs no driver-managed ComputeDomain daemons, so daemon
+	// devices are never published or allocated. A daemon claim reaching Prepare
+	// means a stale or hand-crafted object; reject it permanently.
+	if featuregates.Enabled(featuregates.HostManagedIMEX) {
+		return nil, permanentError{fmt.Errorf("ComputeDomain daemon claims are not supported under the HostManagedIMEX feature gate")}
+	}
+
 	// Get the list of claim requests this config is being applied over.
 	var requests []string
 	for _, r := range results {

--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/utils/ptr"
@@ -33,6 +34,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	configapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+	nvfake "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/nvidia.com/clientset/versioned/fake"
+	nvinformers "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/nvidia.com/informers/externalversions"
 )
 
 type fakeCheckpointManager struct {
@@ -421,6 +425,104 @@ func TestUnprepareMissingClaimIsNoop(t *testing.T) {
 	err := state.Unprepare(context.Background(), claimRef)
 
 	require.NoError(t, err)
+}
+
+func enableHostManagedIMEX(t *testing.T) {
+	t.Helper()
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{string(featuregates.HostManagedIMEX): true}))
+	t.Cleanup(func() {
+		require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{string(featuregates.HostManagedIMEX): false}))
+	})
+}
+
+func TestApplyComputeDomainChannelConfigHostManagedRejectsAllocationMode(t *testing.T) {
+	enableHostManagedIMEX(t)
+
+	for _, mode := range []string{configapi.ComputeDomainChannelAllocationModeAll, "foo"} {
+		t.Run(mode, func(t *testing.T) {
+			result := allocationResult("request", DriverName, "channel-0", nil)
+			config := channelConfig("cd-uid")
+			config.AllocationMode = mode
+
+			_, err := (&DeviceState{}).applyComputeDomainChannelConfig(
+				context.Background(),
+				config,
+				claimWithResults("claim-uid", result),
+				[]*resourceapi.DeviceRequestAllocationResult{&result},
+			)
+
+			require.Error(t, err)
+			assert.True(t, isPermanentError(err), "AllocationMode %q must be a permanent error under HostManagedIMEX", mode)
+		})
+	}
+}
+
+func TestApplyComputeDomainDaemonConfigHostManagedRejected(t *testing.T) {
+	enableHostManagedIMEX(t)
+
+	result := allocationResult("request", DriverName, "daemon-0", nil)
+
+	_, err := (&DeviceState{}).applyComputeDomainDaemonConfig(
+		context.Background(),
+		daemonConfig("cd-uid"),
+		claimWithResults("claim-uid", result),
+		[]*resourceapi.DeviceRequestAllocationResult{&result},
+	)
+
+	require.Error(t, err)
+	assert.True(t, isPermanentError(err), "daemon claims must be a permanent error under HostManagedIMEX")
+}
+
+func TestApplyComputeDomainChannelConfigHostManagedRequiresClique(t *testing.T) {
+	enableHostManagedIMEX(t)
+
+	cd := &configapi.ComputeDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "cd", Namespace: "test-ns", UID: "cd-uid"},
+	}
+
+	// A ComputeDomainManager whose informer already holds the CD (so the
+	// namespace assertion passes) but with an empty cliqueID.
+	factory := nvinformers.NewSharedInformerFactory(nvfake.NewSimpleClientset(), 0)
+	informer := factory.Resource().V1beta1().ComputeDomains().Informer()
+	require.NoError(t, informer.AddIndexers(cache.Indexers{"computeDomainUID": uidIndexer[*configapi.ComputeDomain]}))
+	require.NoError(t, informer.GetIndexer().Add(cd))
+
+	state := &DeviceState{
+		checkpointManager:    &fakeCheckpointManager{checkpoint: checkpointWithClaims(nil)},
+		computeDomainManager: &ComputeDomainManager{informer: informer, cliqueID: ""},
+	}
+
+	config := channelConfig("cd-uid")
+	config.AllocationMode = configapi.ComputeDomainChannelAllocationModeSingle
+	result := allocationResult("request", DriverName, "channel-0", nil)
+	claim := claimWithResults("claim-uid", result)
+	claim.Namespace = "test-ns"
+
+	// AddNodeLabel/AssertComputeDomainReady would dereference the manager's nil
+	// config if they were not skipped; reaching the clique check proves they are.
+	_, err := state.applyComputeDomainChannelConfig(
+		context.Background(),
+		config,
+		claim,
+		[]*resourceapi.DeviceRequestAllocationResult{&result},
+	)
+
+	require.Error(t, err)
+	assert.True(t, isPermanentError(err), "empty clique under HostManagedIMEX must be a permanent error")
+	assert.Contains(t, err.Error(), "clique")
+}
+
+func TestUnprepareDevicesHostManagedSkipsRemoveNodeLabel(t *testing.T) {
+	enableHostManagedIMEX(t)
+
+	// computeDomainManager is intentionally nil: the channel branch must skip
+	// RemoveNodeLabel under HostManagedIMEX, so it must never be dereferenced.
+	state := testDeviceState()
+	status := claimStatus([]resourceapi.DeviceRequestAllocationResult{
+		allocationResult("channel-request", DriverName, "channel-0", nil),
+	})
+
+	require.NoError(t, state.unprepareDevices(context.Background(), &status))
 }
 
 func testDeviceState() *DeviceState {

--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/flock"
 	drametrics "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/metrics"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/workqueue"
@@ -57,6 +58,25 @@ type permanentError struct{ error }
 
 func isPermanentError(err error) bool {
 	return errors.As(err, &permanentError{})
+}
+
+// computeDomainPublishedDevices returns the devices the kubelet plugin should
+// advertise in its node ResourceSlice. ComputeDomain channels other than
+// channel 0 are not advertised here (they are advertised as a network resource
+// from the control plane). Under HostManagedIMEX the driver runs no
+// ComputeDomain daemons, so daemon devices are omitted as well.
+func computeDomainPublishedDevices(allocatable AllocatableDevices, hostManaged bool) []resourceapi.Device {
+	var devices []resourceapi.Device
+	for _, device := range allocatable {
+		if device.Type() == ComputeDomainChannelType && device.Channel.ID != 0 {
+			continue
+		}
+		if hostManaged && device.Type() == ComputeDomainDaemonType {
+			continue
+		}
+		devices = append(devices, device.GetDevice())
+	}
+	return devices
 }
 
 type driver struct {
@@ -102,16 +122,9 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	}
 	driver.pluginhelper = helper
 
-	// Enumerate the set of ComputeDomain daemon devices and publish them
+	// Enumerate the set of ComputeDomain devices to publish.
 	var resourceSlice resourceslice.Slice
-	for _, device := range state.allocatable {
-		// Explicitly exclude ComputeDomain channels from being advertised here. They
-		// are instead advertised in as a network resource from the control plane.
-		if device.Type() == ComputeDomainChannelType && device.Channel.ID != 0 {
-			continue
-		}
-		resourceSlice.Devices = append(resourceSlice.Devices, device.GetDevice())
-	}
+	resourceSlice.Devices = computeDomainPublishedDevices(state.allocatable, featuregates.Enabled(featuregates.HostManagedIMEX))
 
 	resources := resourceslice.DriverResources{
 		Pools: map[string]resourceslice.Pool{

--- a/cmd/compute-domain-kubelet-plugin/driver_test.go
+++ b/cmd/compute-domain-kubelet-plugin/driver_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"sort"
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func deviceNames(devices []resourceapi.Device) []string {
+	names := make([]string, 0, len(devices))
+	for _, d := range devices {
+		names = append(names, d.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestComputeDomainPublishedDevices(t *testing.T) {
+	allocatable := AllocatableDevices{
+		"channel-0": &AllocatableDevice{Channel: &ComputeDomainChannelInfo{ID: 0}},
+		"channel-1": &AllocatableDevice{Channel: &ComputeDomainChannelInfo{ID: 1}},
+		"daemon-0":  &AllocatableDevice{Daemon: &ComputeDomainDaemonInfo{ID: 0}},
+	}
+
+	t.Run("driver-managed publishes channel 0 and the daemon device", func(t *testing.T) {
+		// Non-zero channels are always excluded (advertised from the control plane).
+		assert.Equal(t, []string{"channel-0", "daemon-0"}, deviceNames(computeDomainPublishedDevices(allocatable, false)))
+	})
+
+	t.Run("host-managed omits the daemon device", func(t *testing.T) {
+		assert.Equal(t, []string{"channel-0"}, deviceNames(computeDomainPublishedDevices(allocatable, true)))
+	})
+}

--- a/demo/specs/imex/host-managed/README.md
+++ b/demo/specs/imex/host-managed/README.md
@@ -1,0 +1,116 @@
+# Host-managed IMEX — examples & runbook
+
+These specs exercise the `HostManagedIMEX` alpha feature gate: the cluster
+operator owns the host `nvidia-imex` daemon, and the driver only advertises and
+injects channel 0 (no per-ComputeDomain IMEX DaemonSets). See the design and
+operator guide for the full contract; see `docs/prerequisites.md` →
+"Host-managed IMEX" for host prerequisites.
+
+## Per-node prerequisites (every GPU node)
+
+Two things must be true on every participating GPU node **before the kubelet
+plugin starts**:
+
+### 1. Host `nvidia-imex` running with a consistent node list
+
+`nvidia-imex.service` must be **running** (not masked), reading the same
+`/etc/nvidia-imex/nodes_config.cfg` on every node in the IMEX domain. The file is
+one peer per line — IPv4, IPv6, or DNS name — and **must include this node's own
+address** (IMEX treats itself as a peer). Every node in the domain needs an
+**identical** list; if they disagree, IMEX silently refuses cross-node memory
+operations.
+
+Example `/etc/nvidia-imex/nodes_config.cfg` for a 2-node domain:
+
+```text
+10.0.0.11
+10.0.0.12
+```
+
+Use the addresses the daemons actually bind/route on. The list is one entry per
+node in the NVLink clique (e.g. 18 lines for a full GB200 NVL72 rack). Keep it
+identical across peers and restart `nvidia-imex` after any change. See operator
+guide §3.2 for discovery strategies (static file, a boot-time script that
+scrapes the `nvidia.com/gpu.clique` label, a node-local controller, or BCM/NMX).
+
+### 2. The `nvidia-caps-imex-channels` major + channel 0
+
+The kubelet plugin reads `/proc/devices` at startup to find the
+`nvidia-caps-imex-channels` device major, and workloads need channel `0`. Verify
+(and create the device node if missing):
+
+```bash
+# 1. The kernel must have registered the IMEX-channels major:
+grep nvidia-caps-imex-channels /proc/devices
+major="$(awk '$2 == "nvidia-caps-imex-channels" {print $1}' /proc/devices)"
+test -n "$major" || { echo "IMEX channel major not registered — load/fix the NVIDIA driver first"; exit 1; }
+
+# 2. channel0 must exist and be usable:
+sudo mkdir -p /dev/nvidia-caps-imex-channels
+test -e /dev/nvidia-caps-imex-channels/channel0 || \
+  sudo mknod /dev/nvidia-caps-imex-channels/channel0 c "$major" 0
+sudo chmod 0666 /dev/nvidia-caps-imex-channels/channel0
+ls -l /dev/nvidia-caps-imex-channels/channel0   # -> crw-rw-rw- ... <major>, 0 ... channel0
+```
+
+Preferred over manual `mknod` are the methods that recreate `channel0`
+automatically at driver load:
+
+- the NVIDIA kernel-module parameter `NVreg_CreateImexChannel0=1`, or
+- `sudo nvidia-modprobe -c 0`.
+
+CDI injects this device into the container from its major/minor, so a present
+host node is the signal the node is set up correctly. Only channel `0` is used
+by this mode.
+
+## Install (DGXC GB200 example)
+
+```bash
+helm upgrade --install dra-driver-nvidia-gpu \
+  ./deployments/helm/dra-driver-nvidia-gpu \
+  -n dra-driver-nvidia-gpu --create-namespace \
+  -f demo/specs/imex/host-managed/dgxc-gb200-values.yaml \
+  --set image.repository=<your-multiarch-image> --set image.tag=<tag> \
+  --wait
+```
+
+Verify:
+
+```bash
+kubectl -n dra-driver-nvidia-gpu get pods            # controller Running (not CrashLoop), plugins Ready
+kubectl get deviceclass compute-domain-default-channel.nvidia.com   # present
+kubectl get deviceclass compute-domain-daemon.nvidia.com            # NOT present
+kubectl get resourceslice -A -o yaml | grep -A2 'name: channel-0'   # one per GPU node
+kubectl get ds,po -A | grep computedomain-daemon                    # nothing
+```
+
+## Smoke (expect channel0)
+
+```bash
+kubectl apply -f demo/specs/imex/host-managed/smoke-channel-injection.yaml
+kubectl wait --for=condition=Ready pod/hostmanaged-smoke --timeout=120s
+kubectl logs hostmanaged-smoke        # -> shows channel0
+kubectl delete -f demo/specs/imex/host-managed/smoke-channel-injection.yaml
+```
+
+## Negative (expect a permanent prepare error)
+
+```bash
+kubectl apply -f demo/specs/imex/host-managed/negative-allocationmode-all.yaml
+kubectl describe pod hostmanaged-all  # stays ContainerCreating; permanent error re: allocationMode "Single"
+kubectl logs -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin -c compute-domains --tail=50
+kubectl delete -f demo/specs/imex/host-managed/negative-allocationmode-all.yaml
+```
+
+## Cross-node data path (co-clique nodes only)
+
+`nvbandwidth`/NCCL workers need GPUs. Re-install (or upgrade) with GPU DRA on:
+
+```bash
+helm upgrade ... -f dgxc-gb200-values.yaml \
+  --set resources.gpus.enabled=true --set gpuResourcesEnabledOverride=true
+```
+
+Then adapt `../nvbandwidth-test-job.yaml` for host-managed (ComputeDomain
+`numNodes: 0`, `allocationMode: Single`; no daemon pods expected) and run it
+across two nodes that share a `nvidia.com/gpu.clique` value.

--- a/demo/specs/imex/host-managed/dgxc-gb200-values.yaml
+++ b/demo/specs/imex/host-managed/dgxc-gb200-values.yaml
@@ -1,0 +1,54 @@
+# Helm values overlay for host-managed IMEX on a DGXC GB200 cluster
+# (arm64 Grace GPU nodes tainted skyhook.nvidia.com). Use with:
+#
+#   helm upgrade --install dra-driver-nvidia-gpu \
+#     ./deployments/helm/dra-driver-nvidia-gpu \
+#     -n dra-driver-nvidia-gpu --create-namespace \
+#     -f demo/specs/imex/host-managed/dgxc-gb200-values.yaml --wait
+#
+# IMPORTANT: use a MULTI-ARCH driver image. Otherwise the single-replica
+# controller Deployment can be scheduled onto an amd64 node and a single-arch
+# arm64 image fails with `exec format error`. The controller nodeSelector below
+# pins it to an arm64 GB200 node, which works only if the image has an arm64
+# variant.
+# GPU Operator installs a containerized NVIDIA driver, so the driver root is
+# /run/nvidia/driver, not the chart default of /.
+nvidiaDriverRoot: /run/nvidia/driver
+
+featureGates:
+  HostManagedIMEX: true
+
+resources:
+  # compute-domains only by default. For the cross-node data-path tests
+  # (nvbandwidth/NCCL) the workers need GPUs: flip gpus.enabled=true and set
+  # gpuResourcesEnabledOverride=true so GPUs are served via GPU DRA.
+  gpus:
+    enabled: false
+  computeDomains:
+    enabled: true
+
+controller:
+  # Pin to an arm64 GB200 node so a native-arm64 image runs (see IMPORTANT above).
+  nodeSelector:
+    kubernetes.io/arch: arm64
+  # Replaces the chart default list, so the upstream tolerations are repeated
+  # here alongside the skyhook toleration.
+  tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: skyhook.nvidia.com
+    operator: Exists
+    effect: NoSchedule
+
+kubeletPlugin:
+  # Replaces the chart default (nvidia.com/gpu); keep it and add skyhook.
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: skyhook.nvidia.com
+    operator: Exists
+    effect: NoSchedule

--- a/demo/specs/imex/host-managed/negative-allocationmode-all.yaml
+++ b/demo/specs/imex/host-managed/negative-allocationmode-all.yaml
@@ -1,0 +1,48 @@
+# Host-managed IMEX NEGATIVE test: allocationMode: All is rejected.
+#
+# Under HostManagedIMEX only allocationMode Single (or unset) is allowed.
+# Expected: the pod never reaches Ready; the compute-domains kubelet-plugin logs
+# a PERMANENT prepare error (mentioning allocationMode "Single") and the pod
+# stays in ContainerCreating.
+#
+# Toleration + nodeAffinity target DGXC GB200 nodes; drop them elsewhere.
+---
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: hostmanaged-all
+spec:
+  numNodes: 0
+  channel:
+    resourceClaimTemplate:
+      name: hostmanaged-all-channel
+    allocationMode: All
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostmanaged-all
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: skyhook.nvidia.com
+    operator: Exists
+    effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nvidia.com/gpu.clique
+            operator: Exists
+  containers:
+  - name: ctr
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["ls -la /dev/nvidia-caps-imex-channels; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: imex
+  resourceClaims:
+  - name: imex
+    resourceClaimTemplateName: hostmanaged-all-channel

--- a/demo/specs/imex/host-managed/smoke-channel-injection.yaml
+++ b/demo/specs/imex/host-managed/smoke-channel-injection.yaml
@@ -1,0 +1,50 @@
+# Host-managed IMEX smoke test.
+#
+# A ComputeDomain in host-managed mode (numNodes: 0, allocationMode: Single)
+# plus a pod that confirms channel0 is injected into the container. Requires
+# featureGates.HostManagedIMEX=true on the driver and host nvidia-imex running
+# on the node.
+#
+# The toleration + nodeAffinity below target DGXC GB200 nodes (tainted
+# skyhook.nvidia.com, labeled nvidia.com/gpu.clique). Drop both blocks on
+# clusters without that taint.
+---
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: hostmanaged-smoke
+spec:
+  numNodes: 0
+  channel:
+    resourceClaimTemplate:
+      name: hostmanaged-smoke-channel
+    allocationMode: Single
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostmanaged-smoke
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: skyhook.nvidia.com
+    operator: Exists
+    effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nvidia.com/gpu.clique
+            operator: Exists
+  containers:
+  - name: ctr
+    image: ubuntu:22.04
+    command: ["bash", "-c"]
+    args: ["ls -la /dev/nvidia-caps-imex-channels; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: imex
+  resourceClaims:
+  - name: imex
+    resourceClaimTemplateName: hostmanaged-smoke-channel

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/_helpers.tpl
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/_helpers.tpl
@@ -196,3 +196,21 @@ resource.k8s.io/v1beta1
 {{- else -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+HostManagedIMEX feature gate state.
+
+Returns the string "true" only when the HostManagedIMEX feature gate is
+explicitly enabled in .Values.featureGates (boolean true or the string
+"true"), and an empty string otherwise. Empty string is falsy in Helm
+conditionals, so callers can write:
+  {{- if not (include "dra-driver-nvidia-gpu.hostManagedIMEX" .) }}
+The explicit "true" comparison is required so that
+--set-string featureGates.HostManagedIMEX=false (a non-empty, hence
+truthy, string) is not mistaken for enabled.
+*/}}
+{{- define "dra-driver-nvidia-gpu.hostManagedIMEX" -}}
+{{- if eq (toString (dig "HostManagedIMEX" false (.Values.featureGates | default dict))) "true" -}}
+true
+{{- end -}}
+{{- end -}}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/deviceclass-compute-domain-daemon.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/deviceclass-compute-domain-daemon.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.resources.computeDomains.enabled }}
+{{- if and .Values.resources.computeDomains.enabled (not (include "dra-driver-nvidia-gpu.hostManagedIMEX" .)) }}
 ---
 apiVersion: {{ include "dra-driver-nvidia-gpu.resourceApiVersion" . }}
 kind: DeviceClass

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-compute-domain-daemon.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-compute-domain-daemon.yaml
@@ -1,4 +1,5 @@
 {{- $namespaces := splitList "," (include "dra-driver-nvidia-gpu.namespaces" .) -}}
+{{- if not (include "dra-driver-nvidia-gpu.hostManagedIMEX" .) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -54,4 +55,5 @@ roleRef:
   kind: ClusterRole
   name: system:openshift:scc:anyuid
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -86,6 +86,7 @@ resources:
 # Examples:
 # featureGates:
 #   ExampleFeature: false              # Project-specific alpha feature
+#   HostManagedIMEX: false             # Operator owns host nvidia-imex; driver only advertises/injects channel 0
 #   ContextualLogging: true            # Kubernetes logging feature (enabled by default)
 #   LoggingAlphaOptions: false         # Kubernetes logging alpha features
 #   LoggingBetaOptions: true           # Kubernetes logging beta features

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -26,6 +26,28 @@ If you plan to use ComputeDomains, you also need:
 systemctl disable --now nvidia-imex.service && systemctl mask nvidia-imex.service
 ```
 
+### Host-managed IMEX (`HostManagedIMEX` feature gate)
+
+`HostManagedIMEX` is an alpha, install-wide mode for clusters where the cluster
+operator already owns the host `nvidia-imex` daemon. It **inverts** the rule
+above: the driver does not run per-ComputeDomain IMEX daemons, so the host
+`nvidia-imex.service` must be **configured and running** (not masked) on every
+participating GPU node before workloads use IMEX.
+
+Additional prerequisites when `featureGates.HostManagedIMEX=true`:
+
+- Host `nvidia-imex` installed and `nvidia-imex.service` **enabled and running**,
+  with a consistent `/etc/nvidia-imex/nodes_config.cfg` across the IMEX domain.
+- The `nvidia-caps-imex-channels` device major must be registered (in
+  `/proc/devices`) and channel `0` usable **before the kubelet plugin starts**
+  (the plugin discovers the major at startup and does not republish later).
+- `IMEXDaemonsWithDNSNames` and `ComputeDomainCliques` are forced off
+  automatically when the gate is enabled; no manual override is needed.
+
+Only `allocationMode: Single` (or unset) is supported, and at most one active
+isolated ComputeDomain per host IMEX domain. ComputeDomains should be created
+with `numNodes: 0`.
+
 ## Install prerequisites with NVIDIA GPU Operator
 
 The [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html) is a Kubernetes operator that automates the deployment and lifecycle management of all NVIDIA software components needed to provision and monitor GPUs in a cluster.

--- a/docs/proposals/0001-host-managed-imex.md
+++ b/docs/proposals/0001-host-managed-imex.md
@@ -1,0 +1,302 @@
+# 0001 — Host-managed IMEX (operator-owned `nvidia-imex`)
+
+| Field          | Value         |
+|----------------|---------------|
+| Status         | provisional   |
+| Authors        | @dims         |
+| Created        | 2026-06-01    |
+| Related issues | self-managed host IMEX daemon discussions (link to be added) |
+
+## Summary
+
+This proposal introduces an alpha, install-wide `HostManagedIMEX` feature gate
+for clusters in which the cluster operator already owns the host `nvidia-imex`
+daemon lifecycle. When the gate is enabled, the driver retains the existing
+`ComputeDomain` user API and the existing DRA channel-injection path, but no
+longer creates the per-`ComputeDomain` in-cluster IMEX DaemonSets. The driver
+advertises and injects IMEX channel `0`, while the operator remains responsible
+for starting, configuring, and monitoring `nvidia-imex`. The scope is
+deliberately narrow: this is an operational mode for operator-owned IMEX, not a
+multi-tenant channel-isolation design.
+
+## Motivation
+
+### Who is asking for this, and why?
+
+This is requested by operators of large Multi-Node NVLink (MNNVL) systems —
+GB200 NVL72 and comparable platforms — who already run `nvidia-imex` as a host
+service (through systemd, BCM, NMX, or an equivalent fabric manager), and who
+therefore do not want the DRA driver to launch a second, per-`ComputeDomain`
+IMEX daemon alongside it. The concrete request from these consumers is a
+"self-managed host daemon as a system service" mode, selectable via a Helm
+parameter, in which the user is responsible for the daemon lifecycle and the
+driver only advertises and allocates a channel device. At present the only
+supported model is driver-managed — the controller creates a
+`compute-domain-daemon` DaemonSet for each `ComputeDomain` — which conflicts
+with an operator-run host daemon.
+
+### Goals
+
+- Provide a single install-wide feature gate that, when enabled, prevents the
+  controller from creating IMEX DaemonSets, daemon `ResourceClaimTemplate`s, the
+  daemon `DeviceClass` and RBAC, and `ComputeDomain` node labels.
+- Continue to deliver `/dev/nvidia-caps-imex-channels/channel0` to workloads
+  through the existing DRA channel claim, with no change to how users author a
+  `ComputeDomain` or consume its generated `ResourceClaimTemplate`.
+- Constrain the alpha to a single, well-defined shape: one schedulable channel
+  device per node (`channel-0`), one prepared channel claim per node, and
+  `allocationMode: Single` only.
+- Ensure the driver never starts, restarts, or attests to the health of host
+  `nvidia-imex`. That responsibility belongs to the operator, and the driver's
+  behavior must remain observably independent of imex state.
+- Compose cleanly with the existing GPU DRA path (`resources.gpus.enabled`).
+
+Each goal is measurable: the objects the controller creates, the injected device
+node, the rejected allocation modes, and the driver's inaction on imex failure
+can all be verified directly.
+
+### Non-goals
+
+- Multiple simultaneous, *isolated* `ComputeDomain`s on one host IMEX fabric.
+- Assigning unique IMEX channel IDs per `ComputeDomain`.
+- `allocationMode: All` (multi-channel injection).
+- A scheduler-visible slot model (`slot-0..slot-N`), a channel allocator CRD, or
+  a checkpoint schema migration.
+- Mandatory admission-webhook enforcement.
+- In-place migration between driver-managed and host-managed modes while
+  `ComputeDomain` workloads are running.
+
+## Why this belongs in the NVIDIA DRA driver
+
+The behavior under discussion is entirely the driver's concern: which Kubernetes
+objects the `compute-domain-controller` creates for a `ComputeDomain`, and which
+devices the `compute-domain-kubelet-plugin` publishes and injects. The host
+`nvidia-imex` daemon itself is out of scope and remains owned by the operator
+(or by the GPU Operator, or by BCM/NMX) below the DRA boundary. The change does
+not belong in upstream Kubernetes or DRA core (which are device-agnostic), in
+the device plugin, or in the GPU Operator; it is a mode of the existing
+ComputeDomain/IMEX coordination layer and therefore belongs in this driver. No
+upstream Kubernetes change is required.
+
+## Proposal
+
+### User-facing example
+
+Operators enable a single Helm flag:
+
+```bash
+--set featureGates.HostManagedIMEX=true
+```
+
+Users author a `ComputeDomain` exactly as they do today, with `numNodes: 0` and
+`allocationMode: Single`:
+
+```yaml
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: train-a
+spec:
+  numNodes: 0
+  channel:
+    resourceClaimTemplate:
+      name: train-a-imex-channel
+    allocationMode: Single
+```
+
+Workload pods reference the generated `ResourceClaimTemplate` and receive
+`/dev/nvidia-caps-imex-channels/channel0` inside the container. A
+`status.status` of `Ready` indicates only that the controller has admitted the
+`ComputeDomain` and that the workload `ResourceClaimTemplate` exists; it does
+**not** assert that host IMEX is healthy.
+
+### Affected components
+
+- [ ] `api/` — CRDs, CRD fields, or ResourceClaim shape *(reused unchanged)*
+- [ ] `gpu-kubelet-plugin`
+- [x] `compute-domain-kubelet-plugin`
+- [x] `compute-domain-controller`
+- [ ] `compute-domain-daemon` *(not built or scheduled under the gate)*
+- [ ] admission webhook *(intentionally not required; see Alternatives)*
+- [x] Helm chart (`deployments/helm`)
+- [ ] CDI spec generation *(existing channel-0 edits reused)*
+- [ ] Metrics
+- [ ] Kubelet-plugin checkpoint schema *(no change)*
+- [x] Documentation
+- [x] CI / testing
+
+### Authoritative state owner
+
+This proposal introduces no new persistent state. The host `nvidia-imex` daemon
+and its `/etc/nvidia-imex/nodes_config.cfg` are authoritative for IMEX fabric
+state and are owned by the operator, outside Kubernetes. Within the driver, the
+existing owners are unchanged: the kubelet plugin owns the per-node
+`ResourceSlice` (which publishes `channel-0`) and the local checkpoint (the
+prepared channel claim), and the controller owns the `ComputeDomain` finalizer
+and the workload `ResourceClaimTemplate`. The gate only removes write paths
+(daemon objects and node labels); it adds none.
+
+### Smallest valuable slice
+
+The smallest shippable increment is the gate together with the following:
+suppressing daemon-object creation in the controller; publishing only
+`channel-0` in the kubelet plugin; accepting only an empty or `Single`
+allocation mode; and rejecting daemon-config prepare. This alone provides the
+requested mode. Multi-node scheduling, migration runbooks, and
+documentation and examples can follow incrementally.
+
+## Design
+
+### API changes
+
+There are no changes to CRDs or to the `ComputeDomainChannelConfig` opaque
+config. The only new user-facing value is the Helm setting
+`featureGates.HostManagedIMEX` (default `false`). When the gate is enabled, the
+driver would force two compatible gates off *before* the existing dependency
+validation runs:
+
+- `IMEXDaemonsWithDNSNames=false`
+- `ComputeDomainCliques=false`
+
+This keeps the operator's configuration to a single host-managed flag and avoids
+a three-gate combination. The resulting overrides would be logged at controller
+and kubelet-plugin startup.
+
+One detail concerns the kubelet plugin. The `ComputeDomain` CRD enum restricts
+`allocationMode` to `All` or `Single` for user-created objects, but the opaque
+config the kubelet observes is not covered by that enum. Under the gate,
+`Prepare` would therefore add an explicit allowlist check (empty or `Single`)
+and reject any other value as a permanent error, rather than relying on the
+existing `if == "All"` branch alone.
+
+### Feature gate & graduation
+
+- Introduces `HostManagedIMEX` at **Alpha** stability, default `false`, applied
+  install-wide.
+- The gate is operationally mutually exclusive with driver-managed daemon
+  behavior within a release: mixing driver-managed and host-managed
+  `ComputeDomain`s is not supported. It composes with the GPU DRA path
+  (`resources.gpus.enabled`).
+- Graduation to Beta would be evaluated against the project's three criteria:
+  - *Feature completeness* — channel-0 advertisement and injection, and daemon
+    suppression, behave as designed.
+  - *Interoperability* — validated alongside GPU DRA and the GPU Operator
+    (containerized driver), and against host IMEX run by systemd, BCM, or NMX.
+  - *Stability and soak* — exercised on production-like GB200 fabric long enough
+    to surface fabric and restart edge cases.
+
+### Upgrade & downgrade
+
+Because there is no kubelet-plugin checkpoint schema change, in-flight prepared
+claims are unaffected by a rolling restart of the driver. Switching a cluster
+between driver-managed and host-managed mode is a disruptive, cluster-wide
+operation: drain `ComputeDomain` workloads, delete all `ComputeDomain` objects,
+change the gate value via Helm, and recreate the `ComputeDomain`s. The driver
+would not automatically adopt or remove daemon objects left over from a previous
+mode; the migration runbook covers that cleanup.
+
+### Environment floor
+
+- GPU generations: MNNVL fabric systems on which IMEX channels exist (GB200
+  NVL72 and comparable B200/GB-class fabrics).
+- NVIDIA driver: a version recent enough to register the
+  `nvidia-caps-imex-channels` device major and provide channel 0. The existing
+  ComputeDomain floor (driver ≥ 570.158.01) applies to the channel device even
+  though `IMEXDaemonsWithDNSNames` is forced off.
+- Host `nvidia-imex.service` configured and **running** (not masked), with a
+  consistent `nodes_config.cfg` across the fabric — the inverse of the
+  driver-managed requirement.
+- Kubernetes ≥ 1.34 (`resource.k8s.io/v1` DRA), with CDI enabled in the runtime.
+
+### Test plan
+
+The validation plan spans more than unit tests:
+
+- **Unit** (`pkg/featuregates`, `cmd/compute-domain-controller`,
+  `cmd/compute-domain-kubelet-plugin`): gate registration and the force-off
+  override; channel prepare rejecting `All` and unknown opaque modes via the new
+  allowlist; daemon-config prepare returning a permanent error; an empty clique
+  ID returning a permanent error; the `ResourceSlice` omitting the daemon
+  device; the controller add path creating only the workload RCT and reporting
+  `Ready`; the delete path removing the RCT and finalizers and forgetting
+  metrics; and unprepare skipping node-label removal.
+- **Integration (no GPU):** rendering the Helm chart with the gate on and off,
+  and asserting that the channel `DeviceClass` renders, that the daemon
+  `DeviceClass` and daemon RBAC do not, and that `FEATURE_GATES` is plumbed to
+  the controller and kubelet plugin.
+- **BATS (`tests/bats`):** a host-managed overlay of the channel-injection spec
+  (asserting channel-0 injection with no in-cluster daemon and no daemon
+  objects), and a host-managed variant of the MNNVL workload
+  (`test_cd_mnnvl_workload.bats`'s nvbandwidth) that asserts the
+  `SUM multinode_device_to_device_memcpy_read_ce` line with operator-run host
+  imex.
+- **Mock NVML CI (`hack/ci/mock-nvml`):** exercising the gate behaviors, the
+  `ResourceSlice` shape, and the prepare error paths (including the empty-clique
+  case) on CPU-only runners, since the mock provides the
+  `nvidia-caps-imex-channels` major.
+- **Lambda / real-GPU e2e:** on a `*gb200*` selection, validating channel-0
+  injection end-to-end and a cross-node IMEX workload, and confirming that
+  stopping host imex triggers no driver action and surfaces a CUDA error in the
+  workload.
+
+## Risks
+
+- **Host IMEX health is not visible to Kubernetes.** A pod may start with
+  channel-0 injected while host imex is down or misconfigured, in which case
+  cross-node CUDA operations fail at runtime. The driver deliberately takes no
+  corrective action, so operators must monitor imex out of band. This is an
+  intentional part of the contract, but it relocates a failure mode to the
+  operator and must be documented clearly in the user guide and release notes.
+- **No isolation.** Every host-managed `ComputeDomain` uses channel `0`, so two
+  isolated jobs on the same fabric are not actually isolated. The operational
+  rule is that at most one active, isolated `ComputeDomain` should run per host
+  IMEX domain.
+- **Leftover objects after a mode change.** Skipping the documented migration
+  (deleting all `ComputeDomain`s first) can leave stale driver-managed objects
+  behind.
+- **Privilege surface.** This is unchanged from the existing channel path; the
+  kubelet plugin already injects the channel character device via CDI.
+- **Fail-fast behavior.** The kubelet plugin must continue to fail cleanly when
+  the channel major is absent at startup; the gate must not weaken that.
+
+## Alternatives
+
+- **A full channel allocator** (an `IMEXChannelAllocation` CRD with a reaper,
+  abstract `slot-*` devices, clique-wide optimistic concurrency, a checkpoint
+  V3, and live admission lookups) would enable genuine multi-tenant isolation,
+  but it introduces a large API, status, RBAC, and lifecycle surface. It is
+  deferred to a separate proposal, which this alpha intentionally avoids.
+- **A mandatory admission webhook** (rejecting unsupported claim shapes at
+  admission) was considered and set aside for the alpha: it would require
+  cert-manager, a chart `fail` guard, a config-schema change (a
+  `(namespace, name, domainID)` triple), and live-`Get` RBAC. Host-managed
+  safety can be enforced entirely within the controller and kubelet plugin. An
+  optional, non-mandatory webhook that mirrors the plugin allowlist (to provide
+  clearer errors at `kubectl apply` time) is a possible Beta follow-up.
+- **The status quo (driver-managed only)** does not serve operators who run host
+  `nvidia-imex`, because the driver's daemons collide with the host daemon.
+- **Reuse of existing primitives.** The existing `channel-0` device, the
+  `compute-domain-default-channel.nvidia.com` `DeviceClass`, workload RCT
+  rendering, checkpoint V2, and CDI prepare/unprepare are reused unchanged; the
+  gate suppresses the daemon-side paths rather than introducing new machinery.
+
+## Drawbacks
+
+- The `status` semantics are weak: a `Ready` status says nothing about IMEX
+  health, which may surprise users accustomed to the driver-managed readiness
+  signal.
+- Operator burden increases: `nodes_config.cfg` consistency, channel-0
+  availability, and imex restarts all become the operator's responsibility.
+- The gate is install-wide only — there is no per-namespace or
+  per-`ComputeDomain` mode selection, so a single cluster cannot mix
+  driver-managed and host-managed jobs.
+
+## Open questions
+
+- Should a future revision allow per-namespace or per-`ComputeDomain` mode
+  selection rather than install-wide configuration?
+- Is the optional, non-mandatory admission webhook worth adding for feedback at
+  `kubectl apply` time, or is Prepare-time rejection sufficient?
+- What is the appropriate graduation bridge to a genuine multi-tenant channel
+  allocator? Can host-managed mode and an allocator coexist, or would the
+  allocator subsume this gate?

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 	logsapi "k8s.io/component-base/logs/api/v1"
+	"k8s.io/klog/v2"
 )
 
 // featureGateEmulationVersion is the version passed to component-base's versioned
@@ -74,6 +75,11 @@ const (
 	// DeviceMetadata allows the kubelet plugin to generate device metadata files
 	// in the workloads for prepared devices.
 	DeviceMetadata featuregate.Feature = "DeviceMetadata"
+
+	// HostManagedIMEX assumes the cluster operator owns the host nvidia-imex
+	// daemon lifecycle. The driver keeps the ComputeDomain API and the channel
+	// injection path but stops creating per-ComputeDomain IMEX DaemonSets.
+	HostManagedIMEX featuregate.Feature = "HostManagedIMEX"
 )
 
 // Feature gate Version fields use driver SemVer major.minor.
@@ -148,6 +154,13 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 			Version:    version.MajorMinor(0, 4),
 		},
 	},
+	HostManagedIMEX: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(0, 5),
+		},
+	},
 }
 
 var (
@@ -190,9 +203,32 @@ func newFeatureGates(version *version.Version) featuregate.MutableVersionedFeatu
 	return fg
 }
 
+// resolveHostManagedIMEXOverrides forces the two driver-managed IMEX gates off
+// when HostManagedIMEX is enabled. It runs before the dependency checks in
+// ValidateFeatureGates so the existing "ComputeDomainCliques requires
+// IMEXDaemonsWithDNSNames" rule trivially holds afterwards. Both overridden
+// gates default to true upstream, so this explicitly sets them false rather
+// than resetting to a default.
+func resolveHostManagedIMEXOverrides(gates featuregate.MutableFeatureGate) {
+	if !gates.Enabled(HostManagedIMEX) {
+		return
+	}
+	if gates.Enabled(IMEXDaemonsWithDNSNames) {
+		klog.Infof("HostManagedIMEX is enabled; forcing IMEXDaemonsWithDNSNames=false")
+		_ = gates.Set("IMEXDaemonsWithDNSNames=false")
+	}
+	if gates.Enabled(ComputeDomainCliques) {
+		klog.Infof("HostManagedIMEX is enabled; forcing ComputeDomainCliques=false")
+		_ = gates.Set("ComputeDomainCliques=false")
+	}
+}
+
 // ValidateFeatureGates validates feature gate dependencies and returns an error if
 // any dependencies are not satisfied.
 func ValidateFeatureGates() error {
+	// Resolve install-wide gate overrides before checking dependencies.
+	resolveHostManagedIMEXOverrides(FeatureGates())
+
 	// ComputeDomainCliques requires IMEXDaemonsWithDNSNames
 	if Enabled(ComputeDomainCliques) && !Enabled(IMEXDaemonsWithDNSNames) {
 		return fmt.Errorf("feature gate %s requires %s to also be enabled", ComputeDomainCliques, IMEXDaemonsWithDNSNames)

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -515,6 +515,18 @@ func TestValidateFeatureGates(t *testing.T) {
 			expectError: false,
 			description: "should be valid when both DeviceMetadata and PassthroughSupport are enabled",
 		},
+		{
+			name:        "HostManagedIMEX enabled alone",
+			fgMap:       map[featuregate.Feature]bool{HostManagedIMEX: true},
+			expectError: false,
+			description: "HostManagedIMEX forces the conflicting gates off, so validation passes",
+		},
+		{
+			name:        "HostManagedIMEX resolves CDCliques-without-DNSNames conflict",
+			fgMap:       map[featuregate.Feature]bool{HostManagedIMEX: true, ComputeDomainCliques: true, IMEXDaemonsWithDNSNames: false},
+			expectError: false,
+			description: "the override forces both gates off before the dependency check runs",
+		},
 	}
 
 	for _, tt := range tests {
@@ -544,4 +556,35 @@ func TestValidateFeatureGates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveHostManagedIMEXOverrides(t *testing.T) {
+	t.Run("no-op when HostManagedIMEX is disabled", func(t *testing.T) {
+		fg := newFeatureGates(TestVersion)
+		// Both default to true upstream.
+		require.True(t, fg.Enabled(IMEXDaemonsWithDNSNames))
+		require.True(t, fg.Enabled(ComputeDomainCliques))
+
+		resolveHostManagedIMEXOverrides(fg)
+
+		require.True(t, fg.Enabled(IMEXDaemonsWithDNSNames), "should be untouched when HostManagedIMEX is off")
+		require.True(t, fg.Enabled(ComputeDomainCliques), "should be untouched when HostManagedIMEX is off")
+	})
+
+	t.Run("forces dependent gates off when HostManagedIMEX is enabled", func(t *testing.T) {
+		fg := newFeatureGates(TestVersion)
+		require.NoError(t, fg.SetFromMap(map[string]bool{string(HostManagedIMEX): true}))
+
+		resolveHostManagedIMEXOverrides(fg)
+
+		require.True(t, fg.Enabled(HostManagedIMEX))
+		require.False(t, fg.Enabled(IMEXDaemonsWithDNSNames), "HostManagedIMEX must force IMEXDaemonsWithDNSNames off")
+		require.False(t, fg.Enabled(ComputeDomainCliques), "HostManagedIMEX must force ComputeDomainCliques off")
+
+		// The existing dependency validation must pass after the override.
+		oldGates := featureGates
+		featureGates = fg
+		defer func() { featureGates = oldGates }()
+		require.NoError(t, ValidateFeatureGates())
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

Please see `docs/proposals/0001-host-managed-imex.md`

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note

```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
