### PR TITLE
feat(consumable-shares): implements system-mediated sharing

### DIFF
--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -20,9 +20,13 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
+	"strings"
 
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 )
@@ -96,18 +100,106 @@ func (d *AllocatableDevice) CanonicalName() string {
 	panic("unexpected type for AllocatableDevice")
 }
 
-func (d *AllocatableDevice) GetDevice() resourceapi.Device {
+func (d *AllocatableDevice) GetDevice(config *Config) resourceapi.Device {
+	var dev resourceapi.Device
 	switch d.Type() {
 	case GpuDeviceType:
-		return d.Gpu.GetDevice()
+		dev = d.Gpu.GetDevice()
 	case MigStaticDeviceType:
-		return d.MigStatic.GetDevice()
+		dev = d.MigStatic.GetDevice()
 	case MigDynamicDeviceType:
 		panic("GetDevice() must currently not be called for MigDynamicDeviceType")
 	case VfioDeviceType:
 		return d.Vfio.GetDevice()
+	default:
+		panic("unexpected type for AllocatableDevice")
 	}
-	panic("unexpected type for AllocatableDevice")
+	applyConsumableShares(&dev, config)
+	return dev
+}
+
+func isConsumableSharesEnabled(config *Config) bool {
+	if !featuregates.Enabled(featuregates.ConsumableShares) {
+		return false
+	}
+	if config == nil || config.flags == nil {
+		return false
+	}
+	sharesOption := strings.TrimSpace(config.flags.consumableShares)
+	return sharesOption != "" && sharesOption != "disabled"
+}
+
+func applyConsumableShares(dev *resourceapi.Device, config *Config) {
+	if !isConsumableSharesEnabled(config) {
+		return
+	}
+	sharesOption := strings.TrimSpace(config.flags.consumableShares)
+
+	dev.AllowMultipleAllocations = ptr.To(true)
+
+	if dev.Capacity == nil {
+		dev.Capacity = make(map[resourceapi.QualifiedName]resourceapi.DeviceCapacity)
+	}
+
+	memCap, hasMemory := dev.Capacity["memory"]
+	if !hasMemory {
+		return
+	}
+
+	switch sharesOption {
+	case "memory":
+		oneGi := resource.MustParse("1Gi")
+		memCap.RequestPolicy = &resourceapi.CapacityRequestPolicy{
+			Default: ptr.To(memCap.Value.DeepCopy()),
+			ValidRange: &resourceapi.CapacityRequestPolicyRange{
+				Min:  ptr.To(oneGi.DeepCopy()),
+				Max:  ptr.To(memCap.Value.DeepCopy()),
+				Step: ptr.To(oneGi.DeepCopy()),
+			},
+		}
+		dev.Capacity["memory"] = memCap
+	case "unlimited":
+		zeroGi := resource.MustParse("0")
+		oneGi := resource.MustParse("1Gi")
+		memCap.RequestPolicy = &resourceapi.CapacityRequestPolicy{
+			Default: ptr.To(zeroGi.DeepCopy()),
+			ValidRange: &resourceapi.CapacityRequestPolicyRange{
+				Min:  ptr.To(zeroGi.DeepCopy()),
+				Max:  ptr.To(memCap.Value.DeepCopy()),
+				Step: ptr.To(oneGi.DeepCopy()),
+			},
+		}
+		dev.Capacity["memory"] = memCap
+	default:
+		val, err := strconv.Atoi(sharesOption)
+		if err == nil && val > 0 {
+			zeroGi := resource.MustParse("0")
+			oneGi := resource.MustParse("1Gi")
+			memCap.RequestPolicy = &resourceapi.CapacityRequestPolicy{
+				Default: ptr.To(zeroGi.DeepCopy()),
+				ValidRange: &resourceapi.CapacityRequestPolicyRange{
+					Min:  ptr.To(zeroGi.DeepCopy()),
+					Max:  ptr.To(memCap.Value.DeepCopy()),
+					Step: ptr.To(oneGi.DeepCopy()),
+				},
+			}
+			dev.Capacity["memory"] = memCap
+
+			sharesVal := *resource.NewQuantity(int64(val), resource.BinarySI)
+			oneVal := *resource.NewQuantity(1, resource.BinarySI)
+			dev.Capacity["shares"] = resourceapi.DeviceCapacity{
+				Value: sharesVal,
+				RequestPolicy: &resourceapi.CapacityRequestPolicy{
+					Default: ptr.To(oneVal.DeepCopy()),
+					ValidRange: &resourceapi.CapacityRequestPolicyRange{
+						Min:  ptr.To(oneVal.DeepCopy()),
+						Max:  ptr.To(sharesVal.DeepCopy()),
+						Step: ptr.To(oneVal.DeepCopy()),
+					},
+				},
+			}
+		}
+	}
 }
 
 // UUID() is here for `AllocatableDevices` to implement the `UUIDProvider`

--- a/cmd/gpu-kubelet-plugin/consumable_shares_test.go
+++ b/cmd/gpu-kubelet-plugin/consumable_shares_test.go
@@ -138,3 +138,101 @@ func TestApplyConsumableShares(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNoOverlappingPreparedDevices(t *testing.T) {
+	perGPU := &PerGPUAllocatableDevices{
+		allocatablesMap: map[PCIBusID]AllocatableDevices{
+			"0000:00:00.0": {
+				"gpu-0":  &AllocatableDevice{Gpu: &GpuInfo{minor: 0}},
+				"vfio-0": &AllocatableDevice{Vfio: &VfioDeviceInfo{index: 0}},
+			},
+		},
+	}
+
+	checkpoint := &Checkpoint{
+		V2: &CheckpointV2{
+			PreparedClaims: PreparedClaimsByUID{
+				"claim-1": {
+					CheckpointState: ClaimCheckpointStatePrepareCompleted,
+					Status: resourceapi.ResourceClaimStatus{
+						Allocation: &resourceapi.AllocationResult{
+							Devices: resourceapi.DeviceAllocationResult{
+								Results: []resourceapi.DeviceRequestAllocationResult{
+									{Driver: DriverName, Device: "gpu-0"},
+									{Driver: DriverName, Device: "vfio-0"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                 string
+		featureGate          bool
+		consumableSharesFlag string
+		requestDevice        string
+		expectErr            bool
+	}{
+		{
+			name:                 "gpu overlap rejected when consumable shares disabled",
+			featureGate:          false,
+			consumableSharesFlag: "disabled",
+			requestDevice:        "gpu-0",
+			expectErr:            true,
+		},
+		{
+			name:                 "gpu overlap allowed when consumable shares enabled",
+			featureGate:          true,
+			consumableSharesFlag: "memory",
+			requestDevice:        "gpu-0",
+			expectErr:            false,
+		},
+		{
+			name:                 "vfio overlap rejected even when consumable shares enabled",
+			featureGate:          true,
+			consumableSharesFlag: "memory",
+			requestDevice:        "vfio-0",
+			expectErr:            true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+				string(featuregates.ConsumableShares): tc.featureGate,
+			}))
+
+			state := &DeviceState{
+				config: &Config{
+					flags: &Flags{
+						consumableShares: tc.consumableSharesFlag,
+					},
+				},
+				perGPUAllocatable: perGPU,
+			}
+
+			incomingClaim := &resourceapi.ResourceClaim{
+				Status: resourceapi.ResourceClaimStatus{
+					Allocation: &resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{Driver: DriverName, Device: tc.requestDevice},
+							},
+						},
+					},
+				},
+			}
+
+			err := state.validateNoOverlappingPreparedDevices(checkpoint, incomingClaim)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+

--- a/cmd/gpu-kubelet-plugin/consumable_shares_test.go
+++ b/cmd/gpu-kubelet-plugin/consumable_shares_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+func TestApplyConsumableShares(t *testing.T) {
+	memVal := resource.MustParse("16Gi")
+
+	tests := []struct {
+		name                 string
+		featureGate          bool
+		consumableSharesFlag string
+		expectModified       bool
+		expectedPolicyType   string
+		expectedSharesVal    int64
+	}{
+		{
+			name:                 "feature gate disabled",
+			featureGate:          false,
+			consumableSharesFlag: "memory",
+			expectModified:       false,
+		},
+		{
+			name:                 "flag disabled",
+			featureGate:          true,
+			consumableSharesFlag: "disabled",
+			expectModified:       false,
+		},
+		{
+			name:                 "memory option",
+			featureGate:          true,
+			consumableSharesFlag: "memory",
+			expectModified:       true,
+			expectedPolicyType:   "memory",
+		},
+		{
+			name:                 "unlimited option",
+			featureGate:          true,
+			consumableSharesFlag: "unlimited",
+			expectModified:       true,
+			expectedPolicyType:   "unlimited",
+		},
+		{
+			name:                 "integer option",
+			featureGate:          true,
+			consumableSharesFlag: "10",
+			expectModified:       true,
+			expectedPolicyType:   "integer",
+			expectedSharesVal:    10,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+				string(featuregates.ConsumableShares): tc.featureGate,
+			}))
+
+			config := &Config{
+				flags: &Flags{
+					consumableShares: tc.consumableSharesFlag,
+				},
+			}
+
+			dev := resourceapi.Device{
+				Name: "gpu-0",
+				Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+					"memory": {
+						Value: memVal,
+					},
+				},
+			}
+
+			applyConsumableShares(&dev, config)
+
+			if !tc.expectModified {
+				require.Nil(t, dev.AllowMultipleAllocations)
+				require.Nil(t, dev.Capacity["memory"].RequestPolicy)
+				_, hasShares := dev.Capacity["shares"]
+				require.False(t, hasShares)
+				return
+			}
+
+			require.NotNil(t, dev.AllowMultipleAllocations)
+			require.True(t, *dev.AllowMultipleAllocations)
+
+			memCap := dev.Capacity["memory"]
+			require.NotNil(t, memCap.RequestPolicy)
+			require.NotNil(t, memCap.RequestPolicy.Default)
+			require.NotNil(t, memCap.RequestPolicy.ValidRange)
+			require.Equal(t, resource.MustParse("1Gi"), *memCap.RequestPolicy.ValidRange.Step)
+			require.Equal(t, memVal, *memCap.RequestPolicy.ValidRange.Max)
+
+			switch tc.expectedPolicyType {
+			case "memory":
+				require.Equal(t, memVal, *memCap.RequestPolicy.Default)
+				require.Equal(t, resource.MustParse("1Gi"), *memCap.RequestPolicy.ValidRange.Min)
+			case "unlimited", "integer":
+				require.Equal(t, resource.MustParse("0"), *memCap.RequestPolicy.Default)
+				require.Equal(t, resource.MustParse("0"), *memCap.RequestPolicy.ValidRange.Min)
+			}
+
+			sharesCap, hasShares := dev.Capacity["shares"]
+			if tc.expectedPolicyType == "integer" {
+				require.True(t, hasShares)
+				require.Equal(t, *resource.NewQuantity(tc.expectedSharesVal, resource.BinarySI), sharesCap.Value)
+				require.NotNil(t, sharesCap.RequestPolicy)
+				require.Equal(t, *resource.NewQuantity(1, resource.BinarySI), *sharesCap.RequestPolicy.Default)
+				require.Equal(t, *resource.NewQuantity(1, resource.BinarySI), *sharesCap.RequestPolicy.ValidRange.Min)
+				require.Equal(t, *resource.NewQuantity(tc.expectedSharesVal, resource.BinarySI), *sharesCap.RequestPolicy.ValidRange.Max)
+				require.Equal(t, *resource.NewQuantity(1, resource.BinarySI), *sharesCap.RequestPolicy.ValidRange.Step)
+			} else {
+				require.False(t, hasShares)
+			}
+		})
+	}
+}

--- a/cmd/gpu-kubelet-plugin/consumable_shares_test.go
+++ b/cmd/gpu-kubelet-plugin/consumable_shares_test.go
@@ -235,4 +235,3 @@ func TestValidateNoOverlappingPreparedDevices(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -1248,6 +1248,12 @@ func (s *DeviceState) validateNoOverlappingPreparedDevices(checkpoint *Checkpoin
 		// Check for overlaps between requested devices from the current claim and others.
 		for device := range requestedDevices {
 			if _, found := preparedDevices[device]; found {
+				if isConsumableSharesEnabled(s.config) {
+					dev := s.perGPUAllocatable.GetAllocatableDevice(device)
+					if dev != nil && dev.Type() != VfioDeviceType {
+						continue
+					}
+				}
 				return fmt.Errorf(
 					"requested device %s is already allocated to different claim %s",
 					device, existingClaimUID,

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -229,7 +229,7 @@ func (d *driver) generateSplitResourceSlices(nodeName string) resourceslice.Driv
 			}
 
 			// Add device/partition to the device-only slice for this GPU.
-			deviceSlice.Devices = append(deviceSlice.Devices, device.PartGetDevice())
+			deviceSlice.Devices = append(deviceSlice.Devices, device.PartGetDevice(d.state.config))
 		}
 		if gpuInfo != nil {
 			allCounterSets = append(allCounterSets, gpuInfo.PartSharedCounterSets()...)
@@ -290,7 +290,7 @@ func (d *driver) generateCombinedResourceSlices(nodeName string) resourceslice.D
 			// Add all allocatable devices for this physical GPU to this slice.
 			// This includes not-yet-manifested MIG devices, and the physical
 			// GPU itself.
-			slice.Devices = append(slice.Devices, device.PartGetDevice())
+			slice.Devices = append(slice.Devices, device.PartGetDevice(d.state.config))
 		}
 
 		if gpuInfo != nil {
@@ -474,8 +474,8 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 	var resourceSlice resourceslice.Slice
 	for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
 		for _, device := range devices {
-			klog.V(4).Infof("About to announce device %s", device.GetDevice().Name)
-			resourceSlice.Devices = append(resourceSlice.Devices, device.GetDevice())
+			klog.V(4).Infof("About to announce device %s", device.GetDevice(config).Name)
+			resourceSlice.Devices = append(resourceSlice.Devices, device.GetDevice(config))
 		}
 	}
 
@@ -522,7 +522,7 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
 			var resourceSlice resourceslice.Slice
 			for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
 				for _, dev := range devices {
-					d := dev.GetDevice()
+					d := dev.GetDevice(d.state.config)
 
 					taints := dev.Taints()
 					if len(taints) > 0 {

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -66,6 +67,7 @@ type Flags struct {
 	healthcheckPort               int
 	klogVerbosity                 int
 	additionalXidsToIgnore        string
+	consumableShares              string
 }
 
 type Config struct {
@@ -208,6 +210,13 @@ func newApp() *cli.App {
 			Destination: &flags.metricsPath,
 			EnvVars:     []string{"METRICS_PATH"},
 		},
+		&cli.StringFlag{
+			Name:        "consumable-shares",
+			Usage:       "Configure consumable shares support ('disabled', 'memory', 'unlimited', or a positive integer).",
+			Value:       "disabled",
+			Destination: &flags.consumableShares,
+			EnvVars:     []string{"CONSUMABLE_SHARES"},
+		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)
 	cliFlags = append(cliFlags, featureGateConfig.Flags()...)
@@ -291,6 +300,13 @@ func validateCLIFlags(flags *Flags) error {
 				return fmt.Errorf("host root is not mounted at %q", flags.hostRoot)
 			}
 			return fmt.Errorf("error checking if host root is mounted at %q: %w", flags.hostRoot, err)
+		}
+	}
+
+	if flags.consumableShares != "disabled" && flags.consumableShares != "memory" && flags.consumableShares != "unlimited" {
+		val, err := strconv.Atoi(flags.consumableShares)
+		if err != nil || val <= 0 {
+			return fmt.Errorf("invalid value for --consumable-shares: %q (must be 'disabled', 'memory', 'unlimited', or a positive integer)", flags.consumableShares)
 		}
 	}
 

--- a/cmd/gpu-kubelet-plugin/partitions.go
+++ b/cmd/gpu-kubelet-plugin/partitions.go
@@ -214,18 +214,22 @@ func (i MigSpec) PartConsumesCounters() []resourceapi.DeviceCounterConsumption {
 }
 
 // A variant of the legacy `GetDevice()`, for the Partitionable Devices paradigm.
-func (d *AllocatableDevice) PartGetDevice() resourceapi.Device {
+func (d *AllocatableDevice) PartGetDevice(config *Config) resourceapi.Device {
+	var dev resourceapi.Device
 	switch d.Type() {
 	case GpuDeviceType:
-		return d.Gpu.PartGetDevice()
+		dev = d.Gpu.PartGetDevice()
 	case MigStaticDeviceType:
 		panic("PartGetDevice() called for MigStaticDeviceType")
 	case MigDynamicDeviceType:
-		return d.MigDynamic.PartGetDevice()
+		dev = d.MigDynamic.PartGetDevice()
 	case VfioDeviceType:
 		panic("not yet implemented")
+	default:
+		panic("unexpected type for AllocatableDevice")
 	}
-	panic("unexpected type for AllocatableDevice")
+	applyConsumableShares(&dev, config)
+	return dev
 }
 
 // Insert one counter for each memory slice consumed, as given by the `start`

--- a/demo/specs/consumable-shares/README.md
+++ b/demo/specs/consumable-shares/README.md
@@ -1,0 +1,80 @@
+# Consumable Shares Demo
+
+This directory contains example Kubernetes manifests demonstrating GPU sharing
+using Dynamic Resource Allocation (DRA) with the `consumable-shares` feature
+enabled.
+
+## Configuration Modes
+
+The GPU kubelet plugin supports three sharing modes configured via the
+`--consumable-shares` CLI flag (or `CONSUMABLE_SHARES` environment variable in
+Helm):
+
+### 1. `memory`
+
+When configured with `--consumable-shares=memory`:
+- GPUs announce `allowMultipleAllocations: true`.
+- The `memory` capacity entry gets a request policy where `default` equals
+  total GPU memory, `min` is `1Gi`, and `step` is `1Gi`. This means that if the
+ResourceClaim does not specify a `capacity.requests.memory` value, the claim
+will allocate the entire GPU. Otherwise, it will allocate a share of the GPU,
+and consume the specified amount from the memory value. Note that memory-based
+allocation is advisory only; it is not enforced by the kernel or CUDA.
+
+To try it out, you must run the driver with `--consumable-shares=memory`, and
+then you can use this manifest:
+
+```bash
+kubectl apply -f memory-sharing.yaml
+```
+
+### 2. `unlimited`
+
+When configured with `--consumable-shares=unlimited`:
+- GPUs announce `allowMultipleAllocations: true`.
+- The `memory` capacity entry gets a request policy where `default` is `0`,
+  `min` is `0`, and `step` is `1Gi`. 
+- Claims can share GPUs without specifying memory capacity limits, or can
+  optionally specify memory requests.
+- Claims that do not specify a memory capacity request will always allocate a
+  share of the GPU, regardless of other claims that have already allocated the
+device.
+
+To try it out, you must run the driver with `--consumable-shares=unlimited`,
+and then you can use this manifest:
+
+```bash
+kubectl apply -f unlimited-sharing.yaml
+```
+
+### 3. Integer value (e.g. `4`)
+
+When configured with an integer such as `--consumable-shares=4`:
+- GPUs announce `allowMultipleAllocations: true`.
+- The `memory` capacity entry gets the same policy as `unlimited` (`default:
+  0`).
+- A `shares` capacity entry is added with value equal to `4`, and a request
+  policy with `default: 1`, `min: 1`, `max: 4`, `step: 1`.
+- Up to 4 claims (each consuming 1 share by default) can share a single
+  physical or MIG GPU.
+
+To try it out, you must run the driver with `--consumable-shares=4` (or some
+other positive integer), and then you can use this manifest:
+
+```bash
+kubectl apply -f integer-sharing.yaml
+```
+
+## Scaling Replicas
+
+Each demo manifest deploys a Kubernetes `Deployment` backed by a `ResourceClaimTemplate`. Whenever a new replica is created, Kubernetes automatically generates a unique `ResourceClaim` for that pod replica.
+
+You can easily adjust the number of replicas to see how claims share devices across nodes:
+
+```bash
+# Scale up the unlimited sharing demo
+kubectl scale deployment unlimited-sharing -n gpu-share-unlimited --replicas=6
+
+# Check scheduled pods and generated resource claims
+kubectl get pods,resourceclaims -n gpu-share-unlimited -o wide
+```

--- a/demo/specs/consumable-shares/integer-sharing.yaml
+++ b/demo/specs/consumable-shares/integer-sharing.yaml
@@ -1,0 +1,53 @@
+# Example demonstrating GPU sharing with an integer share count (e.g. --consumable-shares=4)
+# With shares=4, each replica consumes 1 share by default, allowing up to 4 replicas to share each GPU.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-share-integer
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: gpu-share-integer
+  name: gpu-1share
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: gpu-share-integer
+  name: integer-sharing
+  labels:
+    app: integer-sharing
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: integer-sharing
+  template:
+    metadata:
+      labels:
+        app: integer-sharing
+    spec:
+      resourceClaims:
+      - name: gpu
+        resourceClaimTemplateName: gpu-1share
+      containers:
+      - name: ctr
+        image: ubuntu:22.04
+        command: ["bash", "-c"]
+        args: ["nvidia-smi -L; echo 'running with 1 share claim'; sleep 3600"]
+        resources:
+          claims:
+          - name: gpu
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/demo/specs/consumable-shares/memory-sharing.yaml
+++ b/demo/specs/consumable-shares/memory-sharing.yaml
@@ -1,0 +1,56 @@
+# Example demonstrating GPU sharing with --consumable-shares=memory
+# Pod replicas request explicit memory capacity slices (4Gi each) so multiple replicas can run on the same GPU.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-share-memory
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: gpu-share-memory
+  name: gpu-4gi
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          capacity:
+            requests:
+              memory: 4Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: gpu-share-memory
+  name: memory-sharing
+  labels:
+    app: memory-sharing
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: memory-sharing
+  template:
+    metadata:
+      labels:
+        app: memory-sharing
+    spec:
+      resourceClaims:
+      - name: gpu
+        resourceClaimTemplateName: gpu-4gi
+      containers:
+      - name: ctr
+        image: ubuntu:22.04
+        command: ["bash", "-c"]
+        args: ["nvidia-smi -L; echo 'running with 4Gi memory claim'; sleep 3600"]
+        resources:
+          claims:
+          - name: gpu
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/demo/specs/consumable-shares/unlimited-sharing.yaml
+++ b/demo/specs/consumable-shares/unlimited-sharing.yaml
@@ -1,0 +1,53 @@
+# Example demonstrating GPU sharing with --consumable-shares=unlimited
+# Since default memory consumption is 0, multiple pod replicas can claim and share the same GPU.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-share-unlimited
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: gpu-share-unlimited
+  name: gpu-unlimited
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: gpu-share-unlimited
+  name: unlimited-sharing
+  labels:
+    app: unlimited-sharing
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: unlimited-sharing
+  template:
+    metadata:
+      labels:
+        app: unlimited-sharing
+    spec:
+      resourceClaims:
+      - name: gpu
+        resourceClaimTemplateName: gpu-unlimited
+      containers:
+      - name: ctr
+        image: ubuntu:22.04
+        command: ["bash", "-c"]
+        args: ["nvidia-smi -L; echo 'running with unlimited sharing'; sleep 3600"]
+        resources:
+          claims:
+          - name: gpu
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -294,6 +294,10 @@ spec:
         - name: NVIDIA_CDI_HOOK_PATH
           value: "{{ .Values.nvidiaCDIHookPath }}"
         {{- end }}
+        {{- if .Values.consumableShares }}
+        - name: CONSUMABLE_SHARES
+          value: "{{ .Values.consumableShares }}"
+        {{- end }}
         {{- if .Values.featureGates }}
         - name: FEATURE_GATES
           value: "{{ range $key, $value := .Values.featureGates }}{{ $key }}={{ $value }},{{ end }}"

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -38,6 +38,7 @@ fullnameOverride: ""
 namespaceOverride: ""
 selectorLabelsOverride: {}
 gpuResourcesEnabledOverride: false
+consumableShares: ""
 
 allowDefaultNamespace: false
 

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -74,6 +74,9 @@ const (
 	// DeviceMetadata allows the kubelet plugin to generate device metadata files
 	// in the workloads for prepared devices.
 	DeviceMetadata featuregate.Feature = "DeviceMetadata"
+
+	// ConsumableShares allows consumable shares to be configured for devices.
+	ConsumableShares featuregate.Feature = "ConsumableShares"
 )
 
 // Feature gate Version fields use driver SemVer major.minor.
@@ -146,6 +149,13 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 			Default:    false,
 			PreRelease: featuregate.Alpha,
 			Version:    version.MajorMinor(0, 4),
+		},
+	},
+	ConsumableShares: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(0, 5),
 		},
 	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Enables independent sharing of GPUs, even among pods in different namespaces.

#### Which issue(s) this PR is related to:
Fixes #659 

#### Special notes for your reviewer:
* Let's discuss if this is the right approach.
* Needs e2e tests
* Needs more docs

Google Gemini assisted with this PR.

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
Enables a new alpha feature gate, ConsumableShares, and a corresponding configuration option to allow memory-based, unlimited, or shares-based consumable allocation.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
More docs are needed!

```docs
demo/specs/consumable-shares includes manifests demonstrating each mode.
```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- N/A [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- N/A [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [x] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed

#### Remaining Items Summary

- [ ] Implement [device preparation logic](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1231/changes#r3495476763)
- [ ] Resolve how to handle different per-claim configurations
- [ ] Address [driver restarts](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1231#discussion_r3583180014)
- [ ] Move to [per-node configuration](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1231/changes#r3500527369)
- [ ] Memory [step value and rounding](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1231#issuecomment-4978796137)
- [ ] e2e tests
- [ ] Documentation
- [ ] Device health for shared gpus
- [ ] Interaction with MIG - I would think it should compose (MIGs should be shareable), but we should test it and understand how to configure it
- [ ] Consider other use cases
- [ ] Default recommendations and any hard limits