### PR TITLE
Fix: Use kubelet-plugin service account for MPS control daemon

### DIFF
--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -60,6 +60,7 @@ type Flags struct {
 	imageName                     string
 	imagePullSecrets              string
 	imagePullPolicy               string
+	serviceAccountName            string
 	kubeletRegistrarDirectoryPath string
 	kubeletPluginsDirectoryPath   string
 	healthcheckPort               int
@@ -149,15 +150,21 @@ func newApp() *cli.App {
 		},
 		&cli.StringFlag{
 			Name:        "image-pull-secrets",
-			Usage:       "Comma-separated imagePullSecret names for MPS control daemon Deployments (e.g. regcred,other). Empty string means none.",
+			Usage:       "Comma-separated imagePullSecret names for rendering pod templates (e.g. for MPS control daemon Deployments). Empty string means none.",
 			Destination: &flags.imagePullSecrets,
 			EnvVars:     []string{"IMAGE_PULL_SECRETS"},
 		},
 		&cli.StringFlag{
 			Name:        "image-pull-policy",
-			Usage:       "Image pull policy for MPS control daemon Deployments. Empty string uses the Kubernetes default.",
+			Usage:       "Image pull policy to use for rendering pod templates (e.g. for MPS control daemon Deployments). Empty string uses the Kubernetes default.",
 			Destination: &flags.imagePullPolicy,
 			EnvVars:     []string{"IMAGE_PULL_POLICY"},
+		},
+		&cli.StringFlag{
+			Name:        "service-account-name",
+			Usage:       "Service account to use for rendering pod templates (e.g. for MPS control daemon Deployments). Empty string uses the Kubernetes default.",
+			Destination: &flags.serviceAccountName,
+			EnvVars:     []string{"SERVICE_ACCOUNT_NAME"},
 		},
 		&cli.StringFlag{
 			Name:        "kubelet-registrar-directory-path",

--- a/cmd/gpu-kubelet-plugin/sharing.go
+++ b/cmd/gpu-kubelet-plugin/sharing.go
@@ -113,6 +113,7 @@ type MpsControlDaemonTemplateData struct {
 	MpsImageName                    string
 	MpsImagePullPolicy              string
 	MpsImagePullSecretNames         []string
+	ServiceAccountName              string
 	FeatureGates                    map[string]bool
 	MpsShmMountPath                 string
 }
@@ -243,6 +244,7 @@ func (m *MpsControlDaemon) Start(ctx context.Context, config *configapi.MpsConfi
 		MpsImageName:                    m.manager.config.flags.imageName,
 		MpsImagePullPolicy:              m.manager.config.imagePullPolicy,
 		MpsImagePullSecretNames:         m.manager.config.imagePullSecretNames,
+		ServiceAccountName:              m.manager.config.flags.serviceAccountName,
 		FeatureGates:                    featuregates.ToMap(),
 		MpsShmMountPath:                 setMpsShmMountPath(osFileChecker{}),
 	}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -276,6 +276,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: IMAGE_NAME
           value: {{ include "dra-driver-nvidia-gpu.fullimage" . }}
         {{- if .Values.imagePullSecrets }}

--- a/templates/mps-control-daemon.tmpl.yaml
+++ b/templates/mps-control-daemon.tmpl.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         app: {{ .MpsControlDaemonName }}
     spec:
+      {{- if .ServiceAccountName }}
+      serviceAccountName: {{ .ServiceAccountName }}
+      {{- end }}
       nodeName: {{ .NodeName }}
       hostPID: true
       {{- if .MpsImagePullSecretNames }}


### PR DESCRIPTION
Use the kubelet-plugin service account when deploying the MPS control daemon.

OpenShift enforces Security Context Constraints (SCCs) and restricts the use of host-mounted volumes and other privileged pod features to service accounts with the appropriate permissions. Deploying the MPS control daemon with the kubelet-plugin service account ensures it inherits the required privileges and can be scheduled successfully on OpenShift clusters.

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:

This PR uses the service account of the kubelet plugin with the rendered MPS deployment

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1212

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
  Fixed an issue causing the MPS daemon deployment to fail on Red Hat OpenShift systems due to missing service account and a privileged SCC binding.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
