### PR TITLE
remove redundant error wrapping

### DIFF
--- a/cmd/compute-domain-daemon/main.go
+++ b/cmd/compute-domain-daemon/main.go
@@ -452,7 +452,7 @@ func check(ctx context.Context, cancel context.CancelFunc, flags *Flags) error {
 	}
 
 	if string(outerr) != "READY\n" {
-		return fmt.Errorf("IMEX daemon not ready: %s", string(outerr))
+		return fmt.Errorf("IMEX daemon not ready: %s", outerr)
 	}
 
 	return nil

--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -180,7 +180,7 @@ func (d *driver) PrepareResourceClaims(ctx context.Context, claims []*resourceap
 				wg.Done()
 				return nil
 			}
-			return fmt.Errorf("%w", res.Err)
+			return res.Err
 		})
 	}
 
@@ -217,7 +217,7 @@ func (d *driver) UnprepareResourceClaims(ctx context.Context, claimRefs []kubele
 				}
 				return nil
 			}
-			return fmt.Errorf("%w", err)
+			return err
 		})
 	}
 


### PR DESCRIPTION
2 small cleanups:

Replace `fmt.Errorf("%w", err)` with `return err` where no message is added (driver.go)

and Remove redundant `string()` cast in `fmt.Errorf` since `%s` already handles `[]byte` (main.go)
