### PR TITLE
Adding support to build provenance and sbom for build images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,6 +15,8 @@ steps:
     env:
       - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia
       - GIT_COMMIT=${_PULL_BASE_SHA}
+      - IMG_PROVENANCE=true
+      - IMG_SBOM=true
   - id: publish-chart
     name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de
     entrypoint: ./hack/build-and-publish-chart.sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,6 +23,12 @@ steps:
     env:
       - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia
       - GIT_COMMIT=${_PULL_BASE_SHA}
+      - PULL_BASE_REF=${_PULL_BASE_REF}
+      - BUILD_ID=${BUILD_ID}
+      - PROJECT_ID=${PROJECT_ID}
+      - CHART_PROVENANCE=true
+      - CHART_SBOM=true
+      - COSIGN_OIDC_PROVIDER=google
 substitutions:
   _GIT_TAG: 'v0-placeholder'
   _PULL_BASE_REF: 'main'

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -16,6 +16,8 @@ BUILD_MULTI_ARCH_IMAGES ?= no
 DOCKER ?= docker
 REGCTL ?= regctl
 PUSH_ON_BUILD ?= false
+PROVENANCE ?= false
+SBOM ?= false
 
 ##### Global variables #####
 include $(CURDIR)/versions.mk
@@ -48,13 +50,13 @@ DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64,linux/arm64
 ifeq ($(BUILD_MULTI_ARCH_GH),true)
 DOCKER_BUILD_OPTIONS = \
 	--output=type=oci,dest=$(OCI_OUTPUT) \
-	--provenance=false \
-	--sbom=false
+	--provenance=$(PROVENANCE) \
+	--sbom=$(SBOM)
 else
 DOCKER_BUILD_OPTIONS = \
-	--output=type=image,push=$(PUSH_ON_BUILD) \
-	--provenance=false \
-	--sbom=false
+	--output=type=image,push=$(PUSH_ON_BUILD),oci-mediatypes=true \
+	--provenance=$(PROVENANCE) \
+	--sbom=$(SBOM)
 endif
 else
 # We also support building single-platform images.

--- a/hack/build-and-publish-chart.sh
+++ b/hack/build-and-publish-chart.sh
@@ -40,7 +40,67 @@ echo "Using CHART_VERSION=${CHART_VERSION} (IMG_TAG without leading v)"
 
 DRIVER_NAME=$(make --no-print-directory -f "${REPO_ROOT}/versions.mk" print-DRIVER_NAME)
 HELM="${HELM:-helm}"
+COSIGN="${COSIGN:-cosign}"
+COSIGN_VERSION="${COSIGN_VERSION:-v3.0.6}"
+JQ_VERSION="${JQ_VERSION:-jq-1.7.1}"
+CHART_PROVENANCE="${CHART_PROVENANCE:-false}"
+CHART_SBOM="${CHART_SBOM:-false}"
 DIST_DIR="${REPO_ROOT}/dist"
+
+chart_attestations_enabled() {
+	[[ "${CHART_PROVENANCE}" == "true" || "${CHART_SBOM}" == "true" ]]
+}
+
+ensure_cosign() {
+	if command -v "${COSIGN}" >/dev/null 2>&1; then
+		return
+	fi
+
+	if [[ "${COSIGN}" != "cosign" ]]; then
+		echo "COSIGN=${COSIGN} is not available" >&2
+		exit 1
+	fi
+
+	echo "Installing cosign ${COSIGN_VERSION}..."
+	curl -sSfL --retry 8 --retry-all-errors --connect-timeout 10 --retry-delay 5 \
+		-o /usr/local/bin/cosign \
+		"https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64"
+	chmod +x /usr/local/bin/cosign
+}
+
+ensure_jq() {
+	if command -v jq >/dev/null 2>&1; then
+		return
+	fi
+
+	echo "Installing jq ${JQ_VERSION}..."
+	curl -sSfL --retry 8 --retry-all-errors --connect-timeout 10 --retry-delay 5 \
+		-o /usr/local/bin/jq \
+		"https://github.com/jqlang/jq/releases/download/${JQ_VERSION}/jq-linux-amd64"
+	chmod +x /usr/local/bin/jq
+}
+
+cosign_attest_chart() {
+	local predicate=$1
+	local predicate_type=$2
+	local label=$3
+	local cmd=("${COSIGN}" attest --yes --predicate "${predicate}" --type "${predicate_type}")
+
+	if [[ -n ${COSIGN_KEY:-} ]]; then
+		cmd+=(--key "${COSIGN_KEY}")
+	fi
+	if [[ -n ${COSIGN_IDENTITY_TOKEN:-} ]]; then
+		cmd+=(--identity-token "${COSIGN_IDENTITY_TOKEN}")
+	fi
+	if [[ -n ${COSIGN_OIDC_PROVIDER:-} ]]; then
+		cmd+=(--oidc-provider "${COSIGN_OIDC_PROVIDER}")
+	fi
+
+	cmd+=("${CHART_REF}")
+
+	echo "Attesting ${label} for ${CHART_REF}"
+	"${cmd[@]}"
+}
 
 if ! command -v helm >/dev/null 2>&1; then
 	echo "Installing Helm 3..."
@@ -48,6 +108,25 @@ if ! command -v helm >/dev/null 2>&1; then
 		https://get.helm.sh/helm-v3.18.6-linux-amd64.tar.gz
 	tar -zxvf helm-v3*linux-amd64.tar.gz
 	mv linux-amd64/helm /usr/local/bin/helm
+fi
+
+if [[ -z ${GIT_COMMIT:-} ]]; then
+	GIT_COMMIT=$(git rev-parse HEAD)
+fi
+echo "Using GIT_COMMIT=${GIT_COMMIT}"
+
+if chart_attestations_enabled; then
+	ensure_jq
+	ensure_cosign
+fi
+
+REGISTRY_HOST="${IMG_PREFIX%%/*}"
+if command -v gcloud >/dev/null 2>&1; then
+	case "${REGISTRY_HOST}" in
+	*.pkg.dev | gcr.io | *.gcr.io)
+		gcloud auth configure-docker "${REGISTRY_HOST}" --quiet
+		;;
+	esac
 fi
 
 mkdir -p "${DIST_DIR}"
@@ -70,4 +149,38 @@ fi
 
 CHART_TGZ="${DIST_DIR}/${DRIVER_NAME}-${CHART_VERSION}.tgz"
 echo "Pushing ${CHART_TGZ} -> oci://${IMG_PREFIX}/charts"
-"${HELM}" push "${CHART_TGZ}" "oci://${IMG_PREFIX}/charts"
+if ! PUSH_OUTPUT=$("${HELM}" push "${CHART_TGZ}" "oci://${IMG_PREFIX}/charts" 2>&1); then
+	printf '%s\n' "${PUSH_OUTPUT}"
+	exit 1
+fi
+printf '%s\n' "${PUSH_OUTPUT}"
+
+if chart_attestations_enabled; then
+	CHART_DIGEST=${CHART_DIGEST:-$(printf '%s\n' "${PUSH_OUTPUT}" | awk '/Digest:/ { print $2; exit }')}
+	if [[ -z "${CHART_DIGEST}" ]]; then
+		echo "could not determine chart digest from helm push output" >&2
+		exit 1
+	fi
+
+	CHART_REF="${IMG_PREFIX}/charts/${DRIVER_NAME}@${CHART_DIGEST}"
+	echo "Using CHART_REF=${CHART_REF}"
+
+	CHART_NAME="${DRIVER_NAME}" \
+	CHART_VERSION="${CHART_VERSION}" \
+	GIT_COMMIT="${GIT_COMMIT}" \
+	PULL_BASE_REF="${PULL_BASE_REF:-}" \
+	BUILD_ID="${BUILD_ID:-}" \
+	PROJECT_ID="${PROJECT_ID:-}" \
+	bash "${REPO_ROOT}/hack/generate-helm-chart-attestation-predicates.sh" \
+		"${CHART_TGZ}" \
+		"${CHART_REF}" \
+		"${DIST_DIR}"
+
+	CHART_PREDICATE_PREFIX="${DIST_DIR}/${DRIVER_NAME}-${CHART_VERSION}"
+	if [[ "${CHART_PROVENANCE}" == "true" ]]; then
+		cosign_attest_chart "${CHART_PREDICATE_PREFIX}.slsa-provenance.json" slsaprovenance1 "SLSA provenance"
+	fi
+	if [[ "${CHART_SBOM}" == "true" ]]; then
+		cosign_attest_chart "${CHART_PREDICATE_PREFIX}.sbom.spdx.json" spdxjson "SPDX SBOM"
+	fi
+fi

--- a/hack/build-and-publish-image.sh
+++ b/hack/build-and-publish-image.sh
@@ -38,6 +38,9 @@ if [[ -z ${GIT_COMMIT:-} ]]; then
 fi
 echo "Using GIT_COMMIT=${GIT_COMMIT}"
 
+IMG_PROVENANCE="${IMG_PROVENANCE:-false}"
+IMG_SBOM="${IMG_SBOM:-false}"
+
 export CI=true
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
@@ -52,4 +55,6 @@ make -f deployments/container/Makefile build \
 	PUSH_ON_BUILD=true \
 	REGISTRY="${IMG_PREFIX}" \
 	VERSION="${IMG_TAG}" \
-	GIT_COMMIT="${GIT_COMMIT}"
+	GIT_COMMIT="${GIT_COMMIT}" \
+	PROVENANCE="${IMG_PROVENANCE}" \
+	SBOM="${IMG_SBOM}"

--- a/hack/generate-helm-chart-attestation-predicates.sh
+++ b/hack/generate-helm-chart-attestation-predicates.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate predicate files for Helm chart OCI attestations.
+#
+# This emits:
+# - SLSA provenance v1 predicate JSON for cosign --type slsaprovenance1
+# - SPDX 2.3 JSON SBOM predicate for cosign --type spdxjson
+
+set -euo pipefail
+
+usage() {
+	cat >&2 <<'EOF'
+Usage: hack/generate-helm-chart-attestation-predicates.sh CHART_TGZ CHART_REF [OUT_DIR]
+
+CHART_REF must be the OCI chart reference by digest, for example:
+  us-central1-docker.pkg.dev/example/charts/dra-driver-nvidia-gpu@sha256:...
+EOF
+}
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+	usage
+	exit 2
+fi
+
+CHART_TGZ=$1
+CHART_REF=$2
+OUT_DIR=${3:-$(dirname "${CHART_TGZ}")}
+
+if [[ ! -f "${CHART_TGZ}" ]]; then
+	echo "chart package does not exist: ${CHART_TGZ}" >&2
+	exit 1
+fi
+
+for tool in awk date jq sed sha256sum tar; do
+	if ! command -v "${tool}" >/dev/null 2>&1; then
+		echo "required tool not found: ${tool}" >&2
+		exit 1
+	fi
+done
+
+REPO_ROOT=${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
+CHART_FILENAME=$(basename "${CHART_TGZ}")
+CHART_BASENAME=${CHART_FILENAME%.tgz}
+SLSA_PREDICATE="${OUT_DIR}/${CHART_BASENAME}.slsa-provenance.json"
+SBOM_PREDICATE="${OUT_DIR}/${CHART_BASENAME}.sbom.spdx.json"
+
+chart_yaml_path=$(tar -tzf "${CHART_TGZ}" | awk -F/ 'NF == 2 && $2 == "Chart.yaml" && found == 0 { print; found = 1 }')
+if [[ -z "${chart_yaml_path}" ]]; then
+	echo "could not find Chart.yaml in ${CHART_TGZ}" >&2
+	exit 1
+fi
+chart_yaml=$(tar -xOzf "${CHART_TGZ}" "${chart_yaml_path}")
+
+chart_yaml_value() {
+	local key=$1
+	printf '%s\n' "${chart_yaml}" \
+		| sed -n "s/^${key}:[[:space:]]*//p" \
+		| sed -e "s/[[:space:]]*#.*$//" -e "s/^['\"]//" -e "s/['\"]$//" \
+		| awk 'NF && found == 0 { print; found = 1 }'
+}
+
+CHART_NAME=${CHART_NAME:-$(chart_yaml_value name)}
+CHART_VERSION=${CHART_VERSION:-$(chart_yaml_value version)}
+
+if [[ -z "${CHART_NAME}" ]]; then
+	echo "could not determine chart name" >&2
+	exit 1
+fi
+
+if [[ -z "${CHART_VERSION}" ]]; then
+	echo "could not determine chart version" >&2
+	exit 1
+fi
+
+CHART_SHA256=$(sha256sum "${CHART_TGZ}" | awk '{ print $1 }')
+CREATED_ON=${SOURCE_DATE_EPOCH:+$(date -u -d "@${SOURCE_DATE_EPOCH}" '+%Y-%m-%dT%H:%M:%SZ')}
+CREATED_ON=${CREATED_ON:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}
+
+SOURCE_REPO_URL=${SOURCE_REPO_URL:-$(git -C "${REPO_ROOT}" config --get remote.origin.url 2>/dev/null || true)}
+SOURCE_REPO_URL=${SOURCE_REPO_URL:-https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu}
+case "${SOURCE_REPO_URL}" in
+git@github.com:*)
+	SOURCE_REPO_URL="https://github.com/${SOURCE_REPO_URL#git@github.com:}"
+	;;
+esac
+SOURCE_REPO_URL=${SOURCE_REPO_URL%.git}
+case "${SOURCE_REPO_URL}" in
+git+*)
+	SOURCE_URI=${SOURCE_REPO_URL}
+	;;
+*)
+	SOURCE_URI="git+${SOURCE_REPO_URL}"
+	;;
+esac
+
+if [[ -z ${SOURCE_REF:-} ]]; then
+	if git -C "${REPO_ROOT}" describe --exact-match --tags HEAD >/dev/null 2>&1; then
+		SOURCE_REF="refs/tags/$(git -C "${REPO_ROOT}" describe --exact-match --tags HEAD)"
+	elif [[ -n ${PULL_BASE_REF:-} ]]; then
+		SOURCE_REF="refs/heads/${PULL_BASE_REF}"
+	else
+		SOURCE_REF=$(git -C "${REPO_ROOT}" symbolic-ref -q --short HEAD 2>/dev/null || true)
+		if [[ -n "${SOURCE_REF}" ]]; then
+			SOURCE_REF="refs/heads/${SOURCE_REF}"
+		fi
+	fi
+fi
+
+SOURCE_URI_WITH_REF=${SOURCE_URI}
+if [[ -n "${SOURCE_REF}" ]]; then
+	SOURCE_URI_WITH_REF="${SOURCE_URI_WITH_REF}@${SOURCE_REF}"
+fi
+
+GIT_COMMIT=${GIT_COMMIT:-$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || true)}
+PROJECT_ID=${PROJECT_ID:-}
+BUILD_ID=${BUILD_ID:-}
+
+if [[ -n "${PROJECT_ID}" && -n "${BUILD_ID}" ]]; then
+	BUILDER_ID=${SLSA_BUILDER_ID:-"https://cloudbuild.googleapis.com/projects/${PROJECT_ID}"}
+	INVOCATION_ID=${SLSA_INVOCATION_ID:-"https://cloudbuild.googleapis.com/v1/projects/${PROJECT_ID}/builds/${BUILD_ID}"}
+elif [[ -n "${BUILD_ID}" ]]; then
+	BUILDER_ID=${SLSA_BUILDER_ID:-"https://cloudbuild.googleapis.com/CloudBuild"}
+	INVOCATION_ID=${SLSA_INVOCATION_ID:-"cloudbuild:${BUILD_ID}"}
+else
+	BUILDER_ID=${SLSA_BUILDER_ID:-"https://cloudbuild.googleapis.com/CloudBuild"}
+	INVOCATION_ID=${SLSA_INVOCATION_ID:-}
+fi
+
+DOCUMENT_NAMESPACE="https://sigs.k8s.io/dra-driver-nvidia-gpu/spdx/${CHART_NAME}/${CHART_VERSION}/${CHART_SHA256}"
+
+jq -n \
+	--arg builder_id "${BUILDER_ID}" \
+	--arg chart_name "${CHART_NAME}" \
+	--arg chart_ref "${CHART_REF}" \
+	--arg chart_sha256 "${CHART_SHA256}" \
+	--arg chart_version "${CHART_VERSION}" \
+	--arg created_on "${CREATED_ON}" \
+	--arg git_commit "${GIT_COMMIT}" \
+	--arg invocation_id "${INVOCATION_ID}" \
+	--arg source_ref "${SOURCE_REF}" \
+	--arg source_uri "${SOURCE_URI}" \
+	--arg source_uri_with_ref "${SOURCE_URI_WITH_REF}" \
+	'
+	def compact_object: with_entries(select(.value != ""));
+
+	{
+		buildDefinition: {
+			buildType: "https://cloudbuild.googleapis.com/CloudBuildYaml@v1",
+			externalParameters: ({
+				source: ({
+					uri: $source_uri,
+					ref: $source_ref,
+					digest: (if $git_commit == "" then null else {gitCommit: $git_commit} end)
+				} | compact_object),
+				chart: {
+					name: $chart_name,
+					version: $chart_version,
+					ref: $chart_ref,
+					digest: {sha256: $chart_sha256}
+				}
+			} | compact_object),
+			internalParameters: {},
+			resolvedDependencies: (
+				if $git_commit == "" then
+					[]
+				else
+					[{uri: $source_uri_with_ref, digest: {gitCommit: $git_commit}}]
+				end
+			)
+		},
+		runDetails: {
+			builder: {
+				id: $builder_id
+			},
+			metadata: ({
+				invocationId: $invocation_id,
+				finishedOn: $created_on
+			} | compact_object)
+		}
+	}
+	' >"${SLSA_PREDICATE}"
+
+jq -n \
+	--arg chart_name "${CHART_NAME}" \
+	--arg chart_ref "oci://${CHART_REF}" \
+	--arg chart_sha256 "${CHART_SHA256}" \
+	--arg chart_version "${CHART_VERSION}" \
+	--arg created_on "${CREATED_ON}" \
+	--arg document_namespace "${DOCUMENT_NAMESPACE}" \
+	'
+	{
+		spdxVersion: "SPDX-2.3",
+		dataLicense: "CC0-1.0",
+		SPDXID: "SPDXRef-DOCUMENT",
+		name: ($chart_name + "-" + $chart_version + " Helm chart SBOM"),
+		documentNamespace: $document_namespace,
+		documentDescribes: ["SPDXRef-Package-helm-chart"],
+		creationInfo: {
+			created: $created_on,
+			creators: [
+				"Organization: Kubernetes Authors",
+				"Tool: hack/generate-helm-chart-attestation-predicates.sh"
+			]
+		},
+		packages: [
+			{
+				name: $chart_name,
+				SPDXID: "SPDXRef-Package-helm-chart",
+				versionInfo: $chart_version,
+				downloadLocation: $chart_ref,
+				filesAnalyzed: false,
+				checksums: [
+					{algorithm: "SHA256", checksumValue: $chart_sha256}
+				],
+				licenseConcluded: "Apache-2.0",
+				licenseDeclared: "Apache-2.0",
+				copyrightText: "The Kubernetes Authors"
+			}
+		]
+	}
+	' >"${SBOM_PREDICATE}"
+
+echo "Wrote ${SLSA_PREDICATE}"
+echo "Wrote ${SBOM_PREDICATE}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
-->

#### What this PR does / why we need it:
Add support for SLSA provenance and SBOM generation as part of the image build process

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Fixes #1105
https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1105

#### Special notes for your reviewer:
Verified that the provenance and SBOM is built works locally. Not sure how to test this with kpromo. Looking at the documentation it looks like this should work with kpromo.

Sample SLSA Provenance 
```
{
  "buildDefinition": {
    "buildType": "https://cloudbuild.googleapis.com/CloudBuildYaml@v1",
    "externalParameters": {
      "source": {
        "uri": "git+https://github.com/visheshtanksale/k8s-dra-driver-gpu",
        "ref": "refs/heads/sbom-provenance-support",
        "digest": {
          "gitCommit": "160bbb87b5ee827e7152b4bc4d08f40b8bd630f6"
        }
      },
      "chart": {
        "name": "dra-driver-nvidia-gpu",
        "version": "0.0.0-test",
        "ref": "example.com/dra-driver-nvidia/charts/dra-driver-nvidia-gpu@sha256:ae9c140499d32f04de2c9023dca4d3c6eb6453372178db0fe90680cd42b24b0d",
        "digest": {
          "sha256": "ae9c140499d32f04de2c9023dca4d3c6eb6453372178db0fe90680cd42b24b0d"
        }
      }
    },
    "internalParameters": {},
    "resolvedDependencies": [
      {
        "uri": "git+https://github.com/visheshtanksale/k8s-dra-driver-gpu@refs/heads/sbom-provenance-support",
        "digest": {
          "gitCommit": "160bbb87b5ee827e7152b4bc4d08f40b8bd630f6"
        }
      }
    ]
  },
  "runDetails": {
    "builder": {
      "id": "https://cloudbuild.googleapis.com/projects/test-project"
    },
    "metadata": {
      "invocationId": "https://cloudbuild.googleapis.com/v1/projects/test-project/builds/test-build",
      "finishedOn": "2026-06-12T20:22:13Z"
    }
  }
}
```
Sample SBOM SPDX
```
{
  "spdxVersion": "SPDX-2.3",
  "dataLicense": "CC0-1.0",
  "SPDXID": "SPDXRef-DOCUMENT",
  "name": "dra-driver-nvidia-gpu-0.0.0-test Helm chart SBOM",
  "documentNamespace": "https://sigs.k8s.io/dra-driver-nvidia-gpu/spdx/dra-driver-nvidia-gpu/0.0.0-test/ae9c140499d32f04de2c9023dca4d3c6eb6453372178db0fe90680cd42b24b0d",
  "documentDescribes": [
    "SPDXRef-Package-helm-chart"
  ],
  "creationInfo": {
    "created": "2026-06-12T20:22:13Z",
    "creators": [
      "Organization: Kubernetes Authors",
      "Tool: hack/generate-helm-chart-attestation-predicates.sh"
    ]
  },
  "packages": [
    {
      "name": "dra-driver-nvidia-gpu",
      "SPDXID": "SPDXRef-Package-helm-chart",
      "versionInfo": "0.0.0-test",
      "downloadLocation": "oci://example.com/dra-driver-nvidia/charts/dra-driver-nvidia-gpu@sha256:ae9c140499d32f04de2c9023dca4d3c6eb6453372178db0fe90680cd42b24b0d",
      "filesAnalyzed": false,
      "checksums": [
        {
          "algorithm": "SHA256",
          "checksumValue": "ae9c140499d32f04de2c9023dca4d3c6eb6453372178db0fe90680cd42b24b0d"
        }
      ],
      "licenseConcluded": "Apache-2.0",
      "licenseDeclared": "Apache-2.0",
      "copyrightText": "The Kubernetes Authors"
    }
  ]
}
```

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
None
```release-note

```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```
#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
