### PR TITLE
Fix nil pointer panic in verifyDisabledVFs for non-SR-IOV GPUs

### DIFF
--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -134,6 +134,14 @@ func (vm *VfioPciManager) verifyDisabledVFs(pciBusID string) error {
 	if err != nil {
 		return err
 	}
+	if gpu == nil {
+		return fmt.Errorf("no GPU found at PCI bus ID %q", pciBusID)
+	}
+	// PhysicalFunction is nil for GPUs that do not support SR-IOV (e.g. T400).
+	// A nil PhysicalFunction means no VFs can exist, so it is safe to proceed.
+	if gpu.SriovInfo.PhysicalFunction == nil {
+		return nil
+	}
 	numVFs := gpu.SriovInfo.PhysicalFunction.NumVFs
 	if numVFs > 0 {
 		return fmt.Errorf("gpu has %d VFs, cannot unbind", numVFs)


### PR DESCRIPTION
GPUs that do not support SR-IOV (e.g. NVIDIA T400) have SriovInfo.PhysicalFunction set to nil. The existing code dereferences PhysicalFunction.NumVFs without a nil check, causing a panic when VFIO passthrough is configured for such GPUs.

Add nil checks for both the gpu return value and PhysicalFunction. A nil PhysicalFunction means no VFs can exist, so it is safe to proceed.

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

fix [#1185](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1185)

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note

```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
