### PR TITLE
Adding imagepullsecret and pullpolicy for MPS deployment

### DIFF
--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/urfave/cli/v2"
@@ -55,6 +56,8 @@ type Flags struct {
 	hostDriverRoot                string
 	nvidiaCDIHookPath             string
 	imageName                     string
+	imagePullSecrets              string
+	imagePullPolicy               string
 	kubeletRegistrarDirectoryPath string
 	kubeletPluginsDirectoryPath   string
 	healthcheckPort               int
@@ -63,8 +66,10 @@ type Flags struct {
 }
 
 type Config struct {
-	flags      *Flags
-	clientsets pkgflags.ClientSets
+	flags                *Flags
+	clientsets           pkgflags.ClientSets
+	imagePullSecretNames []string
+	imagePullPolicy      string
 }
 
 func (c Config) DriverPluginPath() string {
@@ -132,6 +137,18 @@ func newApp() *cli.App {
 			Required:    true,
 			Destination: &flags.imageName,
 			EnvVars:     []string{"IMAGE_NAME"},
+		},
+		&cli.StringFlag{
+			Name:        "image-pull-secrets",
+			Usage:       "Comma-separated imagePullSecret names for MPS control daemon Deployments (e.g. regcred,other). Empty string means none.",
+			Destination: &flags.imagePullSecrets,
+			EnvVars:     []string{"IMAGE_PULL_SECRETS"},
+		},
+		&cli.StringFlag{
+			Name:        "image-pull-policy",
+			Usage:       "Image pull policy for MPS control daemon Deployments. Empty string uses the Kubernetes default.",
+			Destination: &flags.imagePullPolicy,
+			EnvVars:     []string{"IMAGE_PULL_POLICY"},
 		},
 		&cli.StringFlag{
 			Name:        "kubelet-registrar-directory-path",
@@ -211,8 +228,10 @@ func newApp() *cli.App {
 			}
 
 			config := &Config{
-				flags:      flags,
-				clientsets: clientSets,
+				flags:                flags,
+				clientsets:           clientSets,
+				imagePullSecretNames: strings.Fields(strings.ReplaceAll(strings.TrimSpace(flags.imagePullSecrets), ",", " ")),
+				imagePullPolicy:      strings.TrimSpace(flags.imagePullPolicy),
 			}
 
 			return RunPlugin(c.Context, config)

--- a/cmd/gpu-kubelet-plugin/sharing.go
+++ b/cmd/gpu-kubelet-plugin/sharing.go
@@ -111,6 +111,8 @@ type MpsControlDaemonTemplateData struct {
 	MpsPipeDirectory                string
 	MpsLogDirectory                 string
 	MpsImageName                    string
+	MpsImagePullPolicy              string
+	MpsImagePullSecretNames         []string
 	FeatureGates                    map[string]bool
 	MpsShmMountPath                 string
 }
@@ -239,6 +241,8 @@ func (m *MpsControlDaemon) Start(ctx context.Context, config *configapi.MpsConfi
 		MpsPipeDirectory:                m.pipeDir,
 		MpsLogDirectory:                 m.logDir,
 		MpsImageName:                    m.manager.config.flags.imageName,
+		MpsImagePullPolicy:              m.manager.config.imagePullPolicy,
+		MpsImagePullSecretNames:         m.manager.config.imagePullSecretNames,
 		FeatureGates:                    featuregates.ToMap(),
 		MpsShmMountPath:                 setMpsShmMountPath(osFileChecker{}),
 	}
@@ -265,26 +269,9 @@ func (m *MpsControlDaemon) Start(ctx context.Context, config *configapi.MpsConfi
 		}
 	}
 
-	tmpl, err := template.ParseFiles(m.manager.templatePath)
+	deployment, err := renderMpsControlDaemonDeployment(m.manager.templatePath, templateData)
 	if err != nil {
-		return fmt.Errorf("failed to parse template file: %w", err)
-	}
-
-	var deploymentYaml bytes.Buffer
-	if err := tmpl.Execute(&deploymentYaml, templateData); err != nil {
-		return fmt.Errorf("failed to execute template: %w", err)
-	}
-
-	var unstructuredObj unstructured.Unstructured
-	err = yaml.Unmarshal(deploymentYaml.Bytes(), &unstructuredObj)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal yaml: %w", err)
-	}
-
-	var deployment appsv1.Deployment
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), &deployment)
-	if err != nil {
-		return fmt.Errorf("failed to convert unstructured data to typed object: %w", err)
+		return err
 	}
 
 	err = os.MkdirAll(m.shmDir, 0755)
@@ -320,7 +307,7 @@ func (m *MpsControlDaemon) Start(ctx context.Context, config *configapi.MpsConfi
 		return fmt.Errorf("error setting compute mode: %w", err)
 	}
 
-	_, err = m.manager.config.clientsets.Core.AppsV1().Deployments(m.namespace).Create(ctx, &deployment, metav1.CreateOptions{})
+	_, err = m.manager.config.clientsets.Core.AppsV1().Deployments(m.namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(err) {
 		return nil
 	}
@@ -329,6 +316,32 @@ func (m *MpsControlDaemon) Start(ctx context.Context, config *configapi.MpsConfi
 	}
 
 	return nil
+}
+
+func renderMpsControlDaemonDeployment(templatePath string, templateData MpsControlDaemonTemplateData) (*appsv1.Deployment, error) {
+	tmpl, err := template.ParseFiles(templatePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template file: %w", err)
+	}
+
+	var deploymentYaml bytes.Buffer
+	if err := tmpl.Execute(&deploymentYaml, templateData); err != nil {
+		return nil, fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	var unstructuredObj unstructured.Unstructured
+	err = yaml.Unmarshal(deploymentYaml.Bytes(), &unstructuredObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal yaml: %w", err)
+	}
+
+	var deployment appsv1.Deployment
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), &deployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured data to typed object: %w", err)
+	}
+
+	return &deployment, nil
 }
 
 func (m *MpsControlDaemon) AssertReady(ctx context.Context) error {

--- a/cmd/gpu-kubelet-plugin/sharing_test.go
+++ b/cmd/gpu-kubelet-plugin/sharing_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // mockFileChecker implements fileChecker for tests.
@@ -61,4 +62,32 @@ func TestSetMpsShmMountPath(t *testing.T) {
 			require.Equal(t, tc.expectedMountPath, setMpsShmMountPath(checker))
 		})
 	}
+}
+
+func TestRenderMpsControlDaemonDeploymentImagePullSettings(t *testing.T) {
+	deployment, err := renderMpsControlDaemonDeployment(
+		filepath.Join("..", "..", "templates", "mps-control-daemon.tmpl.yaml"),
+		MpsControlDaemonTemplateData{
+			NodeName:                  "node-a",
+			MpsControlDaemonNamespace: "dra-driver-nvidia-gpu",
+			MpsControlDaemonName:      "mps-control-daemon-test",
+			CUDA_VISIBLE_DEVICES:      "GPU-0",
+			NvidiaDriverRoot:          "/",
+			MpsShmDirectory:           "/var/lib/kubelet/plugins/gpu.nvidia.com/mps/test/shm",
+			MpsPipeDirectory:          "/var/lib/kubelet/plugins/gpu.nvidia.com/mps/test/pipe",
+			MpsLogDirectory:           "/var/lib/kubelet/plugins/gpu.nvidia.com/mps/test/log",
+			MpsImageName:              "registry.example.com/dra-driver:dev",
+			MpsImagePullPolicy:        "Always",
+			MpsImagePullSecretNames:   []string{"regcred", "mirrorcred"},
+			MpsShmMountPath:           MpsDefaultShmMountPath,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, []corev1.LocalObjectReference{
+		{Name: "regcred"},
+		{Name: "mirrorcred"},
+	}, deployment.Spec.Template.Spec.ImagePullSecrets)
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	require.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 }

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -275,6 +275,14 @@ spec:
               fieldPath: metadata.namespace
         - name: IMAGE_NAME
           value: {{ include "dra-driver-nvidia-gpu.fullimage" . }}
+        {{- if .Values.imagePullSecrets }}
+        # Comma-separated secret names (from chart imagePullSecrets) for
+        # dynamically created MPS control daemon Deployment pod specs.
+        - name: IMAGE_PULL_SECRETS
+          value: "{{- range $i, $s := .Values.imagePullSecrets }}{{ if $i }},{{ end }}{{ $s.name }}{{ end }}"
+        {{- end }}
+        - name: IMAGE_PULL_POLICY
+          value: "{{ .Values.image.pullPolicy }}"
         {{- if .Values.nvidiaCDIHookPath }}
         - name: NVIDIA_CDI_HOOK_PATH
           value: "{{ .Values.nvidiaCDIHookPath }}"

--- a/templates/mps-control-daemon.tmpl.yaml
+++ b/templates/mps-control-daemon.tmpl.yaml
@@ -18,9 +18,18 @@ spec:
     spec:
       nodeName: {{ .NodeName }}
       hostPID: true
+      {{- if .MpsImagePullSecretNames }}
+      imagePullSecrets:
+      {{- range .MpsImagePullSecretNames }}
+      - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: mps-control-daemon
         image: {{ .MpsImageName }}
+        {{- if .MpsImagePullPolicy }}
+        imagePullPolicy: {{ .MpsImagePullPolicy }}
+        {{- end }}
         securityContext:
           privileged: true
         command: [sh, -c]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
The MPS control daemon Deployment did not honor the chart's image pull configuration, so its pod could not pull the driver image from a private registry, and its pull policy was left to the Kubernetes default inferred from
the image tag.

This PR plumbs image pull settings through to the MPS control daemon pod spec:

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Fixes #1045
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->

```release-note
Two new gpu-kubelet-plugin flags/env vars are added:
`--mps-control-daemon-image-pull-secret-names` /
`MPS_CONTROL_DAEMON_IMAGE_PULL_SECRET_NAMES` and
`--mps-control-daemon-image-pull-policy` /
`MPS_CONTROL_DAEMON_IMAGE_PULL_POLICY`. 
These are set automatically by the Helm chart from existing `imagePullSecrets` and `image.pullPolicy` values; no action
is required on upgrade.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under docs/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
