### PR TITLE
use %w for error wrapping

### DIFF
--- a/cmd/compute-domain-daemon/controller.go
+++ b/cmd/compute-domain-daemon/controller.go
@@ -117,7 +117,7 @@ func NewController(config *ControllerConfig) (*Controller, error) {
 func (c *Controller) Run(ctx context.Context) error {
 	// Start the daemon info manager
 	if err := c.daemonInfoManager.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start daemon info manager: %v", err)
+		return fmt.Errorf("failed to start daemon info manager: %w", err)
 	}
 
 	// Start processing the workqueue
@@ -125,7 +125,7 @@ func (c *Controller) Run(ctx context.Context) error {
 
 	// Stop the daemon info manager
 	if err := c.daemonInfoManager.Stop(); err != nil {
-		return fmt.Errorf("failed to stop daemon info manager: %v", err)
+		return fmt.Errorf("failed to stop daemon info manager: %w", err)
 	}
 
 	return nil

--- a/cmd/compute-domain-kubelet-plugin/checkpoint.go
+++ b/cmd/compute-domain-kubelet-plugin/checkpoint.go
@@ -54,10 +54,10 @@ func (cp *Checkpoint) MarshalCheckpoint() ([]byte, error) {
 	cp = cp.ToLatestVersion()
 	cp.V1 = cp.V2.ToV1()
 	if err := cp.SetChecksumV1(); err != nil {
-		return nil, fmt.Errorf("error setting v1 checksum: %v", err)
+		return nil, fmt.Errorf("error setting v1 checksum: %w", err)
 	}
 	if err := cp.SetChecksumV2(); err != nil {
-		return nil, fmt.Errorf("error setting v2 checksum: %v", err)
+		return nil, fmt.Errorf("error setting v2 checksum: %w", err)
 	}
 	return json.Marshal(*cp)
 }

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -116,12 +116,12 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	computeDomainManager := NewComputeDomainManager(config, cliqueID)
 
 	if err := cdi.CreateStandardDeviceSpecFile(allocatable); err != nil {
-		return nil, fmt.Errorf("unable to create base CDI spec file: %v", err)
+		return nil, fmt.Errorf("unable to create base CDI spec file: %w", err)
 	}
 
 	checkpointManager, err := checkpointmanager.NewCheckpointManager(config.DriverPluginPath())
 	if err != nil {
-		return nil, fmt.Errorf("unable to create checkpoint manager: %v", err)
+		return nil, fmt.Errorf("unable to create checkpoint manager: %w", err)
 	}
 
 	state := &DeviceState{
@@ -136,7 +136,7 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 
 	checkpoints, err := state.checkpointManager.ListCheckpoints()
 	if err != nil {
-		return nil, fmt.Errorf("unable to list checkpoints: %v", err)
+		return nil, fmt.Errorf("unable to list checkpoints: %w", err)
 	}
 
 	currentBootID, err := bootid.GetCurrentBootID()

--- a/cmd/compute-domain-kubelet-plugin/nvlib.go
+++ b/cmd/compute-domain-kubelet-plugin/nvlib.go
@@ -110,7 +110,7 @@ func (l deviceLib) init() error {
 	// We use the INIT_FLAG_NO_GPUS flag to avoid failing if there are no GPUs.
 	ret := l.nvmllib.InitWithFlags(nvml.INIT_FLAG_NO_GPUS)
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("error initializing NVML: %v", ret)
+		return fmt.Errorf("error initializing NVML: %w", ret)
 	}
 	return nil
 }
@@ -130,7 +130,7 @@ func (l deviceLib) getDriverVersion() (*version.Version, error) {
 
 	driverVersion, ret := l.nvmllib.SystemGetDriverVersion()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting driver version: %v", ret)
+		return nil, fmt.Errorf("error getting driver version: %w", ret)
 	}
 
 	// Parse the version using Kubernetes version utilities
@@ -297,7 +297,7 @@ func (l deviceLib) getCliqueIDStrict() (string, error) {
 		}
 
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("failed to get GPU fabric info (device %d/%s): %v", i, duid, ret)
+			return fmt.Errorf("failed to get GPU fabric info (device %d/%s): %w", i, duid, ret)
 		}
 
 		if info.State == nvml.GPU_FABRIC_STATE_NOT_SUPPORTED {

--- a/cmd/compute-domain-kubelet-plugin/root.go
+++ b/cmd/compute-domain-kubelet-plugin/root.go
@@ -104,7 +104,7 @@ func (r root) findFile(name string, searchIn ...string) (string, error) {
 func resolveLink(l string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(l)
 	if err != nil {
-		return "", fmt.Errorf("error resolving link '%v': %v", l, err)
+		return "", fmt.Errorf("error resolving link %q: %w", l, err)
 	}
 	return resolved, nil
 }

--- a/cmd/gpu-kubelet-plugin/checkpoint.go
+++ b/cmd/gpu-kubelet-plugin/checkpoint.go
@@ -54,10 +54,10 @@ func (cp *Checkpoint) MarshalCheckpoint() ([]byte, error) {
 	cp = cp.ToLatestVersion()
 	cp.V1 = cp.V2.ToV1()
 	if err := cp.SetChecksumV1(); err != nil {
-		return nil, fmt.Errorf("error setting v1 checksum: %v", err)
+		return nil, fmt.Errorf("error setting v1 checksum: %w", err)
 	}
 	if err := cp.SetChecksumV2(); err != nil {
-		return nil, fmt.Errorf("error setting v2 checksum: %v", err)
+		return nil, fmt.Errorf("error setting v2 checksum: %w", err)
 	}
 	return json.Marshal(*cp)
 }

--- a/cmd/gpu-kubelet-plugin/device_health.go
+++ b/cmd/gpu-kubelet-plugin/device_health.go
@@ -114,7 +114,7 @@ func newNvmlDeviceHealthMonitor(config *Config, perGPUAllocatable *PerGPUAllocat
 		return nil, fmt.Errorf("nvml library is nil")
 	}
 	if ret := nvdevlib.nvmllib.Init(); ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("failed to initialize NVML: %v", ret)
+		return nil, fmt.Errorf("failed to initialize NVML: %w", ret)
 	}
 	defer func() {
 		_ = nvdevlib.nvmllib.Shutdown()
@@ -135,7 +135,7 @@ func newNvmlDeviceHealthMonitor(config *Config, perGPUAllocatable *PerGPUAllocat
 
 func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
 	if ret := m.nvmllib.Init(); ret != nvml.SUCCESS {
-		return fmt.Errorf("failed to initialize NVML: %v", ret)
+		return fmt.Errorf("failed to initialize NVML: %w", ret)
 	}
 
 	defer func() {

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -154,13 +154,13 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	if featuregates.Enabled(featuregates.PassthroughSupport) {
 		vfioPciManager, err = NewVfioPciManager(string(containerDriverRoot), string(hostDriverRoot), nvdevlib, true /* nvidiaEnabled */)
 		if err != nil {
-			return nil, fmt.Errorf("unable to create vfio pci manager: %v", err)
+			return nil, fmt.Errorf("unable to create vfio pci manager: %w", err)
 		}
 	}
 
 	checkpointManager, err := checkpointmanager.NewCheckpointManager(config.DriverPluginPath())
 	if err != nil {
-		return nil, fmt.Errorf("unable to create checkpoint manager: %v", err)
+		return nil, fmt.Errorf("unable to create checkpoint manager: %w", err)
 	}
 
 	cpLockPath := filepath.Join(config.DriverPluginPath(), "cp.lock")
@@ -180,7 +180,7 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 
 	checkpoints, err := state.checkpointManager.ListCheckpoints()
 	if err != nil {
-		return nil, fmt.Errorf("unable to list checkpoints: %v", err)
+		return nil, fmt.Errorf("unable to list checkpoints: %w", err)
 	}
 
 	currentBootID, err := bootid.GetCurrentBootID()
@@ -220,7 +220,7 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	klog.Infof("Create empty checkpoint")
 	newCheckpoint := &Checkpoint{V2: &CheckpointV2{NodeBootID: currentBootID}}
 	if err := state.createCheckpoint(ctx, newCheckpoint); err != nil {
-		return nil, fmt.Errorf("unable to create fresh checkpoint: %v", err)
+		return nil, fmt.Errorf("unable to create fresh checkpoint: %w", err)
 	}
 
 	return state, nil
@@ -237,7 +237,7 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	tgcp0 := time.Now()
 	cp, err := s.getCheckpoint(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get checkpoint: %v", err)
+		return nil, fmt.Errorf("unable to get checkpoint: %w", err)
 	}
 	klog.V(7).Infof("t_prep_get_checkpoint %.3f s", time.Since(tgcp0).Seconds())
 
@@ -430,7 +430,7 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 
 	checkpoint, err := s.getCheckpoint(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to get checkpoint: %v", err)
+		return fmt.Errorf("unable to get checkpoint: %w", err)
 	}
 
 	claimUID := string(claimRef.UID)
@@ -700,7 +700,7 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 		claim.Status.Allocation.Devices.Config,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error getting opaque device configs: %v", err)
+		return nil, fmt.Errorf("error getting opaque device configs: %w", err)
 	}
 
 	// Add the default GPU and MIG device Configs to the front of the config

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -129,7 +129,7 @@ func (l deviceLib) Init() error {
 	// We use the INIT_FLAG_NO_GPUS flag to avoid failing if there are no GPUs.
 	ret := l.nvmllib.InitWithFlags(nvml.INIT_FLAG_NO_GPUS)
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("error initializing NVML: %v", ret)
+		return fmt.Errorf("error initializing NVML: %w", ret)
 	}
 	return nil
 }
@@ -457,11 +457,11 @@ func (l deviceLib) obliterateStaleMIGDevices(expectedDeviceNames []DeviceName) e
 func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) {
 	minor, ret := device.GetMinorNumber()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting minor number for device %d: %v", index, ret)
+		return nil, fmt.Errorf("error getting minor number for device %d: %w", index, ret)
 	}
 	uuid, ret := device.GetUUID()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting UUID for device %d: %v", index, ret)
+		return nil, fmt.Errorf("error getting UUID for device %d: %w", index, ret)
 	}
 
 	migCapable, err := device.IsMigCapable()
@@ -483,13 +483,13 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		memoryBytes = nil
 		klog.Warningf("ignoring %v for getting memory info for device %d", ret, index)
 	default:
-		return nil, fmt.Errorf("error getting memory info for device %d: %v", index, ret)
+		return nil, fmt.Errorf("error getting memory info for device %d: %w", index, ret)
 
 	}
 
 	productName, ret := device.GetName()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting product name for device %d: %v", index, ret)
+		return nil, fmt.Errorf("error getting product name for device %d: %w", index, ret)
 	}
 	architecture, err := device.GetArchitectureAsString()
 	if err != nil {
@@ -505,11 +505,11 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 	}
 	driverVersion, ret := l.nvmllib.SystemGetDriverVersion()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting driver version: %v", ret)
+		return nil, fmt.Errorf("error getting driver version: %w", ret)
 	}
 	cudaDriverVersion, ret := l.nvmllib.SystemGetCudaDriverVersion()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting CUDA driver version: %v", ret)
+		return nil, fmt.Errorf("error getting CUDA driver version: %w", ret)
 	}
 	pciBusID, err := device.GetPCIBusID()
 	if err != nil {
@@ -716,38 +716,38 @@ func (l deviceLib) getMigDevices(gpuInfo *GpuInfo) (map[string]*MigDeviceInfo, e
 
 	device, ret := l.DeviceGetHandleByUUID(gpuInfo.UUID)
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting GPU device handle: %v", ret)
+		return nil, fmt.Errorf("error getting GPU device handle: %w", ret)
 	}
 
 	infos := make(map[string]*MigDeviceInfo)
 	err := walkMigDevices(device, func(i int, migDevice nvml.Device) error {
 		giID, ret := migDevice.GetGpuInstanceId()
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error getting GPU instance ID for MIG device: %v", ret)
+			return fmt.Errorf("error getting GPU instance ID for MIG device: %w", ret)
 		}
 		gi, ret := device.GetGpuInstanceById(giID)
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error getting GPU instance for '%v': %v", giID, ret)
+			return fmt.Errorf("error getting GPU instance for '%v': %w", giID, ret)
 		}
 		giInfo, ret := gi.GetInfo()
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error getting GPU instance info for '%v': %v", giID, ret)
+			return fmt.Errorf("error getting GPU instance info for '%v': %w", giID, ret)
 		}
 		ciID, ret := migDevice.GetComputeInstanceId()
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error getting Compute instance ID for MIG device: %v", ret)
+			return fmt.Errorf("error getting Compute instance ID for MIG device: %w", ret)
 		}
 		ci, ret := gi.GetComputeInstanceById(ciID)
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error getting Compute instance for '%v': %v", ciID, ret)
+			return fmt.Errorf("error getting Compute instance for '%v': %w", ciID, ret)
 		}
 		ciInfo, ret := ci.GetInfo()
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error getting Compute instance info for '%v': %v", ciID, ret)
+			return fmt.Errorf("error getting Compute instance info for '%v': %w", ciID, ret)
 		}
 		uuid, ret := migDevice.GetUUID()
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error getting UUID for MIG device: %v", ret)
+			return fmt.Errorf("error getting UUID for MIG device: %w", ret)
 		}
 
 		var migProfile *MigProfileInfo
@@ -813,7 +813,7 @@ func (l deviceLib) getMigDevices(gpuInfo *GpuInfo) (map[string]*MigDeviceInfo, e
 func walkMigDevices(d nvml.Device, f func(i int, d nvml.Device) error) error {
 	count, ret := nvml.Device(d).GetMaxMigDeviceCount()
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("error getting max MIG device count: %v", ret)
+		return fmt.Errorf("error getting max MIG device count: %w", ret)
 	}
 
 	for i := 0; i < count; i++ {
@@ -825,7 +825,7 @@ func walkMigDevices(d nvml.Device, f func(i int, d nvml.Device) error) error {
 			continue
 		}
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error getting MIG device handle at index '%v': %v", i, ret)
+			return fmt.Errorf("error getting MIG device handle at index '%v': %w", i, ret)
 		}
 		err := f(i, device)
 		if err != nil {
@@ -932,7 +932,7 @@ func (l deviceLib) createMigDevice(migspec *MigSpec) (*MigDeviceInfo, error) {
 	// Without handle caching, I've seen this to take up O(10 s).
 	device, ret := l.DeviceGetHandleByUUID(gpu.UUID)
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting GPU device handle: %v", ret)
+		return nil, fmt.Errorf("error getting GPU device handle: %w", ret)
 	}
 	klog.V(7).Infof("t_prep_create_mig_dev_get_dev_handle %.3f s", time.Since(tdhbu0).Seconds())
 
@@ -964,7 +964,7 @@ func (l deviceLib) createMigDevice(migspec *MigSpec) (*MigDeviceInfo, error) {
 		if ret != nvml.SUCCESS {
 			// activationStatus would return the appropriate error code upon unsuccessful activation
 			klog.Warningf("%s: SetMigMode activationStatus (device %s): %s", logpfx, gpu.String(), activationStatus)
-			return nil, fmt.Errorf("error enabling MIG mode for device %s: %v", gpu.String(), ret)
+			return nil, fmt.Errorf("error enabling MIG mode for device %s: %w", gpu.String(), ret)
 		}
 		klog.V(1).Infof("%s: MIG mode now enabled for device %s, t_enable_mig %.3f s", logpfx, gpu.String(), time.Since(tem0).Seconds())
 	} else {
@@ -976,7 +976,7 @@ func (l deviceLib) createMigDevice(migspec *MigSpec) (*MigDeviceInfo, error) {
 	tcgigi0 := time.Now()
 	giProfileInfo, ret := device.GetGpuInstanceProfileInfo(profileInfo.GIProfileID)
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting GPU instance profile info for '%v': %v", profile, ret)
+		return nil, fmt.Errorf("error getting GPU instance profile info for '%v': %w", profile, ret)
 	}
 
 	gi, ret := device.CreateGpuInstanceWithPlacement(&giProfileInfo, placement)
@@ -992,27 +992,27 @@ func (l deviceLib) createMigDevice(migspec *MigSpec) (*MigDeviceInfo, error) {
 	// for now, just return an error without distinguishing "already exists"
 	// from any other type of fault.
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error creating GPU instance for '%s': %v", migspec.CanonicalName(), ret)
+		return nil, fmt.Errorf("error creating GPU instance for '%s': %w", migspec.CanonicalName(), ret)
 	}
 
 	giInfo, ret := gi.GetInfo()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting GPU instance info for '%s': %v", migspec.CanonicalName(), ret)
+		return nil, fmt.Errorf("error getting GPU instance info for '%s': %w", migspec.CanonicalName(), ret)
 	}
 
 	ciProfileInfo, ret := gi.GetComputeInstanceProfileInfo(profileInfo.CIProfileID, profileInfo.CIEngProfileID)
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting Compute instance profile info for '%v': %v", profile, ret)
+		return nil, fmt.Errorf("error getting Compute instance profile info for '%v': %w", profile, ret)
 	}
 
 	ci, ret := gi.CreateComputeInstance(&ciProfileInfo)
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error creating Compute instance for '%v': %v", profile, ret)
+		return nil, fmt.Errorf("error creating Compute instance for '%v': %w", profile, ret)
 	}
 
 	ciInfo, ret := ci.GetInfo()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting GPU instance info for '%v': %v", profile, ret)
+		return nil, fmt.Errorf("error getting GPU instance info for '%v': %w", profile, ret)
 	}
 	klog.V(6).Infof("t_prep_create_mig_dev_cigi %.3f s", time.Since(tcgigi0).Seconds())
 
@@ -1028,7 +1028,7 @@ func (l deviceLib) createMigDevice(migspec *MigSpec) (*MigDeviceInfo, error) {
 	// through indices.
 	uuid, ret := ciInfo.Device.GetUUID()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("error getting UUID from CI info/device for CI %d: %v", ciInfo.Id, ret)
+		return nil, fmt.Errorf("error getting UUID from CI info/device for CI %d: %w", ciInfo.Id, ret)
 	}
 
 	// This now probably needs consolidation with the new types MigLiveTuple and
@@ -1064,7 +1064,7 @@ func (l deviceLib) deleteMigDevice(miglt *MigLiveTuple) error {
 
 	parentNvmlDev, ret := l.DeviceGetHandleByUUID(parentUUID)
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("error getting device from UUID '%v': %v", parentUUID, ret)
+		return fmt.Errorf("error getting device from UUID '%v': %w", parentUUID, ret)
 	}
 
 	// The order of destroying 1) compute instance and 2) GPU instance matters.
@@ -1083,7 +1083,7 @@ func (l deviceLib) deleteMigDevice(miglt *MigLiveTuple) error {
 
 	// UNINITIALIZED, INVALID_ARGUMENT, NO_PERMISSION
 	if gires != nvml.SUCCESS && gires != nvml.ERROR_NOT_FOUND {
-		return fmt.Errorf("error getting GPU instance handle for MIG device: %v", ret)
+		return fmt.Errorf("error getting GPU instance handle for MIG device: %w", ret)
 	}
 
 	if gires == nvml.ERROR_NOT_FOUND {
@@ -1118,7 +1118,7 @@ func (l deviceLib) deleteMigDevice(miglt *MigLiveTuple) error {
 	// INVALID_ARGUMENT, NO_PERMISSION: for those three, it's worth erroring out
 	// here (to be retried later).
 	if cires != nvml.SUCCESS && cires != nvml.ERROR_NOT_FOUND {
-		return fmt.Errorf("error getting Compute instance handle for MIG device %s: %v", migStr, ret)
+		return fmt.Errorf("error getting Compute instance handle for MIG device %s: %w", migStr, ret)
 	}
 
 	// A previous, partial cleanup may actually have already deleted that. Seen
@@ -1128,7 +1128,7 @@ func (l deviceLib) deleteMigDevice(miglt *MigLiveTuple) error {
 	} else {
 		ret := ci.Destroy()
 		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error destroying Compute instance: %v", ret)
+			return fmt.Errorf("error destroying Compute instance: %w", ret)
 		}
 	}
 
@@ -1142,7 +1142,7 @@ func (l deviceLib) deleteMigDevice(miglt *MigLiveTuple) error {
 	// out after 10 seconds, when requests pile up.
 	ret = gi.Destroy()
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("error destroying GPU Instance: %v", ret)
+		return fmt.Errorf("error destroying GPU Instance: %w", ret)
 	}
 	klog.V(6).Infof("t_delete_mig_device %.3f s", time.Since(t0).Seconds())
 
@@ -1188,7 +1188,7 @@ func (l deviceLib) maybeDisableMigMode(uuid string, nvmldev nvml.Device) error {
 		// We could also log this as an error and proceed, and hope for the
 		// state machine to clean this up in the future. Probably not a good
 		// idea.
-		return fmt.Errorf("error disabling MIG mode for device %s: %v", gpu.String(), ret)
+		return fmt.Errorf("error disabling MIG mode for device %s: %w", gpu.String(), ret)
 	}
 	// Note: when we're here, disabling MIG mode might still have failed.
 	// `activationStatus` may reflect "in use by another client".
@@ -1300,17 +1300,17 @@ func (l deviceLib) FindMigDevBySpec(ms *MigSpecTuple) (*MigLiveTuple, error) {
 
 		giId, ret := migHandle.GetGpuInstanceId()
 		if ret != nvml.SUCCESS {
-			return nil, fmt.Errorf("failed to get GI ID: %v", ret)
+			return nil, fmt.Errorf("failed to get GI ID: %w", ret)
 		}
 
 		giHandle, ret := parent.GetGpuInstanceById(giId)
 		if ret != nvml.SUCCESS {
-			return nil, fmt.Errorf("failed to get GI handle for ID %d: %v", giId, ret)
+			return nil, fmt.Errorf("failed to get GI handle for ID %d: %w", giId, ret)
 		}
 
 		giInfo, ret := giHandle.GetInfo()
 		if ret != nvml.SUCCESS {
-			return nil, fmt.Errorf("failed to get GI info: %v", ret)
+			return nil, fmt.Errorf("failed to get GI info: %w", ret)
 		}
 
 		klog.V(7).Infof("FindMigDevBySpec: saw MIG dev with profile id %d and placement start %d", giInfo.ProfileId, giInfo.Placement.Start)
@@ -1422,18 +1422,18 @@ func (l deviceLib) enableGPUPersistenceMode(pciAddress string) error {
 	shutdown, ret := l.ensureNVML()
 	defer shutdown()
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("error ensuring NVML: %v", ret)
+		return fmt.Errorf("error ensuring NVML: %w", ret)
 	}
 
 	device, ret := l.nvmllib.DeviceGetHandleByPciBusId(pciAddress)
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("error getting device handle by UUID: %v", ret)
+		return fmt.Errorf("error getting device handle by UUID: %w", ret)
 	}
 
 	// Check if persistence mode is already enabled.
 	mode, ret := nvml.DeviceGetPersistenceMode(device)
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("error getting persistence mode: %v", ret)
+		return fmt.Errorf("error getting persistence mode: %w", ret)
 	}
 	if mode == nvml.FEATURE_ENABLED {
 		klog.Infof("Persistence mode is already enabled for GPU PCI device %s", pciAddress)
@@ -1442,7 +1442,7 @@ func (l deviceLib) enableGPUPersistenceMode(pciAddress string) error {
 
 	ret = device.SetPersistenceMode(nvml.FEATURE_ENABLED)
 	if ret != nvml.SUCCESS {
-		return fmt.Errorf("error setting persistence mode: %v", ret)
+		return fmt.Errorf("error setting persistence mode: %w", ret)
 	}
 	klog.V(4).Infof("Enabled persistence mode for GPU PCI device %s", pciAddress)
 
@@ -1477,7 +1477,7 @@ func isDynamicMIGCapable(gpuInfo *GpuInfo, dev nvdev.Device) (bool, error) {
 
 	vMode, vret := dev.GetVirtualizationMode()
 	if vret != nvml.SUCCESS {
-		return false, fmt.Errorf("error getting GPU virtualization mode: %v", vret)
+		return false, fmt.Errorf("error getting GPU virtualization mode: %w", vret)
 	}
 
 	// In a vGPU guest the MIG mode and partition size are fixed by the vGPU

--- a/cmd/gpu-kubelet-plugin/root.go
+++ b/cmd/gpu-kubelet-plugin/root.go
@@ -104,7 +104,7 @@ func (r root) findFile(name string, searchIn ...string) (string, error) {
 func resolveLink(l string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(l)
 	if err != nil {
-		return "", fmt.Errorf("error resolving link '%v': %v", l, err)
+		return "", fmt.Errorf("error resolving link %q: %w", l, err)
 	}
 	return resolved, nil
 }


### PR DESCRIPTION
Replace %v with %w in fmt.Errorf calls to allow error unwrapping via errors.Is and errors.As.
