### PR TITLE
[release-0.4] Fix: Use kubelet-plugin service account for MPS control daemon

### DIFF
--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -55,6 +55,7 @@ type Flags struct {
 	hostDriverRoot                string
 	nvidiaCDIHookPath             string
 	imageName                     string
+	serviceAccountName            string
 	kubeletRegistrarDirectoryPath string
 	kubeletPluginsDirectoryPath   string
 	healthcheckPort               int
@@ -132,6 +133,12 @@ func newApp() *cli.App {
 			Required:    true,
 			Destination: &flags.imageName,
 			EnvVars:     []string{"IMAGE_NAME"},
+		},
+		&cli.StringFlag{
+			Name:        "service-account-name",
+			Usage:       "Service account to use for rendering pod templates (e.g. for MPS control daemon Deployments). Empty string uses the Kubernetes default.",
+			Destination: &flags.serviceAccountName,
+			EnvVars:     []string{"SERVICE_ACCOUNT_NAME"},
 		},
 		&cli.StringFlag{
 			Name:        "kubelet-registrar-directory-path",

--- a/cmd/gpu-kubelet-plugin/sharing.go
+++ b/cmd/gpu-kubelet-plugin/sharing.go
@@ -110,6 +110,7 @@ type MpsControlDaemonTemplateData struct {
 	MpsPipeDirectory                string
 	MpsLogDirectory                 string
 	MpsImageName                    string
+	ServiceAccountName              string
 	FeatureGates                    map[string]bool
 	MpsShmMountPath                 string
 }
@@ -237,6 +238,7 @@ func (m *MpsControlDaemon) Start(ctx context.Context, config *configapi.MpsConfi
 		MpsPipeDirectory:                m.pipeDir,
 		MpsLogDirectory:                 m.logDir,
 		MpsImageName:                    m.manager.config.flags.imageName,
+		ServiceAccountName:              m.manager.config.flags.serviceAccountName,
 		FeatureGates:                    featuregates.ToMap(),
 		MpsShmMountPath:                 setMpsShmMountPath(osFileChecker{}),
 	}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -272,6 +272,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: IMAGE_NAME
           value: {{ include "dra-driver-nvidia-gpu.fullimage" . }}
         {{- if .Values.nvidiaCDIHookPath }}

--- a/templates/mps-control-daemon.tmpl.yaml
+++ b/templates/mps-control-daemon.tmpl.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         app: {{ .MpsControlDaemonName }}
     spec:
+      {{- if .ServiceAccountName }}
+      serviceAccountName: {{ .ServiceAccountName }}
+      {{- end }}
       nodeName: {{ .NodeName }}
       hostPID: true
       containers:


### PR DESCRIPTION
Use the kubelet-plugin service account when deploying the MPS control daemon.

OpenShift enforces Security Context Constraints (SCCs) and restricts the use of host-mounted volumes and other privileged pod features to service accounts with the appropriate permissions. Deploying the MPS control daemon with the kubelet-plugin service account ensures it inherits the required privileges and can be scheduled successfully on OpenShift clusters.

This is a cherry-pick of https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1213

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind bug


```release-note
  Fixed an issue causing the MPS daemon deployment to fail on Red Hat OpenShift systems due to missing service account and a privileged SCC binding.
```