### PR TITLE
feat: add gpu numa node attribute

### DIFF
--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 )
 
-const compatibilityNumaNodeAttribute resourceapi.QualifiedName = "dra.net/numaNode"
+const standardNumaNodeAttribute resourceapi.QualifiedName = "resource.kubernetes.io/numaNode"
 
 // Represents a specific, full, physical GPU device.
 type GpuInfo struct {
@@ -202,7 +202,7 @@ func (d *GpuInfo) Attributes() map[resourceapi.QualifiedName]resourceapi.DeviceA
 		attrs[d.pcieRootAttr.Name] = d.pcieRootAttr.Value
 	}
 
-	addCompatibilityNumaNodeAttribute(attrs, d.numaNode)
+	addNumaNodeAttribute(attrs, d.numaNode)
 
 	if d.addressingMode != nil {
 		attrs["addressingMode"] = resourceapi.DeviceAttribute{
@@ -291,7 +291,7 @@ func (d *VfioDeviceInfo) GetDevice() resourceapi.Device {
 	if featuregates.Enabled(featuregates.FabricManagerPartitioning) {
 		d.addFabricManagerAttributes(device.Attributes)
 	}
-	addCompatibilityNumaNodeAttribute(device.Attributes, &d.numaNode)
+	addNumaNodeAttribute(device.Attributes, &d.numaNode)
 
 	return device
 }
@@ -329,11 +329,22 @@ func (d *VfioDeviceInfo) addFabricManagerAttributes(attrs map[resourceapi.Qualif
 	}
 }
 
-func addCompatibilityNumaNodeAttribute(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, numaNode *int) {
+func addNumaNodeAttribute(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, numaNode *int) {
 	if numaNode == nil || *numaNode < 0 {
 		return
 	}
-	attrs[compatibilityNumaNodeAttribute] = resourceapi.DeviceAttribute{
+
+	if featuregates.Enabled(featuregates.DRAListTypeAttributes) {
+		// KEP-6072 prefers the list form when DRAListTypeAttributes is enabled.
+		// Until this driver computes same-socket minimum-SLIT-distance nodes,
+		// publish the physical NUMA node as a valid single-element list.
+		attrs[standardNumaNodeAttribute] = resourceapi.DeviceAttribute{
+			IntValues: []int64{int64(*numaNode)},
+		}
+		return
+	}
+
+	attrs[standardNumaNodeAttribute] = resourceapi.DeviceAttribute{
 		IntValue: ptr.To(int64(*numaNode)),
 	}
 }

--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 )
 
+const compatibilityNumaNodeAttribute resourceapi.QualifiedName = "dra.net/numaNode"
+
 // Represents a specific, full, physical GPU device.
 type GpuInfo struct {
 	UUID                  string `json:"uuid"`
@@ -47,6 +49,7 @@ type GpuInfo struct {
 	pciBusID              string
 	pciBusIDAttr          *deviceattribute.DeviceAttribute
 	pcieRootAttr          *deviceattribute.DeviceAttribute
+	numaNode              *int
 	migProfiles           []*MigProfileInfo
 	addressingMode        *string
 
@@ -199,9 +202,7 @@ func (d *GpuInfo) Attributes() map[resourceapi.QualifiedName]resourceapi.DeviceA
 		attrs[d.pcieRootAttr.Name] = d.pcieRootAttr.Value
 	}
 
-	if d.pciBusIDAttr != nil {
-		attrs[d.pciBusIDAttr.Name] = d.pciBusIDAttr.Value
-	}
+	addCompatibilityNumaNodeAttribute(attrs, d.numaNode)
 
 	if d.addressingMode != nil {
 		attrs["addressingMode"] = resourceapi.DeviceAttribute{
@@ -290,6 +291,7 @@ func (d *VfioDeviceInfo) GetDevice() resourceapi.Device {
 	if featuregates.Enabled(featuregates.FabricManagerPartitioning) {
 		d.addFabricManagerAttributes(device.Attributes)
 	}
+	addCompatibilityNumaNodeAttribute(device.Attributes, &d.numaNode)
 
 	return device
 }
@@ -324,5 +326,14 @@ func (d *VfioDeviceInfo) addFabricManagerAttributes(attrs map[resourceapi.Qualif
 		attrs[key] = resourceapi.DeviceAttribute{
 			IntValue: ptr.To(int64(partitionID)),
 		}
+	}
+}
+
+func addCompatibilityNumaNodeAttribute(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, numaNode *int) {
+	if numaNode == nil || *numaNode < 0 {
+		return
+	}
+	attrs[compatibilityNumaNodeAttribute] = resourceapi.DeviceAttribute{
+		IntValue: ptr.To(int64(*numaNode)),
 	}
 }

--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -263,9 +263,6 @@ func (d *VfioDeviceInfo) GetDevice() resourceapi.Device {
 			"vendorID": {
 				StringValue: &d.vendorID,
 			},
-			"numa": {
-				IntValue: ptr.To(int64(d.numaNode)),
-			},
 			"productName": {
 				StringValue: &d.productName,
 			},

--- a/cmd/gpu-kubelet-plugin/deviceinfo_test.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestGpuInfo(numaNode *int) *GpuInfo {
+	return &GpuInfo{
+		UUID:                  "GPU-test",
+		minor:                 0,
+		productName:           "NVIDIA Test GPU",
+		brand:                 "NVIDIA",
+		architecture:          "Test",
+		cudaComputeCapability: "9.0",
+		driverVersion:         "580.0.0",
+		cudaDriverVersion:     "13.0",
+		numaNode:              numaNode,
+	}
+}
+
+func requireNumaNodeAttribute(t *testing.T, attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, expected int64) {
+	t.Helper()
+
+	attr, ok := attrs[compatibilityNumaNodeAttribute]
+	require.True(t, ok)
+	require.NotNil(t, attr.IntValue)
+	require.Equal(t, expected, *attr.IntValue)
+}
+
+func TestGpuInfoAttributesIncludeCompatibilityNumaNode(t *testing.T) {
+	gpu := newTestGpuInfo(ptr.To(1))
+
+	requireNumaNodeAttribute(t, gpu.Attributes(), 1)
+}
+
+func TestCommonMigAttributesIncludeCompatibilityNumaNode(t *testing.T) {
+	parent := newTestGpuInfo(ptr.To(2))
+
+	requireNumaNodeAttribute(t, CommonAttributesMig(parent, "1g.10gb"), 2)
+}
+
+func TestVfioDeviceIncludesCompatibilityNumaNode(t *testing.T) {
+	vfio := &VfioDeviceInfo{
+		UUID:                   "vfio-test",
+		deviceID:               "0x1234",
+		vendorID:               "0x10de",
+		index:                  0,
+		productName:            "NVIDIA Test GPU",
+		numaNode:               3,
+		addressableMemoryBytes: 1024,
+	}
+
+	requireNumaNodeAttribute(t, vfio.GetDevice().Attributes, 3)
+}

--- a/cmd/gpu-kubelet-plugin/deviceinfo_test.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo_test.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 )
 
 func newTestGpuInfo(numaNode *int) *GpuInfo {
@@ -42,25 +44,49 @@ func newTestGpuInfo(numaNode *int) *GpuInfo {
 func requireNumaNodeAttribute(t *testing.T, attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, expected int64) {
 	t.Helper()
 
-	attr, ok := attrs[compatibilityNumaNodeAttribute]
+	attr, ok := attrs[standardNumaNodeAttribute]
 	require.True(t, ok)
 	require.NotNil(t, attr.IntValue)
 	require.Equal(t, expected, *attr.IntValue)
 }
 
-func TestGpuInfoAttributesIncludeCompatibilityNumaNode(t *testing.T) {
+func requireNumaNodeListAttribute(t *testing.T, attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, expected []int64) {
+	t.Helper()
+
+	attr, ok := attrs[standardNumaNodeAttribute]
+	require.True(t, ok)
+	require.Nil(t, attr.IntValue)
+	require.Equal(t, expected, attr.IntValues)
+}
+
+func TestGpuInfoAttributesIncludeStandardNumaNode(t *testing.T) {
 	gpu := newTestGpuInfo(ptr.To(1))
 
 	requireNumaNodeAttribute(t, gpu.Attributes(), 1)
 }
 
-func TestCommonMigAttributesIncludeCompatibilityNumaNode(t *testing.T) {
+func TestGpuInfoAttributesIncludeStandardNumaNodeListWhenEnabled(t *testing.T) {
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+		string(featuregates.DRAListTypeAttributes): true,
+	}))
+	defer func() {
+		require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+			string(featuregates.DRAListTypeAttributes): false,
+		}))
+	}()
+
+	gpu := newTestGpuInfo(ptr.To(1))
+
+	requireNumaNodeListAttribute(t, gpu.Attributes(), []int64{1})
+}
+
+func TestCommonMigAttributesIncludeStandardNumaNode(t *testing.T) {
 	parent := newTestGpuInfo(ptr.To(2))
 
 	requireNumaNodeAttribute(t, CommonAttributesMig(parent, "1g.10gb"), 2)
 }
 
-func TestVfioDeviceIncludesCompatibilityNumaNode(t *testing.T) {
+func TestVfioDeviceIncludesStandardNumaNode(t *testing.T) {
 	vfio := &VfioDeviceInfo{
 		UUID:                   "vfio-test",
 		deviceID:               "0x1234",

--- a/cmd/gpu-kubelet-plugin/mig.go
+++ b/cmd/gpu-kubelet-plugin/mig.go
@@ -181,6 +181,8 @@ func CommonAttributesMig(parent *GpuInfo, profileName string) map[resourceapi.Qu
 		attrs[parent.pcieRootAttr.Name] = parent.pcieRootAttr.Value
 	}
 
+	addCompatibilityNumaNodeAttribute(attrs, parent.numaNode)
+
 	return attrs
 }
 

--- a/cmd/gpu-kubelet-plugin/mig.go
+++ b/cmd/gpu-kubelet-plugin/mig.go
@@ -181,7 +181,7 @@ func CommonAttributesMig(parent *GpuInfo, profileName string) map[resourceapi.Qu
 		attrs[parent.pcieRootAttr.Name] = parent.pcieRootAttr.Value
 	}
 
-	addCompatibilityNumaNodeAttribute(attrs, parent.numaNode)
+	addNumaNodeAttribute(attrs, parent.numaNode)
 
 	return attrs
 }

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -525,7 +525,7 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		return nil, fmt.Errorf("error getting PCI bus ID for device %d: %w", index, err)
 	}
 
-	numaNode, err := l.discoverNumaNode(pciBusID, device.GetNumaNodeId)
+	numaNode, err := l.discoverNumaNode(pciBusID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting NUMA node ID for device %d: %w", index, err)
 	}
@@ -641,18 +641,7 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 	return gpuInfo, nil
 }
 
-func (l deviceLib) discoverNumaNode(pciBusID string, getNVMLNumaNode func() (int, nvml.Return)) (*int, error) {
-	if node, ret := getNVMLNumaNode(); ret == nvml.SUCCESS {
-		if node < 0 {
-			return nil, nil
-		}
-		return &node, nil
-	} else if ret != nvml.ERROR_NOT_SUPPORTED && ret != nvml.ERROR_FUNCTION_NOT_FOUND && ret != nvml.ERROR_NOT_FOUND {
-		return nil, fmt.Errorf("nvmlDeviceGetNumaNodeId returned %v", ret)
-	} else {
-		klog.V(4).Infof("NVML NUMA node ID unavailable for PCI bus ID %s, falling back to PCI sysfs: %v", pciBusID, ret)
-	}
-
+func (l deviceLib) discoverNumaNode(pciBusID string) (*int, error) {
 	if l.nvpci == nil {
 		return nil, nil
 	}

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -525,6 +525,15 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		return nil, fmt.Errorf("error getting PCI bus ID for device %d: %w", index, err)
 	}
 
+	var numaNode *int
+	if node, ret := device.GetNumaNodeId(); ret == nvml.SUCCESS {
+		numaNode = &node
+	} else if ret == nvml.ERROR_NOT_SUPPORTED || ret == nvml.ERROR_FUNCTION_NOT_FOUND || ret == nvml.ERROR_NOT_FOUND {
+		klog.V(4).Infof("NUMA node ID unavailable for device %d, continuing without attribute: %v", index, ret)
+	} else {
+		return nil, fmt.Errorf("error getting NUMA node ID for device %d: %v", index, ret)
+	}
+
 	// Get the memory-addressing mode supported by the device.
 	// On coherent-memory systems, the possible modes are:
 	//   - HMM  (Hardware Memory Management)
@@ -620,6 +629,7 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		pciBusID:              pciBusID,
 		pciBusIDAttr:          pciBusIDAttr,
 		pcieRootAttr:          pcieRootAttr,
+		numaNode:              numaNode,
 		migProfiles:           migProfiles,
 		addressingMode:        addressingMode,
 	}

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -525,13 +525,9 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		return nil, fmt.Errorf("error getting PCI bus ID for device %d: %w", index, err)
 	}
 
-	var numaNode *int
-	if node, ret := device.GetNumaNodeId(); ret == nvml.SUCCESS {
-		numaNode = &node
-	} else if ret == nvml.ERROR_NOT_SUPPORTED || ret == nvml.ERROR_FUNCTION_NOT_FOUND || ret == nvml.ERROR_NOT_FOUND {
-		klog.V(4).Infof("NUMA node ID unavailable for device %d, continuing without attribute: %v", index, ret)
-	} else {
-		return nil, fmt.Errorf("error getting NUMA node ID for device %d: %v", index, ret)
+	numaNode, err := l.discoverNumaNode(pciBusID, device.GetNumaNodeId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting NUMA node ID for device %d: %w", index, err)
 	}
 
 	// Get the memory-addressing mode supported by the device.
@@ -643,6 +639,33 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 	}
 
 	return gpuInfo, nil
+}
+
+func (l deviceLib) discoverNumaNode(pciBusID string, getNVMLNumaNode func() (int, nvml.Return)) (*int, error) {
+	if node, ret := getNVMLNumaNode(); ret == nvml.SUCCESS {
+		if node < 0 {
+			return nil, nil
+		}
+		return &node, nil
+	} else if ret != nvml.ERROR_NOT_SUPPORTED && ret != nvml.ERROR_FUNCTION_NOT_FOUND && ret != nvml.ERROR_NOT_FOUND {
+		return nil, fmt.Errorf("nvmlDeviceGetNumaNodeId returned %v", ret)
+	} else {
+		klog.V(4).Infof("NVML NUMA node ID unavailable for PCI bus ID %s, falling back to PCI sysfs: %v", pciBusID, ret)
+	}
+
+	if l.nvpci == nil {
+		return nil, nil
+	}
+
+	gpu, err := l.nvpci.GetGPUByPciBusID(pciBusID)
+	if err != nil {
+		klog.Warningf("error getting PCI device for PCI bus ID %s, continuing without NUMA node attribute: %v", pciBusID, err)
+		return nil, nil
+	}
+	if gpu == nil || gpu.NumaNode < 0 {
+		return nil, nil
+	}
+	return &gpu.NumaNode, nil
 }
 
 func (l deviceLib) enumerateGpuVfioDevices(perGPUAllocatable *PerGPUAllocatableDevices) error {

--- a/cmd/gpu-kubelet-plugin/nvlib_test.go
+++ b/cmd/gpu-kubelet-plugin/nvlib_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvlib/pkg/nvpci"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverNumaNodeUsesNVMLWhenAvailable(t *testing.T) {
+	lib := deviceLib{}
+
+	numaNode, err := lib.discoverNumaNode("0000:9f:00.0", func() (int, nvml.Return) {
+		return 1, nvml.SUCCESS
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, numaNode)
+	require.Equal(t, 1, *numaNode)
+}
+
+func TestDiscoverNumaNodeFallsBackToPCIWhenNVMLUnsupported(t *testing.T) {
+	pci := &nvpci.InterfaceMock{
+		GetGPUByPciBusIDFunc: func(pciBusID string) (*nvpci.NvidiaPCIDevice, error) {
+			require.Equal(t, "0000:9f:00.0", pciBusID)
+			return &nvpci.NvidiaPCIDevice{NumaNode: 2}, nil
+		},
+	}
+	lib := deviceLib{nvpci: pci}
+
+	numaNode, err := lib.discoverNumaNode("0000:9f:00.0", func() (int, nvml.Return) {
+		return 0, nvml.ERROR_NOT_SUPPORTED
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, numaNode)
+	require.Equal(t, 2, *numaNode)
+	require.Len(t, pci.GetGPUByPciBusIDCalls(), 1)
+}
+
+func TestDiscoverNumaNodeOmitsUnknownPCINumaNode(t *testing.T) {
+	pci := &nvpci.InterfaceMock{
+		GetGPUByPciBusIDFunc: func(string) (*nvpci.NvidiaPCIDevice, error) {
+			return &nvpci.NvidiaPCIDevice{NumaNode: -1}, nil
+		},
+	}
+	lib := deviceLib{nvpci: pci}
+
+	numaNode, err := lib.discoverNumaNode("0000:9f:00.0", func() (int, nvml.Return) {
+		return 0, nvml.ERROR_NOT_SUPPORTED
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, numaNode)
+}

--- a/cmd/gpu-kubelet-plugin/nvlib_test.go
+++ b/cmd/gpu-kubelet-plugin/nvlib_test.go
@@ -20,23 +20,10 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/go-nvlib/pkg/nvpci"
-	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDiscoverNumaNodeUsesNVMLWhenAvailable(t *testing.T) {
-	lib := deviceLib{}
-
-	numaNode, err := lib.discoverNumaNode("0000:9f:00.0", func() (int, nvml.Return) {
-		return 1, nvml.SUCCESS
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, numaNode)
-	require.Equal(t, 1, *numaNode)
-}
-
-func TestDiscoverNumaNodeFallsBackToPCIWhenNVMLUnsupported(t *testing.T) {
+func TestDiscoverNumaNodeUsesPCI(t *testing.T) {
 	pci := &nvpci.InterfaceMock{
 		GetGPUByPciBusIDFunc: func(pciBusID string) (*nvpci.NvidiaPCIDevice, error) {
 			require.Equal(t, "0000:9f:00.0", pciBusID)
@@ -45,9 +32,7 @@ func TestDiscoverNumaNodeFallsBackToPCIWhenNVMLUnsupported(t *testing.T) {
 	}
 	lib := deviceLib{nvpci: pci}
 
-	numaNode, err := lib.discoverNumaNode("0000:9f:00.0", func() (int, nvml.Return) {
-		return 0, nvml.ERROR_NOT_SUPPORTED
-	})
+	numaNode, err := lib.discoverNumaNode("0000:9f:00.0")
 
 	require.NoError(t, err)
 	require.NotNil(t, numaNode)
@@ -63,9 +48,7 @@ func TestDiscoverNumaNodeOmitsUnknownPCINumaNode(t *testing.T) {
 	}
 	lib := deviceLib{nvpci: pci}
 
-	numaNode, err := lib.discoverNumaNode("0000:9f:00.0", func() (int, nvml.Return) {
-		return 0, nvml.ERROR_NOT_SUPPORTED
-	})
+	numaNode, err := lib.discoverNumaNode("0000:9f:00.0")
 
 	require.NoError(t, err)
 	require.Nil(t, numaNode)

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -114,6 +114,7 @@ resources:
 #   LoggingBetaOptions: true           # Kubernetes logging beta features
 #   NVMLDeviceHealthCheck: false       # GPU Health Checking using NVML
 #   HostManagedIMEXDaemon: false       # Gate allowing resources.computeDomains.imex.mode=hostManaged
+#   DRAListTypeAttributes: false       # Publish list-valued DRA device attributes
 featureGates: {}
 
 # Log verbosity for all components. Zero or greater, higher number means higher

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -84,6 +84,11 @@ const (
 	// driver behavior, it only unlocks the mode for clusters where
 	// the cluster admin owns the host nvidia-imex daemon lifecycle.
 	HostManagedIMEXDaemon featuregate.Feature = "HostManagedIMEXDaemon"
+
+	// DRAListTypeAttributes allows the GPU kubelet plugin to publish list-valued
+	// DRA device attributes. The cluster must have the Kubernetes feature gate
+	// of the same name enabled before enabling this in the driver.
+	DRAListTypeAttributes featuregate.Feature = "DRAListTypeAttributes"
 )
 
 // Feature gate Version fields use driver SemVer major.minor.
@@ -170,6 +175,13 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 			Default:    false,
 			PreRelease: featuregate.Alpha,
 			Version:    version.MajorMinor(0, 5),
+		},
+	},
+	DRAListTypeAttributes: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(0, 4),
 		},
 	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This adds the standard `resource.kubernetes.io/numaNode` attribute to GPU, MIG, and VFIO GPU devices when NUMA locality is available.

The attribute name and list-valued form follow [KEP-6072: DRA Standard NUMA Node Attribute](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/6072-dra-standard-numanode/README.md), while preserving scalar publication when `DRAListTypeAttributes` is disabled for compatibility.

The NUMA node is discovered from PCI sysfs via `nvpci.GetGPUByPciBusID(...)`, using the kernel PCI topology as the source of truth. If sysfs reports `-1`, the attribute is omitted because the NUMA locality is not configured.

This standard attribute is expected to make it easier to write ResourceClaims that align GPUs with other DRA-provided devices on the same NUMA node as other drivers adopt the same attribute.

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
```release-note
Add the standard `resource.kubernetes.io/numaNode` attribute to GPU, MIG, and VFIO GPU devices when NUMA locality is available.
```

#### Additional documentation (design docs, usage docs, etc.):

```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [x] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
