### PR TITLE
 Fix remove redundant component label added for backward compatibility with upgrade tests

### DIFF
--- a/deployments/helm/dra-driver-nvidia-gpu/templates/controller.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/controller.yaml
@@ -35,7 +35,6 @@ spec:
       labels:
         {{- include "dra-driver-nvidia-gpu.templateLabels" . | nindent 8 }}
         {{- include "dra-driver-nvidia-gpu.selectorLabels" (dict "context" . "componentName" "controller") | nindent 8 }}
-        nvidia-dra-driver-gpu-component: controller
     spec:
       {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -38,7 +38,6 @@ spec:
       labels:
         {{- include "dra-driver-nvidia-gpu.templateLabels" . | nindent 8 }}
         {{- include "dra-driver-nvidia-gpu.selectorLabels" (dict "context" . "componentName" "kubelet-plugin") | nindent 8 }}
-        nvidia-dra-driver-gpu-component: kubelet-plugin
     spec:
       {{- if .Values.kubeletPlugin.priorityClassName }}
       priorityClassName: {{ .Values.kubeletPlugin.priorityClassName }}

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -20,8 +20,8 @@ TEST_CHART_REPO ?= "oci://gcr.io/k8s-staging-nvidia/charts/dra-driver-nvidia-gpu
 TEST_CHART_VERSION ?= "$(VERSION_STAGING_CHART)"
 
 # The baseline Helm chart to test upgrades from and downgrades to.
-TEST_CHART_LASTSTABLE_REPO ?= "oci://ghcr.io/nvidia/k8s-dra-driver-gpu"
-TEST_CHART_LASTSTABLE_VERSION ?= "25.12.0-0882da87-chart"
+TEST_CHART_LASTSTABLE_REPO ?= "oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu"
+TEST_CHART_LASTSTABLE_VERSION ?= "0.4.0"
 
 # If not "false": the to-be-tested Helm chart is installed from the local
 # filesystem (from `deployments/helm/dra-driver-nvidia-gpu`). Make sure

--- a/tests/bats/helpers.sh
+++ b/tests/bats/helpers.sh
@@ -85,10 +85,8 @@ iupgrade_wait() {
   # not natively supported by `kubectl wait`, hence this must be something of
   # the shape
   # `kubectl get pods ... | xargs -I{} kubectl wait --for=condition=Ready pod/{} `
-  # TODO: change `nvidia-dra-driver-gpu-component` when last stable supports both, the
-  # new and the old label key
   sleep 1
-  kubectl wait --for=condition=READY pods -A -l nvidia-dra-driver-gpu-component=kubelet-plugin --timeout=15s
+  kubectl wait --for=condition=READY pods -A -l dra-driver-nvidia-gpu-component=kubelet-plugin --timeout=15s
 
   # Again, log current state.
   kubectl get pods -n dra-driver-nvidia-gpu
@@ -96,7 +94,7 @@ iupgrade_wait() {
   # That one should be obvious now, but make that guarantee explicit for
   # consuming tests. Skip when compute domains are disabled (no controller deployment).
   if [ "${DISABLE_COMPUTE_DOMAINS:-}" != "true" ]; then
-    kubectl wait --for=condition=READY pods -A -l nvidia-dra-driver-gpu-component=controller --timeout=10s
+    kubectl wait --for=condition=READY pods -A -l dra-driver-nvidia-gpu-component=controller --timeout=10s
   fi
   # maybe: check version on labels (to confirm that we set labels correctly)
   log "iupgrade_wait: done"

--- a/tests/bats/test_gpu_updowngrade.bats
+++ b/tests/bats/test_gpu_updowngrade.bats
@@ -54,7 +54,7 @@ bats::on_failure() {
   _node=$(kubectl get pod "${_podname}" -o jsonpath='{.spec.nodeName}')
   log "workload runs on node: ${_node}"
   _kpod=$(kubectl get pods -n dra-driver-nvidia-gpu \
-    -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+    -l dra-driver-nvidia-gpu-component=kubelet-plugin \
     --field-selector spec.nodeName="${_node}" \
     -o jsonpath='{.items[0].metadata.name}')
   log "kubelet-plugin pod on that node: ${_kpod}"
@@ -119,7 +119,7 @@ bats::on_failure() {
   _node=$(kubectl get pod "${_podname}" -o jsonpath='{.spec.nodeName}')
   log "workload runs on node: ${_node}"
   _kpod=$(kubectl get pods -n dra-driver-nvidia-gpu \
-    -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+    -l dra-driver-nvidia-gpu-component=kubelet-plugin \
     --field-selector spec.nodeName="${_node}" \
     -o jsonpath='{.items[0].metadata.name}')
   log "kubelet-plugin pod on that node: ${_kpod}"
@@ -172,7 +172,7 @@ bats::on_failure() {
   # Stage 2: pick any kubelet plugin pod.
   local _kpod _node
   _kpod=$(kubectl get pods -n dra-driver-nvidia-gpu \
-    -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+    -l dra-driver-nvidia-gpu-component=kubelet-plugin \
     -o jsonpath='{.items[0].metadata.name}')
   _node=$(kubectl get pod -n dra-driver-nvidia-gpu "${_kpod}" -o jsonpath='{.spec.nodeName}')
   log "targeting plugin pod ${_kpod} on node ${_node}"
@@ -200,7 +200,7 @@ bats::on_failure() {
   local _newkpod="" _deadline=$((SECONDS + 60))
   while true; do
     _newkpod=$(kubectl get pods -n dra-driver-nvidia-gpu \
-      -l nvidia-dra-driver-gpu-component=kubelet-plugin \
+      -l dra-driver-nvidia-gpu-component=kubelet-plugin \
       --field-selector spec.nodeName="${_node}" \
       -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || true
     if [ -n "${_newkpod}" ] && [ "${_newkpod}" != "${_kpod}" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

Fix remove redundant component label added for backward compatibility with upgrade tests
* As part of GitHub issue #1079 we had introduced redundant component label in both kubelet plugin and CD controller.
* This was mainly for compatibility with upgrade tests (checkpoint validation). However, this caused duplicate keys to be rendered and parser validation failures with GitOps like ArgoCD/FluxCD.
* Now that we have a stable release in upstream registries, we can safely remove this label with previous name.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

Fixes: https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1184

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
Resolved an issue where redundant component labels caused errors when Helm templates were rendered with strict parsing in GitOps tools such as ArgoCD.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
