### PR TITLE
Stop injecting implicit TimeSlicing and reset on unprepare

### DIFF
--- a/api/nvidia.com/resource/v1beta1/gpuconfig.go
+++ b/api/nvidia.com/resource/v1beta1/gpuconfig.go
@@ -33,34 +33,18 @@ type GpuConfig struct {
 
 // DefaultGpuConfig provides the default GPU configuration.
 func DefaultGpuConfig() *GpuConfig {
-	config := &GpuConfig{
+	return &GpuConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupName + "/" + Version,
 			Kind:       GpuConfigKind,
 		},
 	}
-
-	if featuregates.Enabled(featuregates.TimeSlicingSettings) {
-		config.Sharing = &GpuSharing{
-			Strategy: TimeSlicingStrategy,
-			TimeSlicingConfig: &TimeSlicingConfig{
-				Interval: ptr.To(DefaultTimeSlice),
-			},
-		}
-	}
-
-	return config
 }
 
 // Normalize updates a GpuConfig config with implied default values based on other settings.
 func (c *GpuConfig) Normalize() error {
 	if c.Sharing == nil {
-		if !featuregates.Enabled(featuregates.TimeSlicingSettings) {
-			return nil
-		}
-		c.Sharing = &GpuSharing{
-			Strategy: TimeSlicingStrategy,
-		}
+		return nil
 	}
 
 	if featuregates.Enabled(featuregates.TimeSlicingSettings) {

--- a/api/nvidia.com/resource/v1beta1/migconfig.go
+++ b/api/nvidia.com/resource/v1beta1/migconfig.go
@@ -32,31 +32,18 @@ type MigDeviceConfig struct {
 
 // DefaultMigDeviceConfig provides the default Mig Device configuration.
 func DefaultMigDeviceConfig() *MigDeviceConfig {
-	config := &MigDeviceConfig{
+	return &MigDeviceConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupName + "/" + Version,
 			Kind:       MigDeviceConfigKind,
 		},
 	}
-
-	if featuregates.Enabled(featuregates.TimeSlicingSettings) {
-		config.Sharing = &MigDeviceSharing{
-			Strategy: TimeSlicingStrategy,
-		}
-	}
-
-	return config
 }
 
 // Normalize updates a MigDeviceConfig config with implied default values based on other settings.
 func (c *MigDeviceConfig) Normalize() error {
 	if c.Sharing == nil {
-		if !featuregates.Enabled(featuregates.TimeSlicingSettings) {
-			return nil
-		}
-		c.Sharing = &MigDeviceSharing{
-			Strategy: TimeSlicingStrategy,
-		}
+		return nil
 	}
 
 	if featuregates.Enabled(featuregates.MPSSupport) {

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/pmezard/go-difflib/difflib"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	cperrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
+	"k8s.io/utils/ptr"
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 
 	"github.com/sirupsen/logrus"
@@ -57,6 +59,7 @@ type DeviceConfigState struct {
 	MpsControlDaemonID string              `json:"mpsControlDaemonID"`
 	Config             configapi.Interface `json:"-"` // don't serialize this.
 	containerEdits     *cdiapi.ContainerEdits
+	TimeSliceApplied   *bool `json:"timeSliceApplied,omitempty"`
 }
 
 type DeviceState struct {
@@ -940,12 +943,18 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, dev
 				return fmt.Errorf("error stopping MPS control daemon: %w", err)
 			}
 		}
-
-		// Go back to default time-slicing for all full GPUs.
-		if featuregates.Enabled(featuregates.TimeSlicingSettings) {
-			tsc := configapi.DefaultGpuConfig().Sharing.TimeSlicingConfig
+		// Reset when time-slicing was applied at prepare (true), or when the
+		// checkpoint predates timeSliceApplied (nil — legacy implicit time-slicing).
+		if featuregates.Enabled(featuregates.TimeSlicingSettings) &&
+			ptr.Deref(group.ConfigState.TimeSliceApplied, true) {
+			defaultInterval := configapi.DefaultTimeSlice
+			tsc := &configapi.TimeSlicingConfig{Interval: &defaultInterval}
 			if err := s.tsManager.SetTimeSlice(group.Devices.GpuUUIDs(), tsc); err != nil {
-				return fmt.Errorf("error setting timeslice for devices: %w", err)
+				if err == nvml.ERROR_NOT_SUPPORTED {
+					klog.Warningf("Unprepare: skip resetting time-slice policy for devices: %v", err)
+				} else {
+					return fmt.Errorf("error setting timeslice for devices: %w", err)
+				}
 			}
 		}
 
@@ -1062,6 +1071,7 @@ func (s *DeviceState) applySharingConfig(ctx context.Context, config configapi.S
 			if err != nil {
 				return nil, fmt.Errorf("error setting timeslice config for requests '%v' in claim '%v': %w", requests, claim.UID, err)
 			}
+			configState.TimeSliceApplied = ptr.To(true)
 		}
 	}
 


### PR DESCRIPTION


#### What type of PR is this?
/kind bug 

#### Which issue(s) this PR is related to:
fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/81
https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/363

#### Special notes for your reviewer:

```release-note
Fix to avoid applying default timeslicing settings on unsupported GPUs.
```

#### Does this PR introduce a user-facing change?
NONE
