### PR TITLE
Adding Unprepare state in checkpointing for compute domain to handle …

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/checkpointv.go
+++ b/cmd/compute-domain-kubelet-plugin/checkpointv.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 
 	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 
@@ -62,6 +63,7 @@ const (
 	ClaimCheckpointStateUnset            ClaimCheckpointState = ""
 	ClaimCheckpointStatePrepareStarted   ClaimCheckpointState = "PrepareStarted"
 	ClaimCheckpointStatePrepareCompleted ClaimCheckpointState = "PrepareCompleted"
+	ClaimCheckpointStatePrepareAborted   ClaimCheckpointState = "PrepareAborted"
 )
 
 // Latest version type aliases
@@ -88,6 +90,7 @@ type PreparedClaimV2 struct {
 	PreparedDevices PreparedDevices                 `json:"preparedDevices,omitempty"`
 	Name            string                          `json:"name,omitempty"`
 	Namespace       string                          `json:"namespace,omitempty"`
+	AbortedAt       *metav1.Time                    `json:"abortedAt,omitempty"`
 }
 
 // V1 types

--- a/cmd/compute-domain-kubelet-plugin/cleanup.go
+++ b/cmd/compute-domain-kubelet-plugin/cleanup.go
@@ -33,9 +33,11 @@ import (
 
 const (
 	ResourceClaimCleanupInterval = 10 * time.Minute
+	PrepareAbortedClaimEntryTTL  = 2 * ErrorRetryMaxTimeout
 )
 
 type TypeUnprepCallable = func(ctx context.Context, claimRef kubeletplugin.NamespacedObject) (bool, error)
+type TypeExpiredEntryCleanupCallable = func(ctx context.Context, now time.Time, ttl time.Duration) (int, error)
 
 type CheckpointCleanupManager struct {
 	waitGroup     sync.WaitGroup
@@ -44,7 +46,8 @@ type CheckpointCleanupManager struct {
 	devicestate   *DeviceState
 	draclient     *draclient.Client
 
-	unprepfunc TypeUnprepCallable
+	unprepfunc            TypeUnprepCallable
+	expiredEntryCleanupFn TypeExpiredEntryCleanupCallable
 }
 
 func NewCheckpointCleanupManager(s *DeviceState, client *draclient.Client) *CheckpointCleanupManager {
@@ -58,10 +61,11 @@ func NewCheckpointCleanupManager(s *DeviceState, client *draclient.Client) *Chec
 	}
 }
 
-func (m *CheckpointCleanupManager) Start(ctx context.Context, unprepfunc TypeUnprepCallable) error {
+func (m *CheckpointCleanupManager) Start(ctx context.Context, unprepfunc TypeUnprepCallable, expiredEntryCleanupFn TypeExpiredEntryCleanupCallable) error {
 	ctx, cancel := context.WithCancel(ctx)
 	m.cancelContext = cancel
 	m.unprepfunc = unprepfunc
+	m.expiredEntryCleanupFn = expiredEntryCleanupFn
 
 	m.waitGroup.Add(1)
 	go func() {
@@ -91,10 +95,10 @@ func (m *CheckpointCleanupManager) Stop() error {
 
 // cleanup() is the high-level cleanup routine run once upon plugin startup and
 // then periodically. It gets all claims in PrepareStarted state from the
-// current checkpoint, and runs `unprepareIfStale()` for each of them. Each
-// invocation of `cleanup()` and each invocation of `unprepareIfStale()` is
-// best-effort: errors do not need to be propagated (but are expected to be
-// properly logged).
+// current checkpoint, and runs `unprepareIfStale()` for each of them. It also
+// removes expired PrepareAborted entries. Each invocation of `cleanup()`
+// and each invocation of `unprepareIfStale()` is best-effort: errors do not
+// need to be propagated (but are expected to be properly logged).
 //
 // Note: This function does not acquire DeviceState lock when reading the checkpoint.
 // The lock is not needed because:
@@ -103,8 +107,8 @@ func (m *CheckpointCleanupManager) Stop() error {
 //     means we catch it on the next periodic iteration.
 //  2. We validate each candidate against the API server (the authoritative source of
 //     truth for whether a claim is truly stale), not the local checkpoint state.
-//  3. The actual checkpoint mutation happens in nodeUnprepareResource(), which properly
-//     acquires the pulock (process-level file lock) for atomic read-modify-write.
+//  3. The actual checkpoint mutations happen in driver callbacks which properly
+//     acquire the pulock (process-level file lock) for atomic read-modify-write.
 //  4. Holding DeviceState lock during the entire cleanup (which could take seconds with
 //     multiple API calls) would unnecessarily block normal Prepare/Unprepare operations.
 func (m *CheckpointCleanupManager) cleanup(ctx context.Context) {
@@ -126,6 +130,15 @@ func (m *CheckpointCleanupManager) cleanup(ctx context.Context) {
 
 	for cpuid, cpclaim := range filtered {
 		m.unprepareIfStale(ctx, cpuid, cpclaim)
+	}
+
+	expiredEntries, err := m.expiredEntryCleanupFn(ctx, time.Now(), PrepareAbortedClaimEntryTTL)
+	if err != nil {
+		klog.Warningf("Checkpointed RC cleanup: unable to delete expired PrepareAborted claim entries: %s", err)
+		return
+	}
+	if expiredEntries > 0 {
+		klog.V(4).Infof("Checkpointed RC cleanup: deleted expired PrepareAborted claim entries: %d", expiredEntries)
 	}
 }
 

--- a/cmd/compute-domain-kubelet-plugin/cleanup_test.go
+++ b/cmd/compute-domain-kubelet-plugin/cleanup_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	draclient "k8s.io/dynamic-resource-allocation/client"
+)
+
+func TestCleanupDeletesExpiredPrepareAbortedEntries(t *testing.T) {
+	now := time.Now()
+	oldAbortedAt := metav1.NewTime(now.Add(-PrepareAbortedClaimEntryTTL - time.Second))
+	freshAbortedAt := metav1.NewTime(now.Add(-PrepareAbortedClaimEntryTTL / 2))
+	state := testCheckpointDeviceState(checkpointWithClaims(map[string]PreparedClaim{
+		"old-aborted": {
+			CheckpointState: ClaimCheckpointStatePrepareAborted,
+			AbortedAt:       &oldAbortedAt,
+		},
+		"fresh-aborted": {
+			CheckpointState: ClaimCheckpointStatePrepareAborted,
+			AbortedAt:       &freshAbortedAt,
+		},
+	}))
+
+	manager := NewCheckpointCleanupManager(state, (*draclient.Client)(nil))
+	expiredCleanupCalled := false
+	manager.expiredEntryCleanupFn = func(ctx context.Context, now time.Time, ttl time.Duration) (int, error) {
+		expiredCleanupCalled = true
+		assert.Equal(t, PrepareAbortedClaimEntryTTL, ttl)
+		return state.deleteExpiredPrepareAbortedClaimsFromCheckpoint(now, ttl)
+	}
+
+	manager.cleanup(context.Background())
+
+	require.True(t, expiredCleanupCalled)
+	stored := requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims
+	assert.NotContains(t, stored, "old-aborted")
+	assert.Contains(t, stored, "fresh-aborted")
+}

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -27,9 +27,11 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pmezard/go-difflib/difflib"
 	resourceapi "k8s.io/api/resource/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -202,6 +204,9 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		klog.V(4).Infof("Skip prepare: claim already in PrepareCompleted state: %s", ResourceClaimToString(claim))
 		return preparedClaim.PreparedDevices.GetDevices(), nil
 	}
+	if exists && preparedClaim.CheckpointState == ClaimCheckpointStatePrepareAborted && claimMatchesPreparedClaim(preparedClaim, claim) {
+		return nil, permanentError{fmt.Errorf("stale prepare for claim %s: claim prepare was already aborted", ResourceClaimToString(claim))}
+	}
 
 	// In certain scenarios, the same device can be prepared/allocated more than once for different claims
 	// due to races between data processing in different goroutines in the scheduler, or when pods are
@@ -244,6 +249,8 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 			CheckpointState: ClaimCheckpointStatePrepareCompleted,
 			Status:          claim.Status,
 			PreparedDevices: preparedDevices,
+			Name:            claim.Name,
+			Namespace:       claim.Namespace,
 		}
 	})
 	if err != nil {
@@ -303,10 +310,25 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 	}
 
 	switch pc.CheckpointState {
-	case ClaimCheckpointStatePrepareStarted, ClaimCheckpointStatePrepareCompleted:
+	case ClaimCheckpointStatePrepareCompleted:
 		if err := s.unprepareDevices(ctx, &pc.Status); err != nil {
 			return fmt.Errorf("unprepare devices failed: %w", err)
 		}
+		if err := s.deleteClaimFromCheckpoint(claimRef); err != nil {
+			return fmt.Errorf("error deleting completed claim from checkpoint: %w", err)
+		}
+	case ClaimCheckpointStatePrepareStarted:
+		if err := s.unprepareDevices(ctx, &pc.Status); err != nil {
+			return fmt.Errorf("unprepare devices failed: %w", err)
+		}
+		// Keep a short-lived PrepareAborted entry so stale prepare retries for the
+		// same claim version cannot recreate device state after unprepare.
+		if err := s.markClaimPrepareAbortedInCheckpoint(claimRef, pc); err != nil {
+			return fmt.Errorf("error marking claim PrepareAborted in checkpoint: %w", err)
+		}
+	case ClaimCheckpointStatePrepareAborted:
+		klog.V(2).Infof("Unprepare noop: claim in PrepareAborted state: %v", claimRef.String())
+		return nil
 	default:
 		return fmt.Errorf("unsupported ClaimCheckpointState: %v", pc.CheckpointState)
 	}
@@ -316,14 +338,11 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 	if err := s.cdi.DeleteClaimSpecFileIfExists(claimUID); err != nil {
 		return fmt.Errorf("unable to delete CDI spec file for claim: %w", err)
 	}
-
-	// Mutate checkpoint reflecting that all devices for this claim have been
-	// unprepared, by virtue of removing its UID from the PreparedClaims map.
-	err = s.deleteClaimFromCheckpoint(claimRef)
-	if err != nil {
-		return fmt.Errorf("error deleting claim from checkpoint: %w", err)
-	}
 	return nil
+}
+
+func claimMatchesPreparedClaim(pc PreparedClaim, claim *resourceapi.ResourceClaim) bool {
+	return apiequality.Semantic.DeepEqual(pc.Status, claim.Status)
 }
 
 func (s *DeviceState) createCheckpoint(cp *Checkpoint) error {
@@ -407,6 +426,66 @@ func (s *DeviceState) deleteClaimFromCheckpoint(claimRef kubeletplugin.Namespace
 	}
 	klog.V(6).Infof("Deleted claim from checkpoint: %s", claimRef.String())
 	return nil
+}
+
+func (s *DeviceState) markClaimPrepareAbortedInCheckpoint(claimRef kubeletplugin.NamespacedObject, pc PreparedClaim) error {
+	abortedAt := metav1.Now()
+	pc.CheckpointState = ClaimCheckpointStatePrepareAborted
+	pc.PreparedDevices = nil
+	pc.Name = claimRef.Name
+	pc.Namespace = claimRef.Namespace
+	pc.AbortedAt = &abortedAt
+
+	err := s.updateCheckpoint(func(cp *Checkpoint) {
+		cp.V2.PreparedClaims[string(claimRef.UID)] = pc
+	})
+	if err != nil {
+		return fmt.Errorf("unable to update checkpoint: %w", err)
+	}
+	klog.V(6).Infof("Marked claim PrepareAborted in checkpoint: %s", claimRef.String())
+	return nil
+}
+
+func (s *DeviceState) deleteExpiredPrepareAbortedClaimsFromCheckpoint(now time.Time, ttl time.Duration) (int, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	checkpoint, err := s.getCheckpoint()
+	if err != nil {
+		return 0, fmt.Errorf("unable to get checkpoint: %w", err)
+	}
+
+	expired := expiredPrepareAbortedClaimEntries(checkpoint, now, ttl)
+	if len(expired) == 0 {
+		return 0, nil
+	}
+
+	err = s.updateCheckpoint(func(cp *Checkpoint) {
+		for _, uid := range expired {
+			delete(cp.V2.PreparedClaims, uid)
+		}
+	})
+	if err != nil {
+		return 0, fmt.Errorf("unable to update checkpoint: %w", err)
+	}
+	return len(expired), nil
+}
+
+func expiredPrepareAbortedClaimEntries(cp *Checkpoint, now time.Time, ttl time.Duration) []string {
+	var expired []string
+	if cp == nil || cp.V2 == nil {
+		return expired
+	}
+	for uid, claim := range cp.V2.PreparedClaims {
+		if claim.CheckpointState != ClaimCheckpointStatePrepareAborted {
+			continue
+		}
+		if claim.AbortedAt == nil || now.Sub(claim.AbortedAt.Time) >= ttl {
+			expired = append(expired, uid)
+		}
+	}
+	slices.Sort(expired)
+	return expired
 }
 
 func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.ResourceClaim) (PreparedDevices, error) {

--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -406,6 +407,126 @@ func TestPrepareReturnsCheckpointedDevicesForCompletedClaim(t *testing.T) {
 	assert.Equal(t, []kubeletplugin.Device{kubeletplugin.Device(expectedDevice)}, got)
 }
 
+func TestPrepareRejectsMatchingPrepareAbortedEntry(t *testing.T) {
+	now := metav1.Now()
+	claim := claimWithResults("claim-uid", allocationResult("request", DriverName, "channel-0", nil))
+	checkpoint := checkpointWithClaims(map[string]PreparedClaim{
+		"claim-uid": {
+			CheckpointState: ClaimCheckpointStatePrepareAborted,
+			Status:          claim.Status,
+			Name:            claim.Name,
+			Namespace:       claim.Namespace,
+			AbortedAt:       &now,
+		},
+	})
+	state := &DeviceState{
+		checkpointManager: &fakeCheckpointManager{checkpoint: checkpoint},
+	}
+
+	got, err := state.Prepare(context.Background(), claim)
+
+	require.Error(t, err)
+	assert.True(t, isPermanentError(err))
+	assert.Contains(t, err.Error(), "claim prepare was already aborted")
+	assert.Nil(t, got)
+	assert.Equal(t, ClaimCheckpointStatePrepareAborted, requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims["claim-uid"].CheckpointState)
+}
+
+func TestClaimMatchesPreparedClaim(t *testing.T) {
+	claim := claimWithResults("claim-uid", allocationResult("request", DriverName, "channel-0", nil))
+
+	assert.True(t, claimMatchesPreparedClaim(PreparedClaim{
+		Status: claim.Status,
+	}, claim))
+
+	assert.False(t, claimMatchesPreparedClaim(PreparedClaim{
+		Status: claimStatus([]resourceapi.DeviceRequestAllocationResult{
+			allocationResult("request", DriverName, "daemon-0", nil),
+		}),
+	}, claim))
+}
+
+func TestMarkClaimPrepareAbortedInCheckpointWritesEntry(t *testing.T) {
+	checkpoint := checkpointWithClaims(map[string]PreparedClaim{
+		"claim-uid": {
+			CheckpointState: ClaimCheckpointStatePrepareStarted,
+			Status:          claimStatus([]resourceapi.DeviceRequestAllocationResult{allocationResult("request", DriverName, "channel-0", nil)}),
+			PreparedDevices: PreparedDevices{
+				{Devices: PreparedDeviceList{preparedChannel(0)}},
+			},
+		},
+	})
+	state := testCheckpointDeviceState(checkpoint)
+	claimRef := kubeletplugin.NamespacedObject{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "claim",
+		},
+		UID: "claim-uid",
+	}
+	pc := checkpoint.V2.PreparedClaims["claim-uid"]
+
+	err := state.markClaimPrepareAbortedInCheckpoint(claimRef, pc)
+
+	require.NoError(t, err)
+	stored := requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims["claim-uid"]
+	assert.Equal(t, ClaimCheckpointStatePrepareAborted, stored.CheckpointState)
+	assert.Equal(t, "claim", stored.Name)
+	assert.Equal(t, "default", stored.Namespace)
+	assert.Nil(t, stored.PreparedDevices)
+	require.NotNil(t, stored.AbortedAt)
+}
+
+func TestDeleteClaimFromCheckpoint(t *testing.T) {
+	checkpoint := checkpointWithClaims(map[string]PreparedClaim{
+		"claim-uid": {
+			CheckpointState: ClaimCheckpointStatePrepareCompleted,
+		},
+	})
+	state := testCheckpointDeviceState(checkpoint)
+	claimRef := kubeletplugin.NamespacedObject{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "claim",
+		},
+		UID: "claim-uid",
+	}
+
+	err := state.deleteClaimFromCheckpoint(claimRef)
+
+	require.NoError(t, err)
+	assert.NotContains(t, requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims, "claim-uid")
+}
+
+func TestDeleteExpiredPrepareAbortedClaimsFromCheckpoint(t *testing.T) {
+	now := time.Now()
+	old := metav1.NewTime(now.Add(-PrepareAbortedClaimEntryTTL - time.Second))
+	fresh := metav1.NewTime(now.Add(-PrepareAbortedClaimEntryTTL + time.Second))
+	checkpoint := checkpointWithClaims(map[string]PreparedClaim{
+		"old": {
+			CheckpointState: ClaimCheckpointStatePrepareAborted,
+			AbortedAt:       &old,
+		},
+		"fresh": {
+			CheckpointState: ClaimCheckpointStatePrepareAborted,
+			AbortedAt:       &fresh,
+		},
+		"completed": {
+			CheckpointState: ClaimCheckpointStatePrepareCompleted,
+		},
+	})
+	state := testCheckpointDeviceState(checkpoint)
+
+	deleted, err := state.deleteExpiredPrepareAbortedClaimsFromCheckpoint(now, PrepareAbortedClaimEntryTTL)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+	stored := requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims
+	assert.NotContains(t, stored, "old")
+	assert.Contains(t, stored, "fresh")
+	assert.Contains(t, stored, "completed")
+}
+
 func TestUnprepareMissingClaimIsNoop(t *testing.T) {
 	state := &DeviceState{
 		checkpointManager: &fakeCheckpointManager{checkpoint: checkpointWithClaims(nil)},
@@ -430,6 +551,23 @@ func testDeviceState() *DeviceState {
 			"daemon-0":  &AllocatableDevice{Daemon: &ComputeDomainDaemonInfo{ID: 0}},
 		},
 	}
+}
+
+func testCheckpointDeviceState(checkpoint *Checkpoint) *DeviceState {
+	return &DeviceState{
+		checkpointManager: &fakeCheckpointManager{checkpoint: checkpoint},
+		config: &Config{
+			flags: &Flags{nodeName: "test-node"},
+		},
+	}
+}
+
+func requireFakeCheckpointManager(t *testing.T, state *DeviceState) *fakeCheckpointManager {
+	t.Helper()
+
+	manager, ok := state.checkpointManager.(*fakeCheckpointManager)
+	require.True(t, ok)
+	return manager
 }
 
 func channelConfig(domainID string) *configapi.ComputeDomainChannelConfig {

--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -123,8 +123,8 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		return nil, fmt.Errorf("error starting ComputeDomain manager: %w", err)
 	}
 
-	// Pass `nodeUnprepareResource` function in the cleanup manager.
-	if err := state.checkpointCleanupManager.Start(ctx, driver.nodeUnprepareResource); err != nil {
+	// Pass checkpoint mutation functions to the cleanup manager.
+	if err := state.checkpointCleanupManager.Start(ctx, driver.nodeUnprepareResource, driver.deleteExpiredPrepareAbortedClaimEntries); err != nil {
 		return nil, fmt.Errorf("error starting CheckpointCleanupManager: %w", err)
 	}
 
@@ -304,6 +304,16 @@ func (d *driver) nodeUnprepareResource(ctx context.Context, claimRef kubeletplug
 	klog.V(1).Infof("Unprepared devices for claim '%v'", claimRef.String())
 	drametrics.ObserveRequest(DriverName, "unprepare", time.Since(tstart))
 	return true, nil
+}
+
+func (d *driver) deleteExpiredPrepareAbortedClaimEntries(ctx context.Context, now time.Time, ttl time.Duration) (int, error) {
+	release, err := d.pulock.Acquire(ctx, flock.WithTimeout(10*time.Second))
+	if err != nil {
+		return 0, fmt.Errorf("error acquiring prep/unprep lock: %w", err)
+	}
+	defer release()
+
+	return d.state.deleteExpiredPrepareAbortedClaimsFromCheckpoint(now, ttl)
 }
 
 // TODO: implement loop to remove CDI files from the CDI path for claimUIDs

--- a/tests/bats/test_cd_misc.bats
+++ b/tests/bats/test_cd_misc.bats
@@ -200,18 +200,18 @@ bats::on_failure() {
     -l dra-driver-nvidia-gpu-component=kubelet-plugin \
     -n dra-driver-nvidia-gpu \
     --prefix --tail=-1
-  assert_output --partial "Deleted claim from checkpoint: default/batssuite-rc-bad-opaque-config"
+  assert_output --partial "Marked claim PrepareAborted in checkpoint: default/batssuite-rc-bad-opaque-config"
   assert_output --partial "Checkpointed RC cleanup: unprepared stale claim: default/batssuite-rc-bad-opaque-config"
 
   # Stage 4: appendix -- happens shortly thereafter: we do get a
-  # UnprepareResourceClaims() call for this claim. Why? It's a noop because the
-  # cleanup above was faster.
+  # UnprepareResourceClaims() call for this claim. Why? It's a noop because
+  # cleanup above already moved the checkpoint entry to PrepareAborted.
   sleep 4
   run kubectl logs \
     -l dra-driver-nvidia-gpu-component=kubelet-plugin \
     -n dra-driver-nvidia-gpu \
     --prefix --tail=-1
-  assert_output --partial "Unprepare noop: claim not found in checkpoint data"
+  assert_output --partial "Unprepare noop: claim in PrepareAborted state"
 }
 
 


### PR DESCRIPTION
…stale prepare call

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
This PR adds an `UnprepareCompleted` checkpoint state for compute-domain ResourceClaims so a stale `Prepare` retry for the same claim version is rejected after the claim has already been unprepared.

Instead of deleting the checkpoint entry immediately on successful unprepare, the compute-domain kubelet plugin now keeps a short-lived unprepared entry with the claim name, namespace, resource version, and unprepare timestamp. Cleanup periodically removes expired unprepared entries after the retry window has passed.

This prevents stale prepare calls from recreating prepared-device checkpoint state after unprepare has completed.
#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Fixes #1162
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
The compute-domain kubelet plugin now rejects stale prepare retries for ResourceClaims that have already completed unprepare, preventing stale prepared-device checkpoint state from being recreated for the same claim version.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed

Output of running CD related bats test
```
All done.
-- -219.ec2.internal
-- -126.ec2.internal
+ set +x
cleanup: done
+ set +x
--- STARTING TEST SUITE ---
+ TMPDIR=/cwd/.tmp/test-out/k8s-dra-driver-gpu-tests-out-vtanksale/bats-tests-1781422978
+ bats --print-output-on-failure --no-tempdir-cleanup --timing --abort tests/bats/test_basics.bats tests/bats/test_cd_imex_chan_inject.bats tests/bats/test_cd_mnnvl_workload.bats tests/bats/test_cd_misc.bats tests/bats/test_cd_logging.bats tests/bats/test_cd_failover.bats tests/bats/test_cd_updowngrade.bats tests/bats/test_cd_leader_election.bats
test_basics.bats
 ✓ basics: test VERSION_W_COMMIT, VERSION_STAGING_CHART, VERSION [88]
 ✓ basics: confirm no kubelet plugin pods running [604]
 ✓ basics: GPU Operator installed [647]
 ✓ basics: helm-install deployments/helm/dra-driver-nvidia-gpu/0.5.0-dev [20079]
 ✓ basics: helm list: validate output [1125]
 ✓ basics: get crd computedomains.resource.nvidia.com [656]
 ✓ basics: wait for plugin & controller pods READY [1536]
 ✓ basics: validate CD controller container image spec [652]
 ✓ basics: SIGUSR2 handler: GPU plugin, CD plugin [5407]
test_cd_imex_chan_inject.bats
 ✓ CDs: IMEX channel injection (single) [18614]
 - CDs: IMEX channel injection (all) (skipped: tested chart version smaller than 25.8.0) [4722]
test_cd_mnnvl_workload.bats
 ✓ CDs: nickelpie (NCCL send/recv/broadcast, 2 pods, 2 nodes, small payload) [67897]
 ✓ CDs: nvbandwidth (2 nodes, 2 GPUs each) [41456]
test_cd_misc.bats
 ✓ CDs: daemon shutdown: confirm CD status cleanup [37468]
 ✓ CDs: reject unknown field in opaque cfg in CD chan ResourceClaim [35977]
 ✓ CDs: self-initiated unprepare of stale RCs in PrepareStarted [109104]
 ✓ CDs: global CD status [26012]
 ✓ CDs: IMEX channel injection (featureGates.ComputeDomainClique=true) [42557]
test_cd_logging.bats
 ✓ CDs: controller/plugin: startup config / detail in logs on level 0 [28171]
 ✓ CDs: controller: test log verbosity levels [287607]
 ✓ CDs: daemon: test log verbosity levels [102015]
test_cd_failover.bats
 ✓ CDs: failover nvb: force-delete worker pod 0 [111333]
 ✓ CDs: failover nvb: force-delete all IMEX daemons [94116]
 ✓ CDs: failover nvb: regular-delete worker pod 1 [96758]
 ✓ CDs: nvb many-iteration wrapper [21587]
test_cd_updowngrade.bats
 ✓ CDs: downgrade: current-dev -> last-stable [56719]
 ✓ CDs: upgrade: wipe-state, install-last-stable, upgrade-to-current-dev [90213]
test_cd_leader_election.bats
 ✓ CD controller: leader election: exactly one leader among two replicas [9130]
 ✓ CD controller: leader election: standby acquires lease after leader is force-deleted [8891]
```
