### PR TITLE
Add health monitoring page

### DIFF
--- a/site/content/docs/guides/gpu-health-checking.md
+++ b/site/content/docs/guides/gpu-health-checking.md
@@ -15,19 +15,9 @@ to the corresponding [`ResourceSlice`](https://kubernetes.io/docs/concepts/sched
 signaling the Kubernetes scheduler to avoid placing new workloads on the affected
 device.
 
-Key capabilities:
+With this feature enabled, unhealthy devices are tainted in the
+`ResourceSlice` so the scheduler stops placing new workloads on them.
 
-- Continuous NVML monitoring: an event monitor watches each GPU for XID
-  errors and device-loss events for as long as the kubelet plugin runs.
-- Automatic device taints: unhealthy devices are tainted on their
-  `ResourceSlice` so the scheduler stops placing new workloads on them.
-- Configurable XID handling: you control which XID codes are treated as
-  non-fatal, so application-level errors do not block scheduling.
-
-This is most useful for distributed training jobs, where a single unhealthy GPU
-can stall or corrupt an entire job; inference serving, where degraded devices
-can cause silent numerical errors; and cluster observability, where non-fatal
-warnings are surfaced to monitoring tools without affecting scheduling.
 
 ## Feature status
 
@@ -110,6 +100,45 @@ helm upgrade dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/chart
     --set featureGates.NVMLDeviceHealthCheck=true
 ```
 
+## View taints on ResourceSlice
+
+Each taint appears on an individual device entry in `ResourceSlice.spec.devices`, not on the `ResourceSlice` itself.
+Use `jq` to show only device entries that have taints:
+
+```bash
+kubectl get resourceslices -o json | jq '
+  .items[].spec.devices[]
+  | select((.taints // []) | length > 0)
+  | {
+      device: .name,
+      taints: [.taints[] | {key, value, effect, timeAdded}]
+    }
+'
+```
+
+The following output shows an example non-fatal XID event:
+
+```json
+    {
+  "device": "gpu-0-mig-1g12gb-19-0",
+  "taints": [
+    {
+      "key": "gpu.nvidia.com/xid",
+      "value": "43",
+      "effect": "None",
+      "timeAdded": "2026-07-22T02:24:46Z"
+    }
+  ]
+}
+```
+
+The response includes the following details:
+* The `device` field identifies the affected device entry in the `ResourceSlice`.
+* The `key` field identifies the health event category, and `gpu.nvidia.com/xid` indicates an XID error.
+* The `value` field contains the decimal XID code reported by NVML, which is `43` in this example.
+* The `effect` field is `None` because the driver classifies XID `43` as non-fatal by default, so this taint records the event without preventing new allocations. For fatal XID codes, the effect is `NoSchedule`, which prevents new allocations that do not tolerate the taint.
+* The `timeAdded` field records when the API server added the taint. The GPU kubelet plugin leaves this field unset when it adds or changes a taint so that the API server assigns the timestamp.
+
 ## Recovering from an unhealthy device
 
 Device taints persist until the GPU kubelet plugin restarts. There is no
@@ -117,9 +146,7 @@ automated taint removal in the current release.
 
 To clear taints after a hardware issue is resolved:
 
-1. Confirm the hardware error is resolved (for example, by checking
-   [`nvidia-smi`](https://docs.nvidia.com/deploy/nvidia-smi/index.html) output or
-   kernel logs).
+1. Confirm the hardware error is resolved. Use dmesg to check the kernal logs.
 2. Restart the GPU kubelet plugin by rolling its `kubelet-plugin` DaemonSet:
 
 ```bash

--- a/site/content/docs/guides/gpu-health-checking.md
+++ b/site/content/docs/guides/gpu-health-checking.md
@@ -1,7 +1,7 @@
 ---
 title: GPU health checking
 linkTitle: GPU health checking
-weight: 40
+weight: 60
 description: >
   Monitor GPU health using NVML and apply device taints to prevent new workloads
   from scheduling on unhealthy GPUs.
@@ -29,17 +29,30 @@ can stall or corrupt an entire job; inference serving, where degraded devices
 can cause silent numerical errors; and cluster observability, where non-fatal
 warnings are surfaced to monitoring tools without affecting scheduling.
 
-## Feature status - Alpha
+## Feature status
 
 `NVMLDeviceHealthCheck` is an Alpha feature gate, disabled by default.
 
 | Feature gate | Default | Stage | Since |
 |---|---|---|---|
-| `NVMLDeviceHealthCheck` | `false` | Alpha | v25.12.0 |
+| `NVMLDeviceHealthCheck` | `false` | Alpha | v0.4.0 |
 
+`NVMLDeviceHealthCheck` is mutually exclusive with the `DynamicMIG`,
+`PassthroughSupport`, and `MPSSupport` feature gates. See
+
+Refer to the [feature gate constraints](../reference/feature-gates/#constraints) documentation for more details.
 > [!NOTE]
 >
 > This page describes the v0.4.0 and later implementation of health checking with the driver.
+
+## Prerequisites
+
+- The [`DRADeviceTaints`](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-taints-and-tolerations)
+  Kubernetes feature gate must be enabled on the `kube-apiserver`,
+  `kube-controller-manager`, and `kube-scheduler`.
+  In Kubernetes v1.34 and 1.35, `DRADeviceTaints` is disabled by default and must be explicitly enabled.
+  In Kubernetes v1.36, it is enabled by default.
+- NVIDIA DRA driver v0.4.0 or later installed via Helm.
 
 ## How it works
 
@@ -76,55 +89,8 @@ XID codes are NVIDIA-defined error identifiers for GPU hardware and firmware
 conditions. The driver classifies XIDs as fatal or non-fatal. Fatal XIDs produce
 a `NoSchedule` taint and non-fatal XIDs produce a `None` taint.
 
-By default, the driver sets the following XID errors as non-fatal because they indicate application-level failures rather than hardware degradation.  
-
-| XID | Description |
-|---|---|
-| 13 | Graphics Engine Exception |
-| 31 | GPU memory page fault |
-| 43 | GPU stopped processing |
-| 45 | Preemptive cleanup due to previous errors |
-| 68 | Video processor exception |
-| 109 | Context Switch Timeout Error |
-
 Refer to the [NVIDIA XID Errors documentation](https://docs.nvidia.com/deploy/xid-errors/index.html) for full descriptions for XID errors and codes.
 
-### Configure non-fatal XID list
-
-You can add XIDs to the non-fatal list using the `ADDITIONAL_XIDS_TO_IGNORE`
-environment variable on the GPU kubelet plugin's `gpus` container. Set it via
-Helm values:
-
-```yaml
-kubeletPlugin:
-  containers:
-    gpus:
-      env:
-        - name: ADDITIONAL_XIDS_TO_IGNORE
-          value: "48,62"
-```
-
-The value is a comma-separated list of XID codes. XIDs in this list receive a
-`None` taint effect instead of `NoSchedule`.
-
-Apply the change with `helm upgrade`, either by passing a values file:
-
-```bash
-helm upgrade dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
-    --namespace dra-driver-nvidia-gpu \
-    -f values.yaml
-```
-
-The new value takes effect after the `kubelet-plugin` DaemonSet pods restart.
-
-## Prerequisites
-
-- The [`DRADeviceTaints`](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-taints-and-tolerations)
-  Kubernetes feature gate must be enabled on the `kube-apiserver`,
-  `kube-controller-manager`, and `kube-scheduler`.
-  In Kubernetes v1.34 and 1.35, `DRADeviceTaints` is disabled by default and must be explicitly enabled.
-  In Kubernetes v1.36, it is enabled by default.
-- NVIDIA DRA driver v0.4.0 or later installed via Helm.
 
 ## Enabling the feature
 
@@ -143,16 +109,6 @@ helm upgrade dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/chart
     --reuse-values \
     --set featureGates.NVMLDeviceHealthCheck=true
 ```
-
-### Incompatible feature gates
-
-`NVMLDeviceHealthCheck` cannot be combined with the following feature gates.
-
-* `DynamicMIG` 
-* `PassthroughSupport`
-* `MPSSupport`
-
-Refer to the [feature gate constraints](../reference/feature-gates.md#constraints) documentation for more details.
 
 ## Recovering from an unhealthy device
 
@@ -194,8 +150,8 @@ objects to manually remove or override device taints without restarting the driv
 - **One taint per key per device**: Each device holds at most one taint per taint
   key. If multiple XID events occur on the same device, only the most recent value
   is retained.
-- **Incompatible feature gates**: Cannot be used with `DynamicMIG` or
-  `PassthroughSupport`. See [Incompatible feature gates](#incompatible-feature-gates).
+- **Mutually exclusive feature gates**: Cannot be used with `DynamicMIG`,
+  `PassthroughSupport`, or `MPSSupport`.
 - **Publish failure handling**: If the driver fails to update the `ResourceSlice`
   after a health event (for example, due to a transient API server error), the
   failure is logged but not retried. The `ResourceSlice` may remain stale until

--- a/site/content/docs/guides/gpu-health-checking.md
+++ b/site/content/docs/guides/gpu-health-checking.md
@@ -1,0 +1,203 @@
+---
+title: GPU health checking
+linkTitle: GPU health checking
+weight: 40
+description: >
+  Monitor GPU health using NVML and apply device taints to prevent new workloads
+  from scheduling on unhealthy GPUs.
+---
+
+The `NVMLDeviceHealthCheck` feature gate enables continuous GPU health monitoring
+through the [NVIDIA Management Library (NVML)](https://developer.nvidia.com/management-library-nvml).
+When a GPU enters an error state, the driver applies a
+[device taint](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-taints-and-tolerations)
+to the corresponding [`ResourceSlice`](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceslice),
+signaling the Kubernetes scheduler to avoid placing new workloads on the affected
+device.
+
+Key capabilities:
+
+- Continuous NVML monitoring: an event monitor watches each GPU for XID
+  errors and device-loss events for as long as the kubelet plugin runs.
+- Automatic device taints: unhealthy devices are tainted on their
+  `ResourceSlice` so the scheduler stops placing new workloads on them.
+- Configurable XID handling: you control which XID codes are treated as
+  non-fatal, so application-level errors do not block scheduling.
+
+This is most useful for distributed training jobs, where a single unhealthy GPU
+can stall or corrupt an entire job; inference serving, where degraded devices
+can cause silent numerical errors; and cluster observability, where non-fatal
+warnings are surfaced to monitoring tools without affecting scheduling.
+
+## Feature status - Alpha
+
+`NVMLDeviceHealthCheck` is an Alpha feature gate, disabled by default.
+
+| Feature gate | Default | Stage | Since |
+|---|---|---|---|
+| `NVMLDeviceHealthCheck` | `false` | Alpha | v25.12.0 |
+
+> [!NOTE]
+>
+> This page describes the v0.4.0 and later implementation of health checking with the driver.
+
+## How it works
+
+When enabled, the GPU kubelet plugin starts an
+[NVML event monitor](https://docs.nvidia.com/deploy/nvml-api/group__nvmlEvents.html).
+When a health
+event occurs on a GPU, the driver updates the `ResourceSlice` for the affected device
+with a device taint.
+
+The monitor tracks three event categories:
+
+| Event | Taint key | Default effect | Description |
+|---|---|---|---|
+| XID error (fatal) | `gpu.nvidia.com/xid` | `NoSchedule` | A critical GPU hardware or firmware error. |
+| XID error (non-fatal) | `gpu.nvidia.com/xid` | `None` | An application-level error that does not indicate hardware degradation. |
+| GPU lost | `gpu.nvidia.com/gpu-lost` | `NoSchedule` | The GPU has become inaccessible to the driver. |
+| Unmonitored | `gpu.nvidia.com/unmonitored` | `None` | The device cannot be monitored by NVML. |
+
+### Taint effects
+
+The driver applies the following [upstream Kubernetes device taint effects](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-taints-and-tolerations):
+
+- `NoSchedule` — the Kubernetes scheduler does not allocate the device to new
+  workloads. Existing workloads that already hold a claim to the device are not
+  evicted.
+- `None` — informational only; scheduling is not affected, but the taint is
+  visible in the `ResourceSlice`.
+
+The driver only ever applies the `None` and `NoSchedule` effects. It never evicts running workloads with `NoExecute`. If you would like to implement eviction rules when a device is tainted, an administrator can create a `DeviceTaintRule` with `effect: NoExecute`. Follow the Kubernetes documentation for [taints set up admins](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#taints-set-by-an-admin) for details.
+
+### XID errors
+
+XID codes are NVIDIA-defined error identifiers for GPU hardware and firmware
+conditions. The driver classifies XIDs as fatal or non-fatal. Fatal XIDs produce
+a `NoSchedule` taint and non-fatal XIDs produce a `None` taint.
+
+By default, the driver sets the following XID errors as non-fatal because they indicate application-level failures rather than hardware degradation.  
+
+| XID | Description |
+|---|---|
+| 13 | Graphics Engine Exception |
+| 31 | GPU memory page fault |
+| 43 | GPU stopped processing |
+| 45 | Preemptive cleanup due to previous errors |
+| 68 | Video processor exception |
+| 109 | Context Switch Timeout Error |
+
+Refer to the [NVIDIA XID Errors documentation](https://docs.nvidia.com/deploy/xid-errors/index.html) for full descriptions for XID errors and codes.
+
+### Configure non-fatal XID list
+
+You can add XIDs to the non-fatal list using the `ADDITIONAL_XIDS_TO_IGNORE`
+environment variable on the GPU kubelet plugin's `gpus` container. Set it via
+Helm values:
+
+```yaml
+kubeletPlugin:
+  containers:
+    gpus:
+      env:
+        - name: ADDITIONAL_XIDS_TO_IGNORE
+          value: "48,62"
+```
+
+The value is a comma-separated list of XID codes. XIDs in this list receive a
+`None` taint effect instead of `NoSchedule`.
+
+Apply the change with `helm upgrade`, either by passing a values file:
+
+```bash
+helm upgrade dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
+    --namespace dra-driver-nvidia-gpu \
+    -f values.yaml
+```
+
+The new value takes effect after the `kubelet-plugin` DaemonSet pods restart.
+
+## Prerequisites
+
+- The [`DRADeviceTaints`](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-taints-and-tolerations)
+  Kubernetes feature gate must be enabled on the `kube-apiserver`,
+  `kube-controller-manager`, and `kube-scheduler`.
+  In Kubernetes v1.34 and 1.35, `DRADeviceTaints` is disabled by default and must be explicitly enabled.
+  In Kubernetes v1.36, it is enabled by default.
+- NVIDIA DRA driver v0.4.0 or later installed via Helm.
+
+## Enabling the feature
+
+Add the following to your Helm values:
+
+```yaml
+featureGates:
+  NVMLDeviceHealthCheck: true
+```
+
+Then apply the change with `helm upgrade`:
+
+```bash
+helm upgrade dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
+    --namespace dra-driver-nvidia-gpu \
+    --reuse-values \
+    --set featureGates.NVMLDeviceHealthCheck=true
+```
+
+### Incompatible feature gates
+
+`NVMLDeviceHealthCheck` cannot be combined with the following feature gates.
+Enabling any combination causes the driver to fail at startup.
+
+| Feature gate | Reason |
+|---|---|
+| `DynamicMIG` | Dynamic [MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) changes the GPU device hierarchy at runtime, which is incompatible with the static device placement map the health monitor relies on. |
+| `PassthroughSupport` | Passthrough devices are not accessible via NVML and cannot be monitored. |
+
+## Recovering from an unhealthy device
+
+Device taints persist until the GPU kubelet plugin restarts. There is no
+automated taint removal in the current release.
+
+To clear taints after a hardware issue is resolved:
+
+1. Confirm the hardware error is resolved (for example, by checking
+   [`nvidia-smi`](https://docs.nvidia.com/deploy/nvidia-smi/index.html) output or
+   kernel logs).
+2. Restart the GPU kubelet plugin by rolling its `kubelet-plugin` DaemonSet:
+
+```bash
+kubectl rollout restart daemonset/dra-driver-nvidia-gpu-kubelet-plugin -n dra-driver-nvidia-gpu
+```
+
+On restart, the GPU kubelet plugin re-evaluates device health. Devices with no active NVML health events will not receive taints.
+
+> [!NOTE]
+>
+> If the underlying hardware issue persists, the taint is reapplied after restart.
+
+Kubernetes administrators can use
+[`DeviceTaintRule`](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#taints-set-by-an-admin)
+objects to manually remove or override device taints without restarting the driver.
+
+> [!NOTE]
+>
+> `DeviceTaintRule` is gated separately from `DRADeviceTaints`. It requires the
+> [`DRADeviceTaintRules`](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#taints-set-by-an-admin)
+> feature gate and the `resource.k8s.io/v1beta2` API. 
+
+## Limitations and considerations
+
+- **No automated recovery**: Taint removal requires a driver restart or a manual
+  `DeviceTaintRule` override. The driver does not clear taints when hardware
+  recovers.
+- **One taint per key per device**: Each device holds at most one taint per taint
+  key. If multiple XID events occur on the same device, only the most recent value
+  is retained.
+- **Incompatible feature gates**: Cannot be used with `DynamicMIG` or
+  `PassthroughSupport`. See [Incompatible feature gates](#incompatible-feature-gates).
+- **Publish failure handling**: If the driver fails to update the `ResourceSlice`
+  after a health event (for example, due to a transient API server error), the
+  failure is logged but not retried. The `ResourceSlice` may remain stale until
+  the next successful publish or driver restart.
+

--- a/site/content/docs/guides/gpu-health-checking.md
+++ b/site/content/docs/guides/gpu-health-checking.md
@@ -147,12 +147,12 @@ helm upgrade dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/chart
 ### Incompatible feature gates
 
 `NVMLDeviceHealthCheck` cannot be combined with the following feature gates.
-Enabling any combination causes the driver to fail at startup.
 
-| Feature gate | Reason |
-|---|---|
-| `DynamicMIG` | Dynamic [MIG](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/) changes the GPU device hierarchy at runtime, which is incompatible with the static device placement map the health monitor relies on. |
-| `PassthroughSupport` | Passthrough devices are not accessible via NVML and cannot be monitored. |
+* `DynamicMIG` 
+* `PassthroughSupport`
+* `MPSSupport`
+
+Refer to the [feature gate constraints](../reference/feature-gates.md#constraints) documentation for more details.
 
 ## Recovering from an unhealthy device
 

--- a/site/content/docs/guides/gpu-health-checking.md
+++ b/site/content/docs/guides/gpu-health-checking.md
@@ -87,9 +87,9 @@ The driver only ever applies the `None` and `NoSchedule` effects. It never evict
 
 XID codes are NVIDIA-defined error identifiers for GPU hardware and firmware
 conditions. The driver classifies XIDs as fatal or non-fatal. Fatal XIDs produce
-a `NoSchedule` taint and non-fatal XIDs produce a `None` taint.
+a `NoSchedule` taint and non-fatal XIDs produce a `None` taint. Refer to the [NVIDIA XID Errors documentation](https://docs.nvidia.com/deploy/xid-errors/index.html) for full descriptions for XID errors and codes.
 
-Refer to the [NVIDIA XID Errors documentation](https://docs.nvidia.com/deploy/xid-errors/index.html) for full descriptions for XID errors and codes.
+By default, the driver sets the some XID errors as non-fatal because they indicate application-level failures rather than hardware degradation. For a full list of these XID errors, refer to in the [Driver repo](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/{{< param driver_release_tag >}}/cmd/gpu-kubelet-plugin/device_health.go#L421).
 
 
 ## Enabling the feature


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:
Adds docs for health monitoring.


#### Which issue(s) this PR is related to:

Replaces https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/878

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
