### PR TITLE
fix typo in CDI spec error message

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/cdi.go
+++ b/cmd/compute-domain-kubelet-plugin/cdi.go
@@ -180,7 +180,7 @@ func (cdi *CDIHandler) CreateStandardDeviceSpecFile(allocatable AllocatableDevic
 		spec.WithEdits(*commonEdits.ContainerEdits),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to creat CDI spec: %w", err)
+		return fmt.Errorf("failed to create CDI spec: %w", err)
 	}
 
 	// Transform the spec to make it aware that it is running inside a container.
@@ -237,7 +237,7 @@ func (cdi *CDIHandler) CreateClaimSpecFile(claimUID string, preparedDevices Prep
 		spec.WithDeviceSpecs(deviceSpecs),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to creat CDI spec: %w", err)
+		return fmt.Errorf("failed to create CDI spec: %w", err)
 	}
 
 	// Transform the spec to make it aware that it is running inside a container.


### PR DESCRIPTION
Fix typo 'creat' -> 'create' in two error messages in cdi.go.