### PR TITLE
fix: bind IOMMU group companion devices to vfio-pci during Configure/Unconfigure

### DIFF
--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,6 +55,10 @@ type VfioPciManager struct {
 	driver              string
 	nvlib               *deviceLib
 	nvidiaEnabled       bool
+	// companionDrivers tracks the original driver of each non-GPU device in the
+	// GPU's IOMMU group that was switched to vfio-pci during Configure().
+	// Key: PCI address, Value: original driver name (empty string = had no driver).
+	companionDrivers map[string]string
 }
 
 func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib *deviceLib, nvidiaEnabled bool) (*VfioPciManager, error) {
@@ -82,6 +87,7 @@ func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib 
 		driver:              vfioPciDriver,
 		nvlib:               nvlib,
 		nvidiaEnabled:       nvidiaEnabled,
+		companionDrivers:    make(map[string]string),
 	}
 
 	return vm, nil
@@ -182,6 +188,14 @@ func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) e
 		return fmt.Errorf("error changing driver for GPU %q: %w", info.PciBusID, err)
 	}
 
+	// Bind all companion devices in the same IOMMU group to vfio-pci.
+	// VFIO requires every non-bridge endpoint in the group to be bound to vfio-pci
+	// before QEMU can open the group (viability check).
+	if err := vm.bindIommuGroupCompanions(info.PciBusID); err != nil {
+		// Log but don't fail — the QEMU viability error will surface if this matters.
+		klog.Warningf("Could not bind all IOMMU group companions for %s: %v", info.PciBusID, err)
+	}
+
 	return nil
 }
 
@@ -191,6 +205,10 @@ func (vm *VfioPciManager) Unconfigure(ctx context.Context, info *VfioDeviceInfo)
 	if !vm.nvidiaEnabled {
 		return nil
 	}
+
+	// Restore all IOMMU group companion devices to their original drivers before
+	// switching the GPU back, so the group is in a consistent state.
+	vm.restoreIommuGroupCompanions(info.PciBusID)
 
 	// Change the GPU driver to nvidia.
 	err := vm.changeDriver(info.PciBusID, nvidiaDriver)
@@ -365,4 +383,119 @@ func execCommandWithChroot(fsRoot, cmd string, args []string) ([]byte, error) {
 // Execute a command.
 func execCommand(cmd string, args []string) ([]byte, error) {
 	return exec.Command(cmd, args...).CombinedOutput()
+}
+
+// getIommuGroupCompanions returns PCI addresses of all non-bridge endpoint devices
+// in the same IOMMU group as gpuPciBusID, excluding the GPU itself.
+// PCIe root ports and bridges (class 0x06xx) are skipped as they do not need to
+// be bound to vfio-pci for VFIO group viability.
+func getIommuGroupCompanions(gpuPciBusID string) ([]string, error) {
+	// /sys/bus/pci/devices/<gpu>/iommu_group is a symlink like
+	// "../../kernel/iommu_groups/<N>". Resolve the devices subdirectory.
+	iommuGroupLink := filepath.Join(pciDevicesPath, gpuPciBusID, "iommu_group")
+	iommuGroupTarget, err := os.Readlink(iommuGroupLink)
+	if err != nil {
+		return nil, fmt.Errorf("error reading iommu_group symlink for %q: %w", gpuPciBusID, err)
+	}
+	// iommuGroupTarget is relative to the symlink location, e.g. "../../kernel/iommu_groups/6"
+	devicesPath := filepath.Join(pciDevicesPath, gpuPciBusID, iommuGroupTarget, "devices")
+
+	entries, err := os.ReadDir(devicesPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading IOMMU group devices at %q: %w", devicesPath, err)
+	}
+
+	var companions []string
+	for _, entry := range entries {
+		devName := entry.Name()
+		if devName == gpuPciBusID {
+			continue // skip the GPU itself
+		}
+
+		// Skip PCIe bridges and root ports (PCI class code 0x06xx).
+		classPath := filepath.Join(pciDevicesPath, devName, "class")
+		classBytes, err := os.ReadFile(classPath)
+		if err != nil {
+			klog.Warningf("Could not read PCI class for %s, skipping: %v", devName, err)
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(string(classBytes)), "0x06") {
+			klog.V(4).Infof("Skipping PCIe bridge/port %s in IOMMU group", devName)
+			continue
+		}
+
+		companions = append(companions, devName)
+	}
+	return companions, nil
+}
+
+// bindIommuGroupCompanions switches every non-bridge companion device in the GPU's
+// IOMMU group to vfio-pci, saving their original drivers for later restoration.
+func (vm *VfioPciManager) bindIommuGroupCompanions(gpuPciBusID string) error {
+	companions, err := getIommuGroupCompanions(gpuPciBusID)
+	if err != nil {
+		return err
+	}
+
+	for _, dev := range companions {
+		origDriver := ""
+		if d, err := getDriver(pciDevicesPath, dev); err == nil {
+			origDriver = d
+		}
+
+		if origDriver == vfioPciDriver {
+			klog.V(4).Infof("IOMMU companion %s already bound to vfio-pci", dev)
+			vm.companionDrivers[dev] = origDriver
+			continue
+		}
+
+		klog.Infof("Binding IOMMU group companion %s (was: %q) to vfio-pci for GPU %s", dev, origDriver, gpuPciBusID)
+
+		// Unbind from current driver if any.
+		if origDriver != "" {
+			if out, err := execCommand(unbindFromDriverScript, []string{dev}); err != nil {
+				return fmt.Errorf("error unbinding companion %s from %q: %w (output: %s)", dev, origDriver, err, string(out))
+			}
+		}
+
+		// Bind to vfio-pci.
+		if out, err := execCommand(bindToDriverScript, []string{dev, vfioPciDriver}); err != nil {
+			return fmt.Errorf("error binding companion %s to vfio-pci: %w (output: %s)", dev, err, string(out))
+		}
+
+		vm.companionDrivers[dev] = origDriver
+	}
+	return nil
+}
+
+// restoreIommuGroupCompanions unbinds companion devices from vfio-pci and
+// triggers re-probe so the kernel re-attaches their original drivers.
+func (vm *VfioPciManager) restoreIommuGroupCompanions(gpuPciBusID string) {
+	if len(vm.companionDrivers) == 0 {
+		return
+	}
+
+	for dev, origDriver := range vm.companionDrivers {
+		klog.Infof("Restoring IOMMU group companion %s to %q for GPU %s", dev, origDriver, gpuPciBusID)
+
+		// Unbind from vfio-pci.
+		if out, err := execCommand(unbindFromDriverScript, []string{dev}); err != nil {
+			klog.Warningf("Error unbinding companion %s from vfio-pci: %v (output: %s)", dev, err, string(out))
+		}
+
+		// Clear driver_override so the kernel will use its normal probe logic.
+		overridePath := filepath.Join(pciDevicesPath, dev, "driver_override")
+		if err := os.WriteFile(overridePath, []byte(""), 0600); err != nil {
+			klog.Warningf("Could not clear driver_override for %s: %v", dev, err)
+		}
+
+		// Trigger re-probe: write the PCI address to /sys/bus/pci/drivers_probe.
+		probePath := "/sys/bus/pci/drivers_probe"
+		if err := os.WriteFile(probePath, []byte(dev), 0600); err != nil {
+			klog.Warningf("Could not trigger re-probe for %s: %v — companion may need manual rebind", dev, err)
+		}
+	}
+
+	// Clear the map after restoration.
+	vm.companionDrivers = make(map[string]string)
 }

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -37,16 +37,19 @@ const (
 	nvidiaDriver                 = "nvidia"
 	hostRoot                     = "/host-root"
 	sysModulePath                = "/sys/module"
-	pciDevicesPath               = "/sys/bus/pci/devices"
 	vfioDevicesRoot              = "/dev/vfio"
 	vfioDevicesPath              = "/dev/vfio/devices"
 	iommuDevicePath              = "/dev/iommu"
 	nvidiaPersistencedSocketPath = "/run/nvidia-persistenced/socket"
 	unbindFromDriverScript       = "/usr/bin/unbind_from_driver.sh"
 	bindToDriverScript           = "/usr/bin/bind_to_driver.sh"
+	pciDriversProbePath          = "/sys/bus/pci/drivers_probe"
 	gpuFreeCheckInterval         = 1 * time.Second
 	gpuFreeCheckTimeout          = 60 * time.Second
 )
+
+// pciDevicesPath is a variable (not const) to allow test overrides with a mock sysfs.
+var pciDevicesPath = "/sys/bus/pci/devices"
 
 type VfioPciManager struct {
 	sync.Mutex
@@ -55,10 +58,12 @@ type VfioPciManager struct {
 	driver              string
 	nvlib               *deviceLib
 	nvidiaEnabled       bool
-	// companionDrivers tracks the original driver of each non-GPU device in the
-	// GPU's IOMMU group that was switched to vfio-pci during Configure().
-	// Key: PCI address, Value: original driver name (empty string = had no driver).
-	companionDrivers map[string]string
+	// companionMu protects companionDrivers from concurrent access.
+	companionMu sync.Mutex
+	// companionDrivers tracks the original driver of each non-GPU companion device
+	// that was switched to vfio-pci during Configure(), keyed by GPU PCI address.
+	// Outer key: GPU PCI address, inner key: companion PCI address, value: original driver.
+	companionDrivers map[string]map[string]string
 }
 
 func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib *deviceLib, nvidiaEnabled bool) (*VfioPciManager, error) {
@@ -87,7 +92,7 @@ func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib 
 		driver:              vfioPciDriver,
 		nvlib:               nvlib,
 		nvidiaEnabled:       nvidiaEnabled,
-		companionDrivers:    make(map[string]string),
+		companionDrivers:    make(map[string]map[string]string),
 	}
 
 	return vm, nil
@@ -390,19 +395,14 @@ func execCommand(cmd string, args []string) ([]byte, error) {
 // PCIe root ports and bridges (class 0x06xx) are skipped as they do not need to
 // be bound to vfio-pci for VFIO group viability.
 func getIommuGroupCompanions(gpuPciBusID string) ([]string, error) {
-	// /sys/bus/pci/devices/<gpu>/iommu_group is a symlink like
-	// "../../kernel/iommu_groups/<N>". Resolve the devices subdirectory.
-	iommuGroupLink := filepath.Join(pciDevicesPath, gpuPciBusID, "iommu_group")
-	iommuGroupTarget, err := os.Readlink(iommuGroupLink)
+	iommuGroupPath, err := resolveIommuGroupDevicesPath(gpuPciBusID)
 	if err != nil {
-		return nil, fmt.Errorf("error reading iommu_group symlink for %q: %w", gpuPciBusID, err)
+		return nil, err
 	}
-	// iommuGroupTarget is relative to the symlink location, e.g. "../../kernel/iommu_groups/6"
-	devicesPath := filepath.Join(pciDevicesPath, gpuPciBusID, iommuGroupTarget, "devices")
 
-	entries, err := os.ReadDir(devicesPath)
+	entries, err := os.ReadDir(iommuGroupPath)
 	if err != nil {
-		return nil, fmt.Errorf("error reading IOMMU group devices at %q: %w", devicesPath, err)
+		return nil, fmt.Errorf("error reading IOMMU group devices at %q: %w", iommuGroupPath, err)
 	}
 
 	var companions []string
@@ -412,14 +412,12 @@ func getIommuGroupCompanions(gpuPciBusID string) ([]string, error) {
 			continue // skip the GPU itself
 		}
 
-		// Skip PCIe bridges and root ports (PCI class code 0x06xx).
-		classPath := filepath.Join(pciDevicesPath, devName, "class")
-		classBytes, err := os.ReadFile(classPath)
+		isBridge, err := isPCIBridgeDevice(devName)
 		if err != nil {
 			klog.Warningf("Could not read PCI class for %s, skipping: %v", devName, err)
 			continue
 		}
-		if strings.HasPrefix(strings.TrimSpace(string(classBytes)), "0x06") {
+		if isBridge {
 			klog.V(4).Infof("Skipping PCIe bridge/port %s in IOMMU group", devName)
 			continue
 		}
@@ -427,6 +425,26 @@ func getIommuGroupCompanions(gpuPciBusID string) ([]string, error) {
 		companions = append(companions, devName)
 	}
 	return companions, nil
+}
+
+// resolveIommuGroupDevicesPath resolves the IOMMU group devices directory for a PCI device.
+func resolveIommuGroupDevicesPath(pciBusID string) (string, error) {
+	iommuGroupLink := filepath.Join(pciDevicesPath, pciBusID, "iommu_group")
+	iommuGroupTarget, err := os.Readlink(iommuGroupLink)
+	if err != nil {
+		return "", fmt.Errorf("error reading iommu_group symlink for %q: %w", pciBusID, err)
+	}
+	return filepath.Join(pciDevicesPath, pciBusID, iommuGroupTarget, "devices"), nil
+}
+
+// isPCIBridgeDevice returns true if the PCI device is a bridge or root port (class 0x06xx).
+func isPCIBridgeDevice(pciBusID string) (bool, error) {
+	classPath := filepath.Join(pciDevicesPath, pciBusID, "class")
+	classBytes, err := os.ReadFile(classPath)
+	if err != nil {
+		return false, err
+	}
+	return strings.HasPrefix(strings.TrimSpace(string(classBytes)), "0x06"), nil
 }
 
 // bindIommuGroupCompanions switches every non-bridge companion device in the GPU's
@@ -437,6 +455,11 @@ func (vm *VfioPciManager) bindIommuGroupCompanions(gpuPciBusID string) error {
 		return err
 	}
 
+	vm.companionMu.Lock()
+	defer vm.companionMu.Unlock()
+
+	gpuCompanions := make(map[string]string)
+
 	for _, dev := range companions {
 		origDriver := ""
 		if d, err := getDriver(pciDevicesPath, dev); err == nil {
@@ -445,7 +468,7 @@ func (vm *VfioPciManager) bindIommuGroupCompanions(gpuPciBusID string) error {
 
 		if origDriver == vfioPciDriver {
 			klog.V(4).Infof("IOMMU companion %s already bound to vfio-pci", dev)
-			vm.companionDrivers[dev] = origDriver
+			gpuCompanions[dev] = origDriver
 			continue
 		}
 
@@ -463,19 +486,46 @@ func (vm *VfioPciManager) bindIommuGroupCompanions(gpuPciBusID string) error {
 			return fmt.Errorf("error binding companion %s to vfio-pci: %w (output: %s)", dev, err, string(out))
 		}
 
-		vm.companionDrivers[dev] = origDriver
+		gpuCompanions[dev] = origDriver
 	}
+
+	vm.companionDrivers[gpuPciBusID] = gpuCompanions
 	return nil
+}
+
+// isCompanionStillNeeded returns true if the companion device is still referenced
+// by another configured GPU (i.e. a GPU other than excludeGPU).
+func (vm *VfioPciManager) isCompanionStillNeeded(companionDev, excludeGPU string) bool {
+	for gpu, companions := range vm.companionDrivers {
+		if gpu == excludeGPU {
+			continue
+		}
+		if _, ok := companions[companionDev]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // restoreIommuGroupCompanions unbinds companion devices from vfio-pci and
 // triggers re-probe so the kernel re-attaches their original drivers.
+// Only companions that are not still needed by other configured GPUs are restored.
 func (vm *VfioPciManager) restoreIommuGroupCompanions(gpuPciBusID string) {
-	if len(vm.companionDrivers) == 0 {
+	vm.companionMu.Lock()
+	defer vm.companionMu.Unlock()
+
+	gpuCompanions, ok := vm.companionDrivers[gpuPciBusID]
+	if !ok || len(gpuCompanions) == 0 {
 		return
 	}
 
-	for dev, origDriver := range vm.companionDrivers {
+	for dev, origDriver := range gpuCompanions {
+		// Skip if another configured GPU still needs this companion bound to vfio-pci.
+		if vm.isCompanionStillNeeded(dev, gpuPciBusID) {
+			klog.V(4).Infof("Companion %s still needed by another GPU, skipping restore", dev)
+			continue
+		}
+
 		klog.Infof("Restoring IOMMU group companion %s to %q for GPU %s", dev, origDriver, gpuPciBusID)
 
 		// Unbind from vfio-pci.
@@ -484,18 +534,17 @@ func (vm *VfioPciManager) restoreIommuGroupCompanions(gpuPciBusID string) {
 		}
 
 		// Clear driver_override so the kernel will use its normal probe logic.
+		// Writing "\n" triggers the kernel's driver_override_store to free the override.
 		overridePath := filepath.Join(pciDevicesPath, dev, "driver_override")
-		if err := os.WriteFile(overridePath, []byte(""), 0600); err != nil {
+		if err := os.WriteFile(overridePath, []byte("\n"), 0600); err != nil {
 			klog.Warningf("Could not clear driver_override for %s: %v", dev, err)
 		}
 
-		// Trigger re-probe: write the PCI address to /sys/bus/pci/drivers_probe.
-		probePath := "/sys/bus/pci/drivers_probe"
-		if err := os.WriteFile(probePath, []byte(dev), 0600); err != nil {
+		// Trigger re-probe so the kernel re-attaches the original driver.
+		if err := os.WriteFile(pciDriversProbePath, []byte(dev), 0600); err != nil {
 			klog.Warningf("Could not trigger re-probe for %s: %v — companion may need manual rebind", dev, err)
 		}
 	}
 
-	// Clear the map after restoration.
-	vm.companionDrivers = make(map[string]string)
+	delete(vm.companionDrivers, gpuPciBusID)
 }

--- a/cmd/gpu-kubelet-plugin/vfio-device_test.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setupMockIommuGroup creates a fake sysfs layout for IOMMU group testing.
+// Returns the temp dir and a cleanup function.
+//
+// Layout:
+//
+//	<tmpdir>/sys/bus/pci/devices/<gpu>/iommu_group -> ../../../../kernel/iommu_groups/<groupID>
+//	<tmpdir>/kernel/iommu_groups/<groupID>/devices/<device>/  (for each device)
+//	<tmpdir>/sys/bus/pci/devices/<device>/class  (PCI class code)
+func setupMockIommuGroup(t *testing.T, groupID string, devices map[string]string, gpuPciBusID string) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	pciDevDir := filepath.Join(tmpDir, "sys", "bus", "pci", "devices")
+	iommuGroupDevicesDir := filepath.Join(tmpDir, "kernel", "iommu_groups", groupID, "devices")
+	require.NoError(t, os.MkdirAll(iommuGroupDevicesDir, 0755))
+
+	for devAddr, classCode := range devices {
+		// Create the device directory under iommu_groups/<N>/devices/
+		devInGroup := filepath.Join(iommuGroupDevicesDir, devAddr)
+		require.NoError(t, os.MkdirAll(devInGroup, 0755))
+
+		// Create /sys/bus/pci/devices/<dev>/class with the PCI class code.
+		devPciDir := filepath.Join(pciDevDir, devAddr)
+		require.NoError(t, os.MkdirAll(devPciDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(devPciDir, "class"), []byte(classCode+"\n"), 0644))
+	}
+
+	// Create the iommu_group symlink for the GPU.
+	gpuPciDir := filepath.Join(pciDevDir, gpuPciBusID)
+	require.NoError(t, os.MkdirAll(gpuPciDir, 0755))
+
+	// Symlink: <pciDevDir>/<gpu>/iommu_group -> relative path to iommu group
+	relTarget, err := filepath.Rel(gpuPciDir, filepath.Join(tmpDir, "kernel", "iommu_groups", groupID))
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink(relTarget, filepath.Join(gpuPciDir, "iommu_group")))
+
+	return tmpDir
+}
+
+func TestGetIommuGroupCompanions(t *testing.T) {
+	testCases := map[string]struct {
+		gpuPciBusID        string
+		devices            map[string]string // PCI address -> class code
+		expectedCompanions []string
+	}{
+		"GPU with HDA audio companion": {
+			gpuPciBusID: "0000:86:00.0",
+			devices: map[string]string{
+				"0000:86:00.0": "0x030000", // VGA controller
+				"0000:86:00.1": "0x040300", // Audio device
+			},
+			expectedCompanions: []string{"0000:86:00.1"},
+		},
+		"GPU alone in group": {
+			gpuPciBusID: "0000:41:00.0",
+			devices: map[string]string{
+				"0000:41:00.0": "0x030000",
+			},
+			expectedCompanions: nil,
+		},
+		"GPU with bridge device (should be skipped)": {
+			gpuPciBusID: "0000:86:00.0",
+			devices: map[string]string{
+				"0000:86:00.0": "0x030000", // VGA controller
+				"0000:85:00.0": "0x060400", // PCI bridge
+			},
+			expectedCompanions: nil,
+		},
+		"GPU with mixed devices": {
+			gpuPciBusID: "0000:86:00.0",
+			devices: map[string]string{
+				"0000:86:00.0": "0x030000", // VGA controller
+				"0000:86:00.1": "0x040300", // Audio device
+				"0000:85:00.0": "0x060400", // PCI bridge (skipped)
+				"0000:86:00.2": "0x0c0330", // USB controller
+			},
+			expectedCompanions: []string{"0000:86:00.1", "0000:86:00.2"},
+		},
+	}
+
+	// Save and restore original pciDevicesPath.
+	origPciDevicesPath := pciDevicesPath
+	t.Cleanup(func() { pciDevicesPath = origPciDevicesPath })
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tmpDir := setupMockIommuGroup(t, "6", tc.devices, tc.gpuPciBusID)
+			pciDevicesPath = filepath.Join(tmpDir, "sys", "bus", "pci", "devices")
+
+			companions, err := getIommuGroupCompanions(tc.gpuPciBusID)
+			require.NoError(t, err)
+
+			if tc.expectedCompanions == nil {
+				require.Empty(t, companions)
+			} else {
+				require.ElementsMatch(t, tc.expectedCompanions, companions)
+			}
+		})
+	}
+}
+
+func TestGetIommuGroupCompanions_NoIommuGroup(t *testing.T) {
+	origPciDevicesPath := pciDevicesPath
+	t.Cleanup(func() { pciDevicesPath = origPciDevicesPath })
+
+	tmpDir := t.TempDir()
+	pciDevicesPath = filepath.Join(tmpDir, "sys", "bus", "pci", "devices")
+
+	// Create the GPU PCI directory without an iommu_group symlink.
+	gpuDir := filepath.Join(pciDevicesPath, "0000:86:00.0")
+	require.NoError(t, os.MkdirAll(gpuDir, 0755))
+
+	_, err := getIommuGroupCompanions("0000:86:00.0")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "iommu_group")
+}
+
+func TestIsPCIBridgeDevice(t *testing.T) {
+	origPciDevicesPath := pciDevicesPath
+	t.Cleanup(func() { pciDevicesPath = origPciDevicesPath })
+
+	tmpDir := t.TempDir()
+	pciDevicesPath = filepath.Join(tmpDir, "sys", "bus", "pci", "devices")
+
+	testCases := map[string]struct {
+		classCode string
+		isBridge  bool
+	}{
+		"VGA controller":  {"0x030000", false},
+		"Audio device":    {"0x040300", false},
+		"PCI bridge":      {"0x060400", true},
+		"Root port":       {"0x060000", true},
+		"USB controller":  {"0x0c0330", false},
+		"NVMe controller": {"0x010802", false},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			devAddr := "0000:00:01.0"
+			devDir := filepath.Join(pciDevicesPath, devAddr)
+			require.NoError(t, os.MkdirAll(devDir, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(devDir, "class"), []byte(tc.classCode+"\n"), 0644))
+
+			result, err := isPCIBridgeDevice(devAddr)
+			require.NoError(t, err)
+			require.Equal(t, tc.isBridge, result)
+
+			// Clean up for next iteration.
+			require.NoError(t, os.RemoveAll(devDir))
+		})
+	}
+}
+
+func TestIsCompanionStillNeeded(t *testing.T) {
+	vm := &VfioPciManager{
+		companionDrivers: map[string]map[string]string{
+			"0000:86:00.0": {
+				"0000:86:00.1": "snd_hda_intel",
+			},
+			"0000:87:00.0": {
+				"0000:86:00.1": "snd_hda_intel", // shared companion
+				"0000:87:00.1": "snd_hda_intel",
+			},
+		},
+	}
+
+	// Companion 86:00.1 is referenced by both GPUs — still needed when excluding 86:00.0.
+	require.True(t, vm.isCompanionStillNeeded("0000:86:00.1", "0000:86:00.0"))
+
+	// Companion 87:00.1 is only referenced by 87:00.0 — not needed when excluding 87:00.0.
+	require.False(t, vm.isCompanionStillNeeded("0000:87:00.1", "0000:87:00.0"))
+
+	// Companion 86:00.1 still needed when excluding 87:00.0 (referenced by 86:00.0).
+	require.True(t, vm.isCompanionStillNeeded("0000:86:00.1", "0000:87:00.0"))
+
+	// Unknown companion is never needed.
+	require.False(t, vm.isCompanionStillNeeded("0000:99:00.1", "0000:86:00.0"))
+}
+
+func TestRestoreIommuGroupCompanions_PerGPUCleanup(t *testing.T) {
+	vm := &VfioPciManager{
+		companionDrivers: map[string]map[string]string{
+			"0000:86:00.0": {
+				"0000:86:00.1": "snd_hda_intel",
+			},
+			"0000:87:00.0": {
+				"0000:87:00.1": "snd_hda_intel",
+			},
+		},
+	}
+
+	// Restoring GPU 86:00.0 should only remove its entry, not affect 87:00.0.
+	// Note: actual restore calls execCommand/WriteFile which will fail in tests,
+	// but we test the map cleanup logic by checking that 87:00.0 companions survive.
+	// Since restore uses klog.Warning for exec failures, this won't panic.
+	vm.restoreIommuGroupCompanions("0000:86:00.0")
+
+	require.NotContains(t, vm.companionDrivers, "0000:86:00.0")
+	require.Contains(t, vm.companionDrivers, "0000:87:00.0")
+	require.Equal(t, "snd_hda_intel", vm.companionDrivers["0000:87:00.0"]["0000:87:00.1"])
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a GPU shares an IOMMU group with other PCI devices (e.g. an HDA audio controller at the same slot: `86:00.0` GPU + `86:00.1` Audio), VFIO requires **all non-bridge endpoints** in the group to be bound to `vfio-pci` before a VM can open the group (group viability check).

This PR adds automatic IOMMU group companion device management to `VfioPciManager`:

- **`Configure()`**: after binding the GPU to `vfio-pci`, discovers and binds all non-bridge companion devices in the same IOMMU group
- **`Unconfigure()`**: restores companion devices to their original drivers before switching the GPU back to nvidia

#### Which issue(s) this PR is related to:

Fixes #1191

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
Fix VFIO passthrough for GPUs sharing IOMMU group with companion devices
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [x] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
