### PR TITLE
feat (host-managed-imex): Add support for host managed IMEX daemon with the ComputeDomain Driver

### DIFF
--- a/cmd/compute-domain-controller/computedomain.go
+++ b/cmd/compute-domain-controller/computedomain.go
@@ -70,6 +70,12 @@ type ComputeDomainManager struct {
 	lister        nvlisters.ComputeDomainLister
 	mutationCache cache.MutationCache
 
+	// daemonSetManager and nodeManager are nil when the driver is configured
+	// for host-managed IMEX (see pkg/imex): in that mode the driver never
+	// creates DaemonSets or ComputeDomain node labels, so this machinery
+	// (including the DaemonSet manager's nested ComputeDomainClique/status
+	// tracking) is never constructed or started at all, rather than merely
+	// left unused.
 	daemonSetManager             *MultiNamespaceDaemonSetManager
 	resourceClaimTemplateManager *WorkloadResourceClaimTemplateManager
 	nodeManager                  *NodeManager
@@ -88,9 +94,11 @@ func NewComputeDomainManager(config *ManagerConfig) *ComputeDomainManager {
 		lister:   lister,
 	}
 
-	m.daemonSetManager = NewMultiNamespaceDaemonSetManager(config, m.Get, m.List, m.UpdateStatus)
+	if !config.imexConfig.EffectiveHostManaged() {
+		m.daemonSetManager = NewMultiNamespaceDaemonSetManager(config, m.Get, m.List, m.UpdateStatus)
+		m.nodeManager = NewNodeManager(config, m.Get)
+	}
 	m.resourceClaimTemplateManager = NewWorkloadResourceClaimTemplateManager(config, m.Get)
-	m.nodeManager = NewNodeManager(config, m.Get)
 
 	return m
 }
@@ -147,30 +155,38 @@ func (m *ComputeDomainManager) Start(ctx context.Context) (rerr error) {
 		return fmt.Errorf("informer cache sync for ComputeDomains failed")
 	}
 
-	if err := m.daemonSetManager.Start(ctx); err != nil {
-		return fmt.Errorf("error starting DaemonSet manager: %w", err)
+	if m.daemonSetManager != nil {
+		if err := m.daemonSetManager.Start(ctx); err != nil {
+			return fmt.Errorf("error starting DaemonSet manager: %w", err)
+		}
 	}
 
 	if err := m.resourceClaimTemplateManager.Start(ctx); err != nil {
 		return fmt.Errorf("error creating ResourceClaim manager: %w", err)
 	}
 
-	if err := m.nodeManager.Start(ctx); err != nil {
-		return fmt.Errorf("error starting Node manager: %w", err)
+	if m.nodeManager != nil {
+		if err := m.nodeManager.Start(ctx); err != nil {
+			return fmt.Errorf("error starting Node manager: %w", err)
+		}
 	}
 
 	return nil
 }
 
 func (m *ComputeDomainManager) Stop() error {
-	if err := m.daemonSetManager.Stop(); err != nil {
-		return fmt.Errorf("error stopping DaemonSet manager: %w", err)
+	if m.daemonSetManager != nil {
+		if err := m.daemonSetManager.Stop(); err != nil {
+			return fmt.Errorf("error stopping DaemonSet manager: %w", err)
+		}
 	}
 	if err := m.resourceClaimTemplateManager.Stop(); err != nil {
 		return fmt.Errorf("error stopping ResourceClaimTemplate manager: %w", err)
 	}
-	if err := m.nodeManager.Stop(); err != nil {
-		return fmt.Errorf("error stopping Node manager: %w", err)
+	if m.nodeManager != nil {
+		if err := m.nodeManager.Stop(); err != nil {
+			return fmt.Errorf("error stopping Node manager: %w", err)
+		}
 	}
 	if m.cancelContext != nil {
 		m.cancelContext()
@@ -251,7 +267,22 @@ func (m *ComputeDomainManager) RemoveFinalizer(ctx context.Context, uid string) 
 	return nil
 }
 
+// hostManaged reports whether the driver is configured for host-managed IMEX
+// (see pkg/imex), in which case the driver never creates per-ComputeDomain
+// DaemonSets, daemon ResourceClaimTemplates, or ComputeDomain node labels.
+func (m *ComputeDomainManager) hostManaged() bool {
+	return m.config.imexConfig.EffectiveHostManaged()
+}
+
 func (m *ComputeDomainManager) calculateGlobalStatus(cd *nvapi.ComputeDomain) string {
+	// In host-managed IMEX mode the controller does not track per-node daemon
+	// readiness (there are no driver-managed daemons), so Ready means only
+	// that the ComputeDomain was admitted and its workload
+	// ResourceClaimTemplate exists.
+	if m.hostManaged() {
+		return nvapi.ComputeDomainStatusReady
+	}
+
 	// Mark the ComputeDomain as not ready if not enough nodes are present in the nodes list.
 	if len(cd.Status.Nodes) < cd.Spec.NumNodes {
 		return nvapi.ComputeDomainStatusNotReady
@@ -314,6 +345,20 @@ func (m *ComputeDomainManager) onAddOrUpdate(ctx context.Context, obj any) error
 		return nil
 	}
 
+	// Host-managed IMEX reconciles a ComputeDomain
+	// with a much smaller set of objects (no DaemonSet, no node labels)
+	// so branch out early
+	if m.hostManaged() {
+		return m.onAddOrUpdateHostManaged(ctx, cd)
+	}
+	return m.onAddOrUpdateDriverManaged(ctx, cd)
+}
+
+// onAddOrUpdateDriverManaged reconciles a ComputeDomain under the default,
+// driver-managed model: the controller owns a per-ComputeDomain DaemonSet,
+// its daemon ResourceClaimTemplate, and ComputeDomain node labels, in
+// addition to the workload ResourceClaimTemplate.
+func (m *ComputeDomainManager) onAddOrUpdateDriverManaged(ctx context.Context, cd *nvapi.ComputeDomain) error {
 	if cd.GetDeletionTimestamp() != nil {
 		if err := m.resourceClaimTemplateManager.Delete(ctx, string(cd.UID)); err != nil {
 			return fmt.Errorf("error deleting ResourceClaimTemplate: %w", err)
@@ -372,6 +417,53 @@ func (m *ComputeDomainManager) onAddOrUpdate(ctx context.Context, obj any) error
 	// Change the global Status to reflect the number of ComputeDomain daemons connected.
 	if err := m.updateGlobalStatus(ctx, cd); err != nil {
 		return fmt.Errorf("error updating global status on ComputeDoimain '%s/%s': %w", cd.Namespace, cd.Name, err)
+	}
+
+	return nil
+}
+
+// onAddOrUpdateHostManaged reconciles a ComputeDomain under host-managed
+// IMEX: the cluster admin owns the host nvidia-imex daemon lifecycle, so
+// the controller only manages the workload ResourceClaimTemplate and the
+// ComputeDomain finalizer.
+func (m *ComputeDomainManager) onAddOrUpdateHostManaged(ctx context.Context, cd *nvapi.ComputeDomain) error {
+	if cd.GetDeletionTimestamp() != nil {
+		if err := m.resourceClaimTemplateManager.Delete(ctx, string(cd.UID)); err != nil {
+			return fmt.Errorf("error deleting ResourceClaimTemplate: %w", err)
+		}
+
+		if err := m.resourceClaimTemplateManager.RemoveFinalizer(ctx, string(cd.UID)); err != nil {
+			return fmt.Errorf("error removing finalizer on ResourceClaimTemplate: %w", err)
+		}
+
+		if err := m.resourceClaimTemplateManager.AssertRemoved(ctx, string(cd.UID)); err != nil {
+			return fmt.Errorf("error asserting removal of ResourceClaimTemplate: %w", err)
+		}
+
+		if err := m.RemoveFinalizer(ctx, string(cd.UID)); err != nil {
+			return fmt.Errorf("error removing finalizer: %w", err)
+		}
+
+		metrics.ForgetComputeDomain(string(cd.UID))
+		return nil
+	}
+
+	// Add the finalizer.
+	if err := m.addFinalizer(ctx, cd); err != nil {
+		return fmt.Errorf("error adding finalizer: %w", err)
+	}
+
+	// Create the workload ResourceClaimTemplate. Its manager adds and tracks
+	// its own finalizer on the template.
+	if _, err := m.resourceClaimTemplateManager.Create(ctx, cd.Namespace, cd.Spec.Channel.ResourceClaimTemplate.Name, cd); err != nil {
+		return fmt.Errorf("error creating ResourceClaimTemplate '%s/%s': %w", cd.Namespace, cd.Spec.Channel.ResourceClaimTemplate.Name, err)
+	}
+
+	// Mark the ComputeDomain Ready. Under host-managed IMEX this only means
+	// the ComputeDomain was admitted and the workload ResourceClaimTemplate
+	// exists; it says nothing about host nvidia-imex health.
+	if err := m.updateGlobalStatus(ctx, cd); err != nil {
+		return fmt.Errorf("error updating global status on ComputeDomain '%s/%s': %w", cd.Namespace, cd.Name, err)
 	}
 
 	return nil

--- a/cmd/compute-domain-controller/computedomain_test.go
+++ b/cmd/compute-domain-controller/computedomain_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	nvapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/imex"
+)
+
+func TestCalculateGlobalStatusHostManaged(t *testing.T) {
+	m := &ComputeDomainManager{
+		config: &ManagerConfig{
+			imexConfig: imex.Config{Mode: imex.ModeHostManaged, Isolation: imex.IsolationIMEXDomain},
+		},
+	}
+
+	// In driver-managed mode this would be NotReady (required nodes are
+	// missing). Under host-managed IMEX the controller does not track
+	// per-node readiness, so it reports Ready once admitted.
+	cd := &nvapi.ComputeDomain{}
+	cd.Spec.NumNodes = 8
+	require.Equal(t, nvapi.ComputeDomainStatusReady, m.calculateGlobalStatus(cd))
+}
+
+func TestCalculateGlobalStatusDriverManagedUnaffected(t *testing.T) {
+	m := &ComputeDomainManager{
+		config: &ManagerConfig{
+			imexConfig: imex.Config{Mode: imex.ModeDriverManaged},
+		},
+	}
+
+	cd := &nvapi.ComputeDomain{}
+	cd.Spec.NumNodes = 8
+	require.Equal(t, nvapi.ComputeDomainStatusNotReady, m.calculateGlobalStatus(cd))
+}
+
+// NewComputeDomainManager only stores clientsets on the informer factories it
+// builds (it never calls them synchronously), so a zero-value ClientSets is
+// sufficient here: these tests only assert on which sub-managers get
+// constructed, not on their runtime behavior.
+
+func TestNewComputeDomainManagerHostManagedSkipsDaemonAndNodeManagers(t *testing.T) {
+	config := &ManagerConfig{
+		imexConfig: imex.Config{Mode: imex.ModeHostManaged, Isolation: imex.IsolationIMEXDomain},
+	}
+
+	m := NewComputeDomainManager(config)
+
+	// Host-managed IMEX never creates DaemonSets or ComputeDomain node
+	// labels, so this machinery (including the DaemonSet manager's nested
+	// ComputeDomainClique/status tracking) must not even be constructed.
+	require.Nil(t, m.daemonSetManager, "daemonSetManager must not be constructed under host-managed IMEX")
+	require.Nil(t, m.nodeManager, "nodeManager must not be constructed under host-managed IMEX")
+	require.NotNil(t, m.resourceClaimTemplateManager, "resourceClaimTemplateManager is still needed to manage the workload ResourceClaimTemplate")
+}
+
+func TestNewComputeDomainManagerDriverManagedConstructsDaemonAndNodeManagers(t *testing.T) {
+	config := &ManagerConfig{
+		imexConfig: imex.Config{Mode: imex.ModeDriverManaged},
+	}
+
+	m := NewComputeDomainManager(config)
+
+	require.NotNil(t, m.daemonSetManager)
+	require.NotNil(t, m.nodeManager)
+	require.NotNil(t, m.resourceClaimTemplateManager)
+}

--- a/cmd/compute-domain-controller/controller.go
+++ b/cmd/compute-domain-controller/controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/flags"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/imex"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/workqueue"
 )
 
@@ -42,6 +43,9 @@ type ManagerConfig struct {
 
 	// maxNodesPerIMEXDomain is the maximum number of nodes per IMEX domain to allocate
 	maxNodesPerIMEXDomain int
+
+	// imexConfig holds the resolved imex.mode / imex.isolation configuration.
+	imexConfig imex.Config
 
 	// clientsets provides access to various Kubernetes API client interfaces
 	clientsets flags.ClientSets
@@ -91,6 +95,7 @@ func (c *Controller) Run(ctx context.Context) error {
 		additionalNamespaces:  c.config.flags.additionalNamespaces.Value(),
 		imageName:             c.config.flags.imageName,
 		maxNodesPerIMEXDomain: c.config.flags.maxNodesPerIMEXDomain,
+		imexConfig:            c.config.imexConfig,
 		clientsets:            c.config.clientsets,
 		workQueue:             workQueue,
 		logVerbosityCDDaemon:  c.config.flags.logVerbosityCDDaemon,

--- a/cmd/compute-domain-controller/main.go
+++ b/cmd/compute-domain-controller/main.go
@@ -153,7 +153,7 @@ func newApp() *cli.App {
 		},
 		&cli.StringFlag{
 			Name:        "imex-isolation",
-			Usage:       "IMEX isolation strategy: IMEXDomain (default; all workloads in the same IMEX domain share channel 0) or IMEXChannel (not yet supported).",
+			Usage:       "IMEX isolation strategy: domain (default; all workloads in the same IMEX domain share channel 0) or channel (not yet supported).",
 			Value:       string(imex.IsolationIMEXDomain),
 			Destination: &flags.imexIsolation,
 			EnvVars:     []string{"IMEX_ISOLATION"},

--- a/cmd/compute-domain-controller/main.go
+++ b/cmd/compute-domain-controller/main.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/dra-driver-nvidia-gpu/internal/info"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 	pkgflags "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/flags"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/imex"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/metrics"
 )
 
@@ -68,6 +69,9 @@ type Flags struct {
 	maxNodesPerIMEXDomain int
 	logVerbosityCDDaemon  int
 
+	imexMode      string
+	imexIsolation string
+
 	httpEndpoint string
 	metricsPath  string
 	profilePath  string
@@ -83,6 +87,7 @@ type Config struct {
 	clientsets           pkgflags.ClientSets
 	mux                  *http.ServeMux
 	imagePullSecretNames []string
+	imexConfig           imex.Config
 }
 
 func main() {
@@ -138,6 +143,20 @@ func newApp() *cli.App {
 			Value:       defaultMaxNodesPerIMEXDomain,
 			EnvVars:     []string{"MAX_NODES_PER_IMEX_DOMAIN"},
 			Destination: &flags.maxNodesPerIMEXDomain,
+		},
+		&cli.StringFlag{
+			Name:        "imex-mode",
+			Usage:       "IMEX deployment mode: driverManaged or hostManaged.",
+			Value:       string(imex.ModeDriverManaged),
+			Destination: &flags.imexMode,
+			EnvVars:     []string{"IMEX_MODE"},
+		},
+		&cli.StringFlag{
+			Name:        "imex-isolation",
+			Usage:       "IMEX isolation strategy: IMEXDomain (default; all workloads in the same IMEX domain share channel 0) or IMEXChannel (not yet supported).",
+			Value:       string(imex.IsolationIMEXDomain),
+			Destination: &flags.imexIsolation,
+			EnvVars:     []string{"IMEX_ISOLATION"},
 		},
 		&cli.StringFlag{
 			Category:    "HTTP server:",
@@ -202,6 +221,22 @@ func newApp() *cli.App {
 				return fmt.Errorf("feature gate validation failed: %w", err)
 			}
 
+			imexConfig := imex.Config{Mode: imex.Mode(flags.imexMode), Isolation: imex.Isolation(flags.imexIsolation)}
+			if err := imexConfig.Validate(featuregates.Enabled(featuregates.HostManagedIMEXDaemon)); err != nil {
+				return fmt.Errorf("imex configuration validation failed: %w", err)
+			}
+			if imexConfig.EffectiveHostManaged() {
+				// The driver never creates per-ComputeDomain IMEX DaemonSets or
+				// ComputeDomainClique objects in host-managed mode, so these gates
+				// are meaningless (and their defaults would otherwise conflict).
+				if err := featuregates.FeatureGates().SetFromMap(map[string]bool{
+					string(featuregates.IMEXDaemonsWithDNSNames): false,
+					string(featuregates.ComputeDomainCliques):    false,
+				}); err != nil {
+					return fmt.Errorf("error forcing feature gates for hostManaged IMEX: %w", err)
+				}
+			}
+
 			mux := http.NewServeMux()
 
 			clientsets, err := flags.kubeClientConfig.NewClientSets()
@@ -215,6 +250,7 @@ func newApp() *cli.App {
 				clientsets:           clientsets,
 				driverName:           DriverName,
 				imagePullSecretNames: strings.Fields(strings.ReplaceAll(strings.TrimSpace(flags.imagePullSecretsCSV), ",", " ")),
+				imexConfig:           imexConfig,
 			}
 
 			if flags.httpEndpoint != "" {

--- a/cmd/compute-domain-controller/resourceclaimtemplate.go
+++ b/cmd/compute-domain-controller/resourceclaimtemplate.go
@@ -361,6 +361,23 @@ func NewWorkloadResourceClaimTemplateManager(config *ManagerConfig, getComputeDo
 	return m
 }
 
+// channelAllocationModeFor decides the AllocationMode to request in the
+// workload ResourceClaimTemplate for a ComputeDomain.
+//
+// Under host-managed IMEX this always forces AllocationMode Single (channel
+// 0), regardless of what the ComputeDomain requested: host-managed IMEX only
+// ever has channel 0 to give out today. TODO: once the controller can assign
+// a unique IMEX channel per ComputeDomain, request that channel here instead.
+//
+// Otherwise (driver-managed), the ComputeDomain's own AllocationMode is used
+// as-is.
+func channelAllocationModeFor(cd *nvapi.ComputeDomain, hostManaged bool) string {
+	if hostManaged {
+		return nvapi.ComputeDomainChannelAllocationModeSingle
+	}
+	return cd.Spec.Channel.AllocationMode
+}
+
 func (m *WorkloadResourceClaimTemplateManager) Create(ctx context.Context, namespace, name string, cd *nvapi.ComputeDomain) (*resourceapi.ResourceClaimTemplate, error) {
 	rcts, err := getByComputeDomainUID[*resourceapi.ResourceClaimTemplate](ctx, m.mutationCache, string(cd.UID))
 	if err != nil {
@@ -375,7 +392,7 @@ func (m *WorkloadResourceClaimTemplateManager) Create(ctx context.Context, names
 
 	channelConfig := nvapi.DefaultComputeDomainChannelConfig()
 	channelConfig.DomainID = string(cd.UID)
-	channelConfig.AllocationMode = cd.Spec.Channel.AllocationMode
+	channelConfig.AllocationMode = channelAllocationModeFor(cd, m.config.imexConfig.EffectiveHostManaged())
 
 	templateData := ResourceClaimTemplateTemplateData{
 		Namespace:               namespace,

--- a/cmd/compute-domain-controller/resourceclaimtemplate_test.go
+++ b/cmd/compute-domain-controller/resourceclaimtemplate_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	nvapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+)
+
+func TestChannelAllocationModeFor(t *testing.T) {
+	cdWithMode := func(mode string) *nvapi.ComputeDomain {
+		cd := &nvapi.ComputeDomain{}
+		cd.Spec.Channel = &nvapi.ComputeDomainChannelSpec{AllocationMode: mode}
+		return cd
+	}
+
+	tests := []struct {
+		name        string
+		cd          *nvapi.ComputeDomain
+		hostManaged bool
+		want        string
+	}{
+		{
+			name:        "host-managed always forces Single, even when the ComputeDomain requested All",
+			cd:          cdWithMode(nvapi.ComputeDomainChannelAllocationModeAll),
+			hostManaged: true,
+			want:        nvapi.ComputeDomainChannelAllocationModeSingle,
+		},
+		{
+			name:        "host-managed always forces Single, even when the ComputeDomain requested nothing",
+			cd:          cdWithMode(""),
+			hostManaged: true,
+			want:        nvapi.ComputeDomainChannelAllocationModeSingle,
+		},
+		{
+			name:        "driver-managed passes through the ComputeDomain's AllocationMode unchanged (All)",
+			cd:          cdWithMode(nvapi.ComputeDomainChannelAllocationModeAll),
+			hostManaged: false,
+			want:        nvapi.ComputeDomainChannelAllocationModeAll,
+		},
+		{
+			name:        "driver-managed passes through the ComputeDomain's AllocationMode unchanged (Single)",
+			cd:          cdWithMode(nvapi.ComputeDomainChannelAllocationModeSingle),
+			hostManaged: false,
+			want:        nvapi.ComputeDomainChannelAllocationModeSingle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, channelAllocationModeFor(tt.cd, tt.hostManaged))
+		})
+	}
+}

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -78,8 +78,11 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		return nil, fmt.Errorf("failed to create device library: %w", err)
 	}
 
-	// Check driver version if IMEXDaemonsWithDNSNames feature gate is enabled
-	if featuregates.Enabled(featuregates.IMEXDaemonsWithDNSNames) {
+	// Check driver version if IMEXDaemonsWithDNSNames feature gate is
+	// enabled. DNS-named IMEX daemons are a driver-managed-only concept (the
+	// driver never creates IMEX daemons under host-managed IMEX), so this
+	// check does not apply there
+	if !config.imexConfig.EffectiveHostManaged() && featuregates.Enabled(featuregates.IMEXDaemonsWithDNSNames) {
 		if err := validateDriverVersionForIMEXDaemonsWithDNSNames(config.flags, nvdevlib); err != nil {
 			return nil, fmt.Errorf("driver version validation failed: %w", err)
 		}
@@ -589,6 +592,11 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, cs *resourceapi.Reso
 	for c := range configResultsMap {
 		switch config := c.(type) {
 		case *configapi.ComputeDomainChannelConfig:
+			// Host-managed mode never adds the ComputeDomain node label, so
+			// there is nothing to remove here.
+			if s.config.imexConfig.EffectiveHostManaged() {
+				continue
+			}
 			// If a channel type, remove the ComputeDomain label from the node
 			if err := s.computeDomainManager.RemoveNodeLabel(ctx, config.DomainID); err != nil {
 				return fmt.Errorf("error removing Node label for ComputeDomain: %w", err)
@@ -622,6 +630,58 @@ func (s *DeviceState) applyComputeDomainChannelConfig(ctx context.Context, confi
 		return nil, fmt.Errorf("applyComputeDomainChannelConfig: unexpected results %v", results)
 	}
 
+	// Host-managed IMEX skips daemon bootstrap and readiness bookkeeping entirely,
+	// so the two modes are handled by separate functions instead of threading
+	// hostManaged checks through a shared code path.
+	if s.config.imexConfig.EffectiveHostManaged() {
+		return s.applyComputeDomainChannelConfigHostManaged(ctx, config, claim, results[0])
+	}
+	return s.applyComputeDomainChannelConfigDriverManaged(ctx, config, claim)
+}
+
+// applyComputeDomainChannelConfigHostManaged handles a channel claim when the
+// cluster admin (not the driver) owns the host nvidia-imex daemon. It skips the IMEX
+// daemon management and readiness checks completely.
+func (s *DeviceState) applyComputeDomainChannelConfigHostManaged(ctx context.Context, config *configapi.ComputeDomainChannelConfig, claim *resourceapi.ResourceClaim, result *resourceapi.DeviceRequestAllocationResult) (*DeviceConfigState, error) {
+	device, ok := s.allocatable[result.Device]
+	if !ok || device.Channel == nil {
+		return nil, fmt.Errorf("applyComputeDomainChannelConfigHostManaged: %q is not an allocatable IMEX channel device", result.Device)
+	}
+	channelID := device.Channel.ID
+
+	if err := s.assertImexChannelNotAllocated(channelID); err != nil {
+		return nil, fmt.Errorf("allocation failed: %w", err)
+	}
+
+	if err := s.computeDomainManager.AssertComputeDomainNamespace(ctx, claim.Namespace, config.DomainID); err != nil {
+		return nil, permanentError{fmt.Errorf("error asserting ComputeDomain's namespace: %w", err)}
+	}
+
+	configState := DeviceConfigState{
+		Type:          ComputeDomainChannelType,
+		ComputeDomain: config.DomainID,
+	}
+
+	if s.computeDomainManager.cliqueID == "" {
+		// Non-fabric node (e.g. not part of an MNNVL clique): do not inject
+		// IMEX channel device nodes, but let the claim succeed.
+		return &configState, nil
+	}
+
+	if channelID < 0 || channelID >= len(s.nvdevlib.nvCapImexChanDevInfos) {
+		return nil, fmt.Errorf("applyComputeDomainChannelConfigHostManaged: channel %d out of range (node has %d IMEX channels)",
+			channelID, len(s.nvdevlib.nvCapImexChanDevInfos))
+	}
+	edits := s.computeDomainManager.GetComputeDomainChannelContainerEdits(s.cdi.devRoot, s.nvdevlib.nvCapImexChanDevInfos[channelID])
+	configState.containerEdits = configState.containerEdits.Append(edits)
+
+	return &configState, nil
+}
+
+// applyComputeDomainChannelConfigDriverManaged handles a channel claim under
+// the default, driver-managed model where it adds necessary node labels and checks
+// the the IMEX daemon readiness.
+func (s *DeviceState) applyComputeDomainChannelConfigDriverManaged(ctx context.Context, config *configapi.ComputeDomainChannelConfig, claim *resourceapi.ResourceClaim) (*DeviceConfigState, error) {
 	// If explicitly requested, inject all channels instead of just one.
 	chancount := 1
 	if config.AllocationMode == configapi.ComputeDomainChannelAllocationModeAll {
@@ -667,6 +727,14 @@ func (s *DeviceState) applyComputeDomainChannelConfig(ctx context.Context, confi
 }
 
 func (s *DeviceState) applyComputeDomainDaemonConfig(ctx context.Context, config *configapi.ComputeDomainDaemonConfig, claim *resourceapi.ResourceClaim, results []*resourceapi.DeviceRequestAllocationResult) (*DeviceConfigState, error) {
+	// Host-managed IMEX runs no driver-managed ComputeDomain daemons, so
+	// daemon devices are never published or allocated. A daemon claim
+	// reaching Prepare means a stale or hand-crafted object; reject it
+	// permanently.
+	if s.config.imexConfig.EffectiveHostManaged() {
+		return nil, permanentError{fmt.Errorf("ComputeDomain daemon claims are not supported when imex.mode=hostManaged")}
+	}
+
 	// Get the list of claim requests this config is being applied over.
 	var requests []string
 	for _, r := range results {

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -640,8 +640,10 @@ func (s *DeviceState) applyComputeDomainChannelConfig(ctx context.Context, confi
 }
 
 // applyComputeDomainChannelConfigHostManaged handles a channel claim when the
-// cluster admin (not the driver) owns the host nvidia-imex daemon. It skips the IMEX
-// daemon management and readiness checks completely.
+// cluster admin (not the driver) owns the host nvidia-imex daemon. It skips
+// the driver-managed IMEX daemon management entirely, but on fabric nodes
+// still validates that the operator's host nvidia-imex daemon is actually
+// ready before handing out a channel, via checkHostIMEXReady.
 func (s *DeviceState) applyComputeDomainChannelConfigHostManaged(ctx context.Context, config *configapi.ComputeDomainChannelConfig, claim *resourceapi.ResourceClaim, result *resourceapi.DeviceRequestAllocationResult) (*DeviceConfigState, error) {
 	device, ok := s.allocatable[result.Device]
 	if !ok || device.Channel == nil {
@@ -666,6 +668,10 @@ func (s *DeviceState) applyComputeDomainChannelConfigHostManaged(ctx context.Con
 		// Non-fabric node (e.g. not part of an MNNVL clique): do not inject
 		// IMEX channel device nodes, but let the claim succeed.
 		return &configState, nil
+	}
+
+	if err := s.nvdevlib.checkHostIMEXReady(s.config.flags.imexHostSocketPath); err != nil {
+		return nil, fmt.Errorf("host nvidia-imex daemon readiness check failed: %w", err)
 	}
 
 	if channelID < 0 || channelID >= len(s.nvdevlib.nvCapImexChanDevInfos) {

--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -549,7 +549,10 @@ func TestUnprepareMissingClaimIsNoop(t *testing.T) {
 }
 
 func hostManagedConfig() *Config {
-	return &Config{imexConfig: imex.Config{Mode: imex.ModeHostManaged, Isolation: imex.IsolationIMEXDomain}}
+	return &Config{
+		flags:      &Flags{imexHostSocketPath: defaultIMEXHostSocketPath},
+		imexConfig: imex.Config{Mode: imex.ModeHostManaged, Isolation: imex.IsolationIMEXDomain},
+	}
 }
 
 // TestApplyComputeDomainChannelConfigHostManagedIgnoresAllocationMode
@@ -711,6 +714,47 @@ func TestApplyComputeDomainChannelConfigHostManagedUsesAllocatedChannel(t *testi
 
 	require.Error(t, err, "channel 2 is already allocated by another claim, so this must fail")
 	assert.Contains(t, err.Error(), "channel 2 already allocated")
+}
+
+// TestApplyComputeDomainChannelConfigHostManagedRequiresHostIMEXReady confirms
+// that on a fabric node (non-empty cliqueID), a host-managed channel claim is
+// rejected when the operator's host nvidia-imex daemon cannot be validated as
+// ready (here: nvidia-imex-ctl isn't even present under the driver root).
+// This is the only readiness signal host-managed mode has, since there is no
+// driver-managed daemon to report ComputeDomain readiness.
+func TestApplyComputeDomainChannelConfigHostManagedRequiresHostIMEXReady(t *testing.T) {
+	cd := &configapi.ComputeDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "cd", Namespace: "default", UID: "cd-uid"},
+	}
+	factory := nvinformers.NewSharedInformerFactory(nvfake.NewSimpleClientset(), 0)
+	informer := factory.Resource().V1beta1().ComputeDomains().Informer()
+	require.NoError(t, informer.AddIndexers(cache.Indexers{"computeDomainUID": uidIndexer[*configapi.ComputeDomain]}))
+	require.NoError(t, informer.GetIndexer().Add(cd))
+
+	state := &DeviceState{
+		config:               hostManagedConfig(),
+		checkpointManager:    &fakeCheckpointManager{checkpoint: checkpointWithClaims(nil)},
+		computeDomainManager: &ComputeDomainManager{informer: informer, cliqueID: "clique-a"},
+		nvdevlib:             &deviceLib{devRoot: t.TempDir()},
+		allocatable: AllocatableDevices{
+			"channel-0": &AllocatableDevice{Channel: &ComputeDomainChannelInfo{ID: 0}},
+		},
+	}
+
+	config := channelConfig("cd-uid")
+	result := allocationResult("request", DriverName, "channel-0", nil)
+	claim := claimWithResults("claim-uid", result)
+
+	_, err := state.applyComputeDomainChannelConfig(
+		context.Background(),
+		config,
+		claim,
+		[]*resourceapi.DeviceRequestAllocationResult{&result},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host nvidia-imex daemon readiness check failed")
+	assert.False(t, isPermanentError(err), "an unready host daemon must be retried, not treated as permanently broken")
 }
 
 func TestUnprepareDevicesHostManagedSkipsRemoveNodeLabel(t *testing.T) {

--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/utils/ptr"
@@ -34,6 +35,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	configapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/imex"
+	nvfake "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/nvidia.com/clientset/versioned/fake"
+	nvinformers "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/nvidia.com/informers/externalversions"
 )
 
 type fakeCheckpointManager struct {
@@ -542,6 +546,184 @@ func TestUnprepareMissingClaimIsNoop(t *testing.T) {
 	err := state.Unprepare(context.Background(), claimRef)
 
 	require.NoError(t, err)
+}
+
+func hostManagedConfig() *Config {
+	return &Config{imexConfig: imex.Config{Mode: imex.ModeHostManaged, Isolation: imex.IsolationIMEXDomain}}
+}
+
+// TestApplyComputeDomainChannelConfigHostManagedIgnoresAllocationMode
+// confirms the kubelet plugin does not (re-)validate AllocationMode under
+// host-managed IMEX: today the controller is the one that always requests
+// AllocationMode Single (channel 0) for host-managed ComputeDomains, so the
+// kubelet plugin trusts it rather than duplicating that policy. This leaves
+// room for the controller to later request other channels without needing a
+// matching change here.
+func TestApplyComputeDomainChannelConfigHostManagedIgnoresAllocationMode(t *testing.T) {
+	for _, mode := range []string{"", configapi.ComputeDomainChannelAllocationModeSingle, configapi.ComputeDomainChannelAllocationModeAll, "foo"} {
+		t.Run(mode, func(t *testing.T) {
+			cd := &configapi.ComputeDomain{
+				ObjectMeta: metav1.ObjectMeta{Name: "cd", Namespace: "default", UID: "cd-uid"},
+			}
+
+			// Empty cliqueID keeps this fixture minimal (no nvdevlib/cdi
+			// setup needed): it only needs to reach past the removed
+			// AllocationMode check to prove the mode is no longer rejected.
+			factory := nvinformers.NewSharedInformerFactory(nvfake.NewSimpleClientset(), 0)
+			informer := factory.Resource().V1beta1().ComputeDomains().Informer()
+			require.NoError(t, informer.AddIndexers(cache.Indexers{"computeDomainUID": uidIndexer[*configapi.ComputeDomain]}))
+			require.NoError(t, informer.GetIndexer().Add(cd))
+
+			state := &DeviceState{
+				config:               hostManagedConfig(),
+				checkpointManager:    &fakeCheckpointManager{checkpoint: checkpointWithClaims(nil)},
+				computeDomainManager: &ComputeDomainManager{informer: informer, cliqueID: ""},
+				allocatable: AllocatableDevices{
+					"channel-0": &AllocatableDevice{Channel: &ComputeDomainChannelInfo{ID: 0}},
+				},
+			}
+
+			result := allocationResult("request", DriverName, "channel-0", nil)
+			config := channelConfig("cd-uid")
+			config.AllocationMode = mode
+
+			_, err := state.applyComputeDomainChannelConfig(
+				context.Background(),
+				config,
+				claimWithResults("claim-uid", result),
+				[]*resourceapi.DeviceRequestAllocationResult{&result},
+			)
+
+			require.NoError(t, err, "AllocationMode %q must not be rejected by the kubelet plugin under host-managed IMEX", mode)
+		})
+	}
+}
+
+func TestApplyComputeDomainDaemonConfigHostManagedRejected(t *testing.T) {
+	result := allocationResult("request", DriverName, "daemon-0", nil)
+
+	state := &DeviceState{config: hostManagedConfig()}
+	_, err := state.applyComputeDomainDaemonConfig(
+		context.Background(),
+		daemonConfig("cd-uid"),
+		claimWithResults("claim-uid", result),
+		[]*resourceapi.DeviceRequestAllocationResult{&result},
+	)
+
+	require.Error(t, err)
+	assert.True(t, isPermanentError(err), "daemon claims must be a permanent error under host-managed IMEX")
+}
+
+func TestApplyComputeDomainChannelConfigHostManagedNoCliqueSkipsInjection(t *testing.T) {
+	cd := &configapi.ComputeDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "cd", Namespace: "default", UID: "cd-uid"},
+	}
+
+	// A ComputeDomainManager whose informer already holds the CD (so the
+	// namespace assertion passes) but with an empty cliqueID, simulating a
+	// non-MNNVL node with no NVLink fabric.
+	factory := nvinformers.NewSharedInformerFactory(nvfake.NewSimpleClientset(), 0)
+	informer := factory.Resource().V1beta1().ComputeDomains().Informer()
+	require.NoError(t, informer.AddIndexers(cache.Indexers{"computeDomainUID": uidIndexer[*configapi.ComputeDomain]}))
+	require.NoError(t, informer.GetIndexer().Add(cd))
+
+	state := &DeviceState{
+		config:               hostManagedConfig(),
+		checkpointManager:    &fakeCheckpointManager{checkpoint: checkpointWithClaims(nil)},
+		computeDomainManager: &ComputeDomainManager{informer: informer, cliqueID: ""},
+		allocatable: AllocatableDevices{
+			"channel-0": &AllocatableDevice{Channel: &ComputeDomainChannelInfo{ID: 0}},
+		},
+	}
+
+	config := channelConfig("cd-uid")
+	config.AllocationMode = configapi.ComputeDomainChannelAllocationModeSingle
+	result := allocationResult("request", DriverName, "channel-0", nil)
+	claim := claimWithResults("claim-uid", result)
+
+	// applyComputeDomainChannelConfigHostManaged never calls
+	// AddNodeLabel/AssertComputeDomainReady at all (unlike the driver-managed
+	// path), which would otherwise dereference the manager's nil config;
+	// reaching the clique check (without panicking) proves the host-managed
+	// branch was taken.
+	//
+	// Like the driver-managed path, a missing clique must not fail the claim:
+	// some nodes in a cluster are legitimately non-MNNVL, and claim
+	// preparation there should still succeed, just without an injected
+	// channel device node.
+	configState, err := state.applyComputeDomainChannelConfig(
+		context.Background(),
+		config,
+		claim,
+		[]*resourceapi.DeviceRequestAllocationResult{&result},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, configState)
+	assert.Equal(t, ComputeDomainChannelType, configState.Type)
+	assert.Nil(t, configState.containerEdits, "no clique on this node means no IMEX channel device node is injected")
+}
+
+// TestApplyComputeDomainChannelConfigHostManagedUsesAllocatedChannel confirms
+// that the channel-conflict check operates on whichever channel was actually
+// allocated for the claim (via result.Device), not a hardcoded channel 0.
+// Today the controller only ever requests channel 0, but this proves the
+// kubelet plugin itself imposes no such restriction.
+func TestApplyComputeDomainChannelConfigHostManagedUsesAllocatedChannel(t *testing.T) {
+	cd := &configapi.ComputeDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "cd", Namespace: "default", UID: "cd-uid"},
+	}
+	factory := nvinformers.NewSharedInformerFactory(nvfake.NewSimpleClientset(), 0)
+	informer := factory.Resource().V1beta1().ComputeDomains().Informer()
+	require.NoError(t, informer.AddIndexers(cache.Indexers{"computeDomainUID": uidIndexer[*configapi.ComputeDomain]}))
+	require.NoError(t, informer.GetIndexer().Add(cd))
+
+	// Seed the checkpoint with channel 2 (not channel 0) already allocated by
+	// another claim.
+	checkpoint := checkpointWithClaims(map[string]PreparedClaim{
+		"existing-uid": {
+			CheckpointState: ClaimCheckpointStatePrepareCompleted,
+			PreparedDevices: PreparedDevices{
+				{Devices: PreparedDeviceList{preparedChannel(2)}},
+			},
+		},
+	})
+
+	state := &DeviceState{
+		config:               hostManagedConfig(),
+		checkpointManager:    &fakeCheckpointManager{checkpoint: checkpoint},
+		computeDomainManager: &ComputeDomainManager{informer: informer, cliqueID: ""},
+		allocatable: AllocatableDevices{
+			"channel-2": &AllocatableDevice{Channel: &ComputeDomainChannelInfo{ID: 2}},
+		},
+	}
+
+	config := channelConfig("cd-uid")
+	result := allocationResult("request", DriverName, "channel-2", nil)
+	claim := claimWithResults("claim-uid", result)
+
+	_, err := state.applyComputeDomainChannelConfig(
+		context.Background(),
+		config,
+		claim,
+		[]*resourceapi.DeviceRequestAllocationResult{&result},
+	)
+
+	require.Error(t, err, "channel 2 is already allocated by another claim, so this must fail")
+	assert.Contains(t, err.Error(), "channel 2 already allocated")
+}
+
+func TestUnprepareDevicesHostManagedSkipsRemoveNodeLabel(t *testing.T) {
+	// computeDomainManager is intentionally nil: the channel branch must skip
+	// RemoveNodeLabel under host-managed IMEX, so it must never be
+	// dereferenced.
+	state := testDeviceState()
+	state.config = hostManagedConfig()
+	status := claimStatus([]resourceapi.DeviceRequestAllocationResult{
+		allocationResult("channel-request", DriverName, "channel-0", nil),
+	})
+
+	require.NoError(t, state.unprepareDevices(context.Background(), &status))
 }
 
 func testDeviceState() *DeviceState {

--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -37,6 +37,26 @@ import (
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/workqueue"
 )
 
+// computeDomainPublishedDevices returns the devices the kubelet plugin should
+// advertise in its node ResourceSlice. IMEX channel devices other than
+// channel 0 are never advertised here (they are advertised as a network
+// resource from the control plane instead). ComputeDomain daemon devices are
+// additionally omitted when hostManaged is true, since daemon claims are
+// never valid in that mode (see applyComputeDomainDaemonConfig).
+func computeDomainPublishedDevices(allocatable AllocatableDevices, hostManaged bool) []resourceapi.Device {
+	var devices []resourceapi.Device
+	for _, device := range allocatable {
+		if device.Type() == ComputeDomainChannelType && device.Channel.ID != 0 {
+			continue
+		}
+		if hostManaged && device.Type() == ComputeDomainDaemonType {
+			continue
+		}
+		devices = append(devices, device.GetDevice())
+	}
+	return devices
+}
+
 const (
 	// ErrorRetryMaxTimeout limits the amount of time spent in the request
 	// handlers UnprepareResourceClaims() and PrepareResourceClaims(), so that
@@ -102,16 +122,9 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	}
 	driver.pluginhelper = helper
 
-	// Enumerate the set of ComputeDomain daemon devices and publish them
+	// Enumerate the set of ComputeDomain devices to publish.
 	var resourceSlice resourceslice.Slice
-	for _, device := range state.allocatable {
-		// Explicitly exclude ComputeDomain channels from being advertised here. They
-		// are instead advertised in as a network resource from the control plane.
-		if device.Type() == ComputeDomainChannelType && device.Channel.ID != 0 {
-			continue
-		}
-		resourceSlice.Devices = append(resourceSlice.Devices, device.GetDevice())
-	}
+	resourceSlice.Devices = computeDomainPublishedDevices(state.allocatable, config.imexConfig.EffectiveHostManaged())
 
 	resources := resourceslice.DriverResources{
 		Pools: map[string]resourceslice.Pool{

--- a/cmd/compute-domain-kubelet-plugin/driver_test.go
+++ b/cmd/compute-domain-kubelet-plugin/driver_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"sort"
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func deviceNames(devices []resourceapi.Device) []string {
+	names := make([]string, 0, len(devices))
+	for _, d := range devices {
+		names = append(names, d.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestComputeDomainPublishedDevices(t *testing.T) {
+	allocatable := AllocatableDevices{
+		"channel-0": &AllocatableDevice{Channel: &ComputeDomainChannelInfo{ID: 0}},
+		"channel-1": &AllocatableDevice{Channel: &ComputeDomainChannelInfo{ID: 1}},
+		"daemon-0":  &AllocatableDevice{Daemon: &ComputeDomainDaemonInfo{ID: 0}},
+	}
+
+	t.Run("driver-managed publishes channel 0 and the daemon device", func(t *testing.T) {
+		// Non-zero channels are always excluded (advertised from the control plane).
+		assert.Equal(t, []string{"channel-0", "daemon-0"}, deviceNames(computeDomainPublishedDevices(allocatable, false)))
+	})
+
+	t.Run("host-managed omits the daemon device", func(t *testing.T) {
+		assert.Equal(t, []string{"channel-0"}, deviceNames(computeDomainPublishedDevices(allocatable, true)))
+	})
+}

--- a/cmd/compute-domain-kubelet-plugin/main.go
+++ b/cmd/compute-domain-kubelet-plugin/main.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/dra-driver-nvidia-gpu/internal/info"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 	pkgflags "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/flags"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/imex"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/metrics"
 )
 
@@ -60,11 +61,14 @@ type Flags struct {
 	healthcheckPort               int
 	klogVerbosity                 int
 	gpuCliqueLabelEnabled         bool
+	imexMode                      string
+	imexIsolation                 string
 }
 
 type Config struct {
 	flags      *Flags
 	clientsets pkgflags.ClientSets
+	imexConfig imex.Config
 }
 
 func (c Config) DriverPluginPath() string {
@@ -167,6 +171,20 @@ func newApp() *cli.App {
 			Destination: &flags.gpuCliqueLabelEnabled,
 			EnvVars:     []string{"GPU_CLIQUE_LABEL_ENABLED"},
 		},
+		&cli.StringFlag{
+			Name:        "imex-mode",
+			Usage:       "IMEX deployment mode: driverManaged or hostManaged.",
+			Value:       string(imex.ModeDriverManaged),
+			Destination: &flags.imexMode,
+			EnvVars:     []string{"IMEX_MODE"},
+		},
+		&cli.StringFlag{
+			Name:        "imex-isolation",
+			Usage:       "IMEX isolation strategy: domain (default; all workloads in the same IMEX domain share channel 0) or channel (not yet supported).",
+			Value:       string(imex.IsolationIMEXDomain),
+			Destination: &flags.imexIsolation,
+			EnvVars:     []string{"IMEX_ISOLATION"},
+		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)
 	cliFlags = append(cliFlags, featureGateConfig.Flags()...)
@@ -198,6 +216,11 @@ func newApp() *cli.App {
 				return fmt.Errorf("feature gate validation failed: %w", err)
 			}
 
+			imexConfig := imex.Config{Mode: imex.Mode(flags.imexMode), Isolation: imex.Isolation(flags.imexIsolation)}
+			if err := imexConfig.Validate(featuregates.Enabled(featuregates.HostManagedIMEXDaemon)); err != nil {
+				return fmt.Errorf("imex configuration validation failed: %w", err)
+			}
+
 			clientSets, err := flags.kubeClientConfig.NewClientSets()
 			if err != nil {
 				return fmt.Errorf("create client: %w", err)
@@ -206,6 +229,7 @@ func newApp() *cli.App {
 			config := &Config{
 				flags:      flags,
 				clientsets: clientSets,
+				imexConfig: imexConfig,
 			}
 
 			return RunPlugin(c.Context, config)

--- a/cmd/compute-domain-kubelet-plugin/main.go
+++ b/cmd/compute-domain-kubelet-plugin/main.go
@@ -43,6 +43,13 @@ const (
 	DriverName                              = "compute-domain.nvidia.com"
 	DriverPluginCheckpointFileBasename      = "checkpoint.json"
 	IMEXDaemonsWithDNSNamesMinDriverVersion = "570.158.01"
+
+	// defaultIMEXHostSocketPath is the default location, under the driver
+	// root, of the Unix domain socket the host nvidia-imex daemon's
+	// command/control service listens on when host-managed IMEX is enabled.
+	// It corresponds to the host's IMEX_CMD_UNIX_DOMAIN_PATH setting in
+	// /etc/nvidia-imex/config.cfg (see site/content/docs/prerequisites.md).
+	defaultIMEXHostSocketPath = "/etc/nvidia-imex/imex_ctrl.sock"
 )
 
 type Flags struct {
@@ -63,6 +70,7 @@ type Flags struct {
 	gpuCliqueLabelEnabled         bool
 	imexMode                      string
 	imexIsolation                 string
+	imexHostSocketPath            string
 }
 
 type Config struct {
@@ -184,6 +192,13 @@ func newApp() *cli.App {
 			Value:       string(imex.IsolationIMEXDomain),
 			Destination: &flags.imexIsolation,
 			EnvVars:     []string{"IMEX_ISOLATION"},
+		},
+		&cli.StringFlag{
+			Name:        "imex-host-socket-path",
+			Usage:       "Path (under the nvidia-driver-root) to the Unix domain socket the host nvidia-imex daemon's command/control service listens on. Only used when imex-mode=hostManaged, to validate host IMEX readiness during channel allocation.",
+			Value:       defaultIMEXHostSocketPath,
+			Destination: &flags.imexHostSocketPath,
+			EnvVars:     []string{"IMEX_HOST_SOCKET_PATH"},
 		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)

--- a/cmd/compute-domain-kubelet-plugin/nvlib.go
+++ b/cmd/compute-domain-kubelet-plugin/nvlib.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog/v2"
@@ -382,6 +383,38 @@ func (l deviceLib) getNVCapIMEXChannelDeviceInfo(channelID int) (*common.NVcapDe
 	}
 
 	return info, nil
+}
+
+// nvidiaImexCtlBinaryName is the CLI tool shipped alongside nvidia-imex that
+// queries the local IMEX daemon's readiness.
+const nvidiaImexCtlBinaryName = "nvidia-imex-ctl"
+
+// checkHostIMEXReady validates that the operator-managed host nvidia-imex
+// daemon (see the HostManagedIMEXDaemon feature gate) is up and ready.
+//
+// It runs `nvidia-imex-ctl -q --u=<socketPath>` ("Query the status of the
+// IMEX daemon once and return", connecting over the given Unix domain
+// socket) chrooted into the driver root.
+//
+// This check requires the host's nvidia-imex daemon to be configured with
+// IMEX_CMD_UNIX_DOMAIN_PATH (see site/content/docs/prerequisites.md).
+func (l deviceLib) checkHostIMEXReady(socketPath string) error {
+	if _, err := root(l.devRoot).getNvidiaImexCtlPath(); err != nil {
+		return fmt.Errorf("%s not found under driver root %q: %w (is nvidia-imex installed on this node?)",
+			nvidiaImexCtlBinaryName, l.devRoot, err)
+	}
+
+	cmd := exec.Command("chroot", l.devRoot, nvidiaImexCtlBinaryName, "-q", "--u="+socketPath) //nolint:gosec
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error running %s (socket %q): %w, output: %s", nvidiaImexCtlBinaryName, socketPath, err, string(output))
+	}
+
+	if !strings.Contains(string(output), "READY") {
+		return fmt.Errorf("host nvidia-imex daemon not ready: %s", string(output))
+	}
+
+	return nil
 }
 
 func (l deviceLib) unmountRecursively(root string) error {

--- a/cmd/compute-domain-kubelet-plugin/nvlib_test.go
+++ b/cmd/compute-domain-kubelet-plugin/nvlib_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckHostIMEXReadyMissingBinary confirms that a driver root without
+// nvidia-imex-ctl (e.g. a node where the optional nvidia-imex package was
+// never installed) fails with an actionable error, without ever attempting
+// to chroot/exec. The success path (chrooting in and parsing "READY") needs
+// a real nvidia-imex-ctl binary and elevated privileges, so it is not
+// covered by this unit test.
+func TestCheckHostIMEXReadyMissingBinary(t *testing.T) {
+	l := deviceLib{devRoot: t.TempDir()}
+
+	err := l.checkHostIMEXReady(defaultIMEXHostSocketPath)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nvidia-imex-ctl not found")
+}

--- a/cmd/compute-domain-kubelet-plugin/root.go
+++ b/cmd/compute-domain-kubelet-plugin/root.go
@@ -62,6 +62,30 @@ func (r root) getNvidiaSMIPath() (string, error) {
 	return binaryPath, nil
 }
 
+// getNvidiaImexCtlPath returns the path to the `nvidia-imex-ctl` executable
+// in the driver root. Unlike nvidia-smi, this is not resolved eagerly at
+// startup: nvidia-imex-ctl ships with the optional nvidia-imex package,
+// which is only expected to be present when the host administrator runs
+// nvidia-imex as a host service (see the HostManagedIMEXDaemon feature
+// gate), so callers should look it up lazily and treat its absence as an
+// ordinary, actionable error rather than a startup failure.
+func (r root) getNvidiaImexCtlPath() (string, error) {
+	binarySearchPaths := []string{
+		"/opt/bin",
+		"/usr/bin",
+		"/usr/sbin",
+		"/bin",
+		"/sbin",
+	}
+
+	binaryPath, err := r.findFile("nvidia-imex-ctl", binarySearchPaths...)
+	if err != nil {
+		return "", err
+	}
+
+	return binaryPath, nil
+}
+
 // isDevRoot checks whether the specified root is a dev root.
 // A dev root is defined as a root containing a /dev folder.
 func (r root) isDevRoot() bool {

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/_helpers.tpl
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/_helpers.tpl
@@ -196,3 +196,40 @@ resource.k8s.io/v1beta1
 {{- else -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Returns "true" when resources.computeDomains.imex.mode is exactly
+"hostManaged", empty string otherwise. Used only to control structural
+rendering (omitting the compute-domain-daemon DeviceClass/RBAC).
+*/}}
+{{- define "dra-driver-nvidia-gpu.hostManagedIMEX" -}}
+{{- if eq (toString (dig "mode" "" (.Values.resources.computeDomains.imex | default dict))) "hostManaged" -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validates resources.computeDomains.imex.mode / .isolation against
+featureGates.HostManagedIMEXDaemon. Included from controller.yaml and
+kubeletplugin.yaml (both already gated on resources.computeDomains.enabled)
+*/}}
+{{- define "dra-driver-nvidia-gpu.validateIMEXConfig" -}}
+{{- $imex := .Values.resources.computeDomains.imex | default dict -}}
+{{- $mode := toString (dig "mode" "driverManaged" $imex) -}}
+{{- $isolation := toString (dig "isolation" "domain" $imex) -}}
+{{- $gateEnabled := and .Values.featureGates (and (hasKey .Values.featureGates "HostManagedIMEXDaemon") .Values.featureGates.HostManagedIMEXDaemon) -}}
+{{- if eq $mode "hostManaged" -}}
+  {{- if not $gateEnabled -}}
+    {{- fail "resources.computeDomains.imex.mode=hostManaged requires featureGates.HostManagedIMEXDaemon=true" -}}
+  {{- end -}}
+{{- else if ne $mode "driverManaged" -}}
+  {{- fail (printf "unknown resources.computeDomains.imex.mode %q: must be \"driverManaged\" or \"hostManaged\"" $mode) -}}
+{{- end -}}
+{{- if and (ne $isolation "") (ne $isolation "domain") -}}
+  {{- if eq $isolation "channel" -}}
+    {{- fail "resources.computeDomains.imex.isolation=channel is not supported yet: per-workload IMEX channel allocation is not implemented. Use the default, \"domain\"." -}}
+  {{- else -}}
+    {{- fail (printf "unknown resources.computeDomains.imex.isolation %q: must be \"domain\" or \"channel\"" $isolation) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/_helpers.tpl
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/_helpers.tpl
@@ -210,8 +210,9 @@ true
 
 {{/*
 Validates resources.computeDomains.imex.mode / .isolation against
-featureGates.HostManagedIMEXDaemon. Included from controller.yaml and
-kubeletplugin.yaml (both already gated on resources.computeDomains.enabled)
+featureGates.HostManagedIMEXDaemon so `helm install`/`helm template` fails fast
+with a clear message instead of the controller/kubelet-plugin pods crash-looping
+on an invalid combination. Produces no output on success.
 */}}
 {{- define "dra-driver-nvidia-gpu.validateIMEXConfig" -}}
 {{- $imex := .Values.resources.computeDomains.imex | default dict -}}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/controller.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/controller.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 {{- if .Values.resources.computeDomains.enabled }}
+{{- include "dra-driver-nvidia-gpu.validateIMEXConfig" . }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -99,6 +100,10 @@ spec:
         - name: FEATURE_GATES
           value: "{{ range $key, $value := .Values.featureGates }}{{ $key }}={{ $value }},{{ end }}"
         {{- end }}
+        - name: IMEX_MODE
+          value: "{{ .Values.resources.computeDomains.imex.mode }}"
+        - name: IMEX_ISOLATION
+          value: "{{ .Values.resources.computeDomains.imex.isolation }}"
         {{- with .Values.controller.containers.computeDomain.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/deviceclass-compute-domain-daemon.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/deviceclass-compute-domain-daemon.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.resources.computeDomains.enabled }}
+{{- if and .Values.resources.computeDomains.enabled (not (include "dra-driver-nvidia-gpu.hostManagedIMEX" .)) }}
 ---
 apiVersion: {{ include "dra-driver-nvidia-gpu.resourceApiVersion" . }}
 kind: DeviceClass

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 {{- if or .Values.resources.computeDomains.enabled .Values.resources.gpus.enabled }}
+{{- if .Values.resources.computeDomains.enabled }}
+{{- include "dra-driver-nvidia-gpu.validateIMEXConfig" . }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -167,6 +170,10 @@ spec:
         - name: FEATURE_GATES
           value: "{{ range $key, $value := .Values.featureGates }}{{ $key }}={{ $value }},{{ end }}"
         {{- end }}
+        - name: IMEX_MODE
+          value: "{{ .Values.resources.computeDomains.imex.mode }}"
+        - name: IMEX_ISOLATION
+          value: "{{ .Values.resources.computeDomains.imex.isolation }}"
         - name: KUBELET_REGISTRAR_DIRECTORY_PATH
           value: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}
         - name: KUBELET_PLUGINS_DIRECTORY_PATH

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -174,6 +174,8 @@ spec:
           value: "{{ .Values.resources.computeDomains.imex.mode }}"
         - name: IMEX_ISOLATION
           value: "{{ .Values.resources.computeDomains.imex.isolation }}"
+        - name: IMEX_HOST_SOCKET_PATH
+          value: "{{ .Values.resources.computeDomains.imex.hostSocketPath }}"
         - name: KUBELET_REGISTRAR_DIRECTORY_PATH
           value: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}
         - name: KUBELET_PLUGINS_DIRECTORY_PATH

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-compute-domain-daemon.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-compute-domain-daemon.yaml
@@ -1,3 +1,4 @@
+{{- if not (include "dra-driver-nvidia-gpu.hostManagedIMEX" .) }}
 {{- $namespaces := splitList "," (include "dra-driver-nvidia-gpu.namespaces" .) -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -54,4 +55,5 @@ roleRef:
   kind: ClusterRole
   name: system:openshift:scc:anyuid
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -96,6 +96,13 @@ resources:
       #   channel: not supported. In this mode, each workload will get a unique
       #     channel within an IMEX domain.
       isolation: "domain"
+      # hostSocketPath is the path (under the driver root) to the Unix domain
+      # socket the host nvidia-imex daemon's command/control service listens
+      # on. Only used when mode=hostManaged: the kubelet plugin uses it to
+      # validate host IMEX readiness (via `nvidia-imex-ctl -q --u=<path>`) during channel claim prepare.
+      # Requires the host's /etc/nvidia-imex/config.cfg to set IMEX_CMD_ENABLED to 1 and
+      # IMEX_CMD_UNIX_DOMAIN_PATH to this same path.
+      hostSocketPath: "/etc/nvidia-imex/imex_ctrl.sock"
 
 # Feature gates configuration following Kubernetes patterns
 # Configure feature gates as key-value pairs (feature_name: true/false)

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -79,7 +79,23 @@ resources:
     enabled: true
   computeDomains:
     enabled: true
-
+    # Changing `imex.mode` or `imex.isolation` on a cluster with active ComputeDomain workloads
+    # is not supported and is not enforced by the driver, drain and remove existing ComputeDomains first.
+    imex:
+      # mode selects the deployment mode of the IMEX daemon in the cluster. It tells
+      #   who owns the nvidia-imex daemon lifecycle:
+      #   driverManaged (default): the driver creates and manages a
+      #     per-ComputeDomain nvidia-imex DaemonSet.
+      #   hostManaged: the cluster administrator runs nvidia-imex as a host service
+      #     and the driver only advertises/injects an IMEX channel device
+      #     Requires featureGates.HostManagedIMEXDaemon=true
+      mode: driverManaged
+      # isolation selects the IMEX isolation strategy. The value can be one of:
+      #   domain (default): In this mode, all workloads running in the
+      #     same IMEX domain will share the same channel (0).
+      #   channel: not supported. In this mode, each workload will get a unique
+      #     channel within an IMEX domain.
+      isolation: "domain"
 
 # Feature gates configuration following Kubernetes patterns
 # Configure feature gates as key-value pairs (feature_name: true/false)
@@ -90,6 +106,7 @@ resources:
 #   LoggingAlphaOptions: false         # Kubernetes logging alpha features
 #   LoggingBetaOptions: true           # Kubernetes logging beta features
 #   NVMLDeviceHealthCheck: false       # GPU Health Checking using NVML
+#   HostManagedIMEXDaemon: false       # Gate allowing resources.computeDomains.imex.mode=hostManaged
 featureGates: {}
 
 # Log verbosity for all components. Zero or greater, higher number means higher

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -78,6 +78,12 @@ const (
 	// FabricManagerPartitioning enables Fabric Manager (NVSwitch) partition
 	// management for Passthrough VFIO devices.
 	FabricManagerPartitioning featuregate.Feature = "FabricManagerPartitioning"
+
+	// HostManagedIMEXDaemon gates whether the imex deployment mode
+	// may be set to "hostManaged" (see pkg/imex). It does not directly change
+	// driver behavior, it only unlocks the mode for clusters where
+	// the cluster admin owns the host nvidia-imex daemon lifecycle.
+	HostManagedIMEXDaemon featuregate.Feature = "HostManagedIMEXDaemon"
 )
 
 // Feature gate Version fields use driver SemVer major.minor.
@@ -153,6 +159,13 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 		},
 	},
 	FabricManagerPartitioning: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(0, 5),
+		},
+	},
+	HostManagedIMEXDaemon: {
 		{
 			Default:    false,
 			PreRelease: featuregate.Alpha,

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -145,6 +145,7 @@ func TestDefaultFeatureGates(t *testing.T) {
 
 		// Test that real features have expected defaults
 		require.False(t, fg.Enabled(TimeSlicingSettings), "TimeSlicingSettings should be disabled by default (alpha)")
+		require.False(t, fg.Enabled(HostManagedIMEXDaemon), "HostManagedIMEXDaemon should be disabled by default (alpha)")
 	})
 }
 

--- a/pkg/imex/imex.go
+++ b/pkg/imex/imex.go
@@ -1,0 +1,99 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package imex resolves and validates the imex.mode / imex.isolation Helm
+// values shared by the compute-domain-controller and
+// compute-domain-kubelet-plugin binaries.
+package imex
+
+import "fmt"
+
+// Mode selects who owns the host nvidia-imex daemon lifecycle.
+type Mode string
+
+const (
+	// ModeDriverManaged is the default: the driver creates and manages a
+	// per-ComputeDomain nvidia-imex DaemonSet.
+	ModeDriverManaged Mode = "driverManaged"
+
+	// ModeHostManaged assumes the cluster admin owns the host
+	// nvidia-imex daemon lifecycle. The driver stops creating per-ComputeDomain
+	// IMEX DaemonSets and only advertises/injects an IMEX channel device.
+	// Requires the HostManagedIMEXDaemon feature gate.
+	ModeHostManaged Mode = "hostManaged"
+)
+
+// Isolation selects the IMEX isolation strategy. Meaningful under both
+// ModeDriverManaged and ModeHostManaged.
+type Isolation string
+
+const (
+	// IsolationIMEXDomain is the default isolation strategy, under both
+	// ModeDriverManaged and ModeHostManaged: all workloads running in the
+	// same IMEX domain share the same channel (0).
+	IsolationIMEXDomain Isolation = "domain"
+
+	// IsolationIMEXChannel would give each workload a unique channel within
+	// an IMEX domain. Not implemented/supported yet: currently rejected as
+	// an error.
+	IsolationIMEXChannel Isolation = "channel"
+)
+
+// Config is the resolved imex.mode / imex.isolation configuration.
+type Config struct {
+	Mode      Mode
+	Isolation Isolation
+}
+
+// EffectiveHostManaged reports whether the resolved configuration puts the
+// driver into host-managed IMEX mode.
+func (c Config) EffectiveHostManaged() bool {
+	return c.Mode == ModeHostManaged
+}
+
+// Validate checks the Mode/Isolation combination against the
+// HostManagedIMEXDaemon feature gate state. hostManagedGateEnabled must
+// reflect whether the HostManagedIMEXDaemon feature gate is currently
+// enabled.
+//
+// The supported combinations are:
+//
+//	ModeDriverManaged, IsolationIMEXDomain (default)  -> OK
+//	ModeDriverManaged, IsolationIMEXChannel           -> error (not implemented yet)
+//	ModeHostManaged, !hostManagedGateEnabled          -> error (gate required)
+//	ModeHostManaged, IsolationIMEXDomain (default)    -> OK
+//	ModeHostManaged, IsolationIMEXChannel             -> error (not implemented yet)
+func (c Config) Validate(hostManagedGateEnabled bool) error {
+	switch c.Mode {
+	case ModeDriverManaged:
+		// No feature gate requirement.
+	case ModeHostManaged:
+		if !hostManagedGateEnabled {
+			return fmt.Errorf("imex.mode=%q requires the HostManagedIMEXDaemon feature gate to be enabled", ModeHostManaged)
+		}
+	default:
+		return fmt.Errorf("unknown imex.mode %q", c.Mode)
+	}
+
+	switch c.Isolation {
+	case "", IsolationIMEXDomain:
+		return nil
+	case IsolationIMEXChannel:
+		return fmt.Errorf("imex.isolation=%q is not supported yet: per-workload IMEX channel allocation is not implemented", IsolationIMEXChannel)
+	default:
+		return fmt.Errorf("unknown imex.isolation %q: must be %q or %q", c.Isolation, IsolationIMEXDomain, IsolationIMEXChannel)
+	}
+}

--- a/pkg/imex/imex_test.go
+++ b/pkg/imex/imex_test.go
@@ -31,21 +31,21 @@ func TestConfigValidate(t *testing.T) {
 		description string
 	}{
 		{
-			name:        "driverManaged with empty isolation defaults to IMEXDomain",
+			name:        "driverManaged with empty isolation defaults to domain",
 			config:      Config{Mode: ModeDriverManaged, Isolation: ""},
 			gateEnabled: false,
 			expectError: false,
-			description: "empty isolation is treated the same as the IMEXDomain default",
+			description: "empty isolation is treated the same as the domain default",
 		},
 		{
-			name:        "driverManaged with explicit IMEXDomain isolation succeeds",
+			name:        "driverManaged with explicit domain isolation succeeds",
 			config:      Config{Mode: ModeDriverManaged, Isolation: IsolationIMEXDomain},
 			gateEnabled: false,
 			expectError: false,
-			description: "IMEXDomain is the default, supported isolation strategy under driverManaged too",
+			description: "domain is the default, supported isolation strategy under driverManaged too",
 		},
 		{
-			name:        "driverManaged with IMEXChannel isolation errors",
+			name:        "driverManaged with channel isolation errors",
 			config:      Config{Mode: ModeDriverManaged, Isolation: IsolationIMEXChannel},
 			gateEnabled: false,
 			expectError: true,
@@ -66,21 +66,21 @@ func TestConfigValidate(t *testing.T) {
 			description: "mode=hostManaged is rejected when HostManagedIMEXDaemon is disabled",
 		},
 		{
-			name:        "hostManaged with empty isolation defaults to IMEXDomain",
+			name:        "hostManaged with empty isolation defaults to domain",
 			config:      Config{Mode: ModeHostManaged, Isolation: ""},
 			gateEnabled: true,
 			expectError: false,
-			description: "empty isolation is treated the same as the IMEXDomain default under hostManaged too",
+			description: "empty isolation is treated the same as the domain default under hostManaged too",
 		},
 		{
-			name:        "hostManaged with explicit IMEXDomain isolation succeeds",
+			name:        "hostManaged with explicit domain isolation succeeds",
 			config:      Config{Mode: ModeHostManaged, Isolation: IsolationIMEXDomain},
 			gateEnabled: true,
 			expectError: false,
-			description: "IMEXDomain is the default isolation strategy, supported under hostManaged",
+			description: "domain is the default isolation strategy, supported under hostManaged",
 		},
 		{
-			name:        "hostManaged with IMEXChannel isolation errors for now",
+			name:        "hostManaged with channel isolation errors for now",
 			config:      Config{Mode: ModeHostManaged, Isolation: IsolationIMEXChannel},
 			gateEnabled: true,
 			expectError: true,

--- a/pkg/imex/imex_test.go
+++ b/pkg/imex/imex_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      Config
+		gateEnabled bool
+		expectError bool
+		description string
+	}{
+		{
+			name:        "driverManaged with empty isolation defaults to IMEXDomain",
+			config:      Config{Mode: ModeDriverManaged, Isolation: ""},
+			gateEnabled: false,
+			expectError: false,
+			description: "empty isolation is treated the same as the IMEXDomain default",
+		},
+		{
+			name:        "driverManaged with explicit IMEXDomain isolation succeeds",
+			config:      Config{Mode: ModeDriverManaged, Isolation: IsolationIMEXDomain},
+			gateEnabled: false,
+			expectError: false,
+			description: "IMEXDomain is the default, supported isolation strategy under driverManaged too",
+		},
+		{
+			name:        "driverManaged with IMEXChannel isolation errors",
+			config:      Config{Mode: ModeDriverManaged, Isolation: IsolationIMEXChannel},
+			gateEnabled: false,
+			expectError: true,
+			description: "per-workload channel isolation is not implemented yet, regardless of mode",
+		},
+		{
+			name:        "driverManaged with unknown isolation errors",
+			config:      Config{Mode: ModeDriverManaged, Isolation: "bogus"},
+			gateEnabled: true,
+			expectError: true,
+			description: "isolation is validated regardless of mode",
+		},
+		{
+			name:        "hostManaged requires the feature gate",
+			config:      Config{Mode: ModeHostManaged, Isolation: IsolationIMEXDomain},
+			gateEnabled: false,
+			expectError: true,
+			description: "mode=hostManaged is rejected when HostManagedIMEXDaemon is disabled",
+		},
+		{
+			name:        "hostManaged with empty isolation defaults to IMEXDomain",
+			config:      Config{Mode: ModeHostManaged, Isolation: ""},
+			gateEnabled: true,
+			expectError: false,
+			description: "empty isolation is treated the same as the IMEXDomain default under hostManaged too",
+		},
+		{
+			name:        "hostManaged with explicit IMEXDomain isolation succeeds",
+			config:      Config{Mode: ModeHostManaged, Isolation: IsolationIMEXDomain},
+			gateEnabled: true,
+			expectError: false,
+			description: "IMEXDomain is the default isolation strategy, supported under hostManaged",
+		},
+		{
+			name:        "hostManaged with IMEXChannel isolation errors for now",
+			config:      Config{Mode: ModeHostManaged, Isolation: IsolationIMEXChannel},
+			gateEnabled: true,
+			expectError: true,
+			description: "per-workload channel isolation is not implemented yet, so it errors out",
+		},
+		{
+			name:        "unknown mode errors",
+			config:      Config{Mode: "bogus"},
+			gateEnabled: true,
+			expectError: true,
+			description: "an unrecognized mode value must be rejected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate(tt.gateEnabled)
+			if tt.expectError {
+				require.Error(t, err, tt.description)
+			} else {
+				require.NoError(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestConfigEffectiveHostManaged(t *testing.T) {
+	require.True(t, Config{Mode: ModeHostManaged}.EffectiveHostManaged())
+	require.False(t, Config{Mode: ModeDriverManaged}.EffectiveHostManaged())
+	require.False(t, Config{}.EffectiveHostManaged())
+}

--- a/site/content/docs/prerequisites.md
+++ b/site/content/docs/prerequisites.md
@@ -33,6 +33,24 @@ If you plan to use ComputeDomains, you also need:
 systemctl disable --now nvidia-imex.service && systemctl mask nvidia-imex.service
 ```
 
+### Host-managed IMEX
+
+By default the driver owns the `nvidia-imex` daemon lifecycle, per the requirement above. For clusters where the operator already runs `nvidia-imex` as a host service (for example through systemd), set `resources.computeDomains.imex.mode=hostManaged` to stop the driver from creating per-ComputeDomain `nvidia-imex` DaemonSets. This **inverts** the requirement above: `nvidia-imex.service` must be installed, configured, and left **running** on every participating GPU node.
+
+Host-managed mode requires two Helm values together:
+
+```bash
+--set featureGates.HostManagedIMEXDaemon=true \
+--set resources.computeDomains.imex.mode=hostManaged
+```
+
+- `featureGates.HostManagedIMEXDaemon` is an alpha gate that only unlocks setting `imex.mode=hostManaged`. It does not by itself change any behavior. Setting `imex.mode=hostManaged` without this gate enabled is a startup validation error (`helm install`/`helm template` fails immediately, and if bypassed, the controller and kubelet plugin pods will fail to start).
+- `imex.isolation` selects the IMEX isolation strategy, and applies under both `driverManaged` and `hostManaged` mode. It must be set to one of:
+  - `IMEXDomain` (default) — all workloads running in the same IMEX domain share the same channel (0). Under `driverManaged` mode this is inherent to the model (the driver creates one `nvidia-imex` daemon per ComputeDomain); under `hostManaged` mode, multiple ComputeDomains can still run against the same host IMEX domain, all receiving channel 0, with no isolation between them.
+  - `IMEXChannel` — intended to eventually give each workload a unique channel within an IMEX domain. Not implemented yet: setting it is a startup validation error regardless of `imex.mode`.
+  - Any other value is a startup validation error.
+- Changing `imex.mode` or `imex.isolation` on a cluster with active ComputeDomain workloads is not supported and is not enforced by the driver, drain and remove existing ComputeDomains first.
+
 ## Install prerequisites with NVIDIA GPU Operator
 
 The [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html) is a Kubernetes operator that automates the deployment and lifecycle management of all NVIDIA software components needed to provision and monitor GPUs in a cluster.

--- a/site/content/docs/prerequisites.md
+++ b/site/content/docs/prerequisites.md
@@ -35,7 +35,8 @@ systemctl disable --now nvidia-imex.service && systemctl mask nvidia-imex.servic
 
 ### Host-managed IMEX
 
-By default the driver owns the `nvidia-imex` daemon lifecycle, per the requirement above. For clusters where the operator already runs `nvidia-imex` as a host service (for example through systemd), set `resources.computeDomains.imex.mode=hostManaged` to stop the driver from creating per-ComputeDomain `nvidia-imex` DaemonSets. This **inverts** the requirement above: `nvidia-imex.service` must be installed, configured, and left **running** on every participating GPU node.
+By default the driver owns the `nvidia-imex` daemon lifecycle, per the requirement above. For clusters where the operator already runs `nvidia-imex` as a host service (for example through systemd), set `resources.computeDomains.imex.mode=hostManaged` to stop the driver from creating per-ComputeDomain `nvidia-imex` DaemonSets. This **inverts** the requirement above: `nvidia-imex.service` must be installed, configured, and left **running** on every participating GPU node. Also, the `nvidia-imex` service should be configured with
+`IMEX_CMD_ENABLED=1` and `IMEX_CMD_UNIX_DOMAIN_PATH=/etc/nvidia-imex/imex_ctrl.sock` (configurable via Helm).
 
 Host-managed mode requires two Helm values together:
 
@@ -46,10 +47,27 @@ Host-managed mode requires two Helm values together:
 
 - `featureGates.HostManagedIMEXDaemon` is an alpha gate that only unlocks setting `imex.mode=hostManaged`. It does not by itself change any behavior. Setting `imex.mode=hostManaged` without this gate enabled is a startup validation error (`helm install`/`helm template` fails immediately, and if bypassed, the controller and kubelet plugin pods will fail to start).
 - `imex.isolation` selects the IMEX isolation strategy, and applies under both `driverManaged` and `hostManaged` mode. It must be set to one of:
-  - `IMEXDomain` (default) — all workloads running in the same IMEX domain share the same channel (0). Under `driverManaged` mode this is inherent to the model (the driver creates one `nvidia-imex` daemon per ComputeDomain); under `hostManaged` mode, multiple ComputeDomains can still run against the same host IMEX domain, all receiving channel 0, with no isolation between them.
-  - `IMEXChannel` — intended to eventually give each workload a unique channel within an IMEX domain. Not implemented yet: setting it is a startup validation error regardless of `imex.mode`.
+  - `domain` (default) — all workloads running in the same IMEX domain share the same channel (0). Under `driverManaged` mode this is inherent to the model (the driver creates one `nvidia-imex` daemon per ComputeDomain); under `hostManaged` mode, multiple ComputeDomains can still run against the same host IMEX domain, all receiving channel 0, with no isolation between them.
+  - `channel` — intended to eventually give each workload a unique channel within an IMEX domain. Not implemented yet: setting it is a startup validation error regardless of `imex.mode`.
   - Any other value is a startup validation error.
 - Changing `imex.mode` or `imex.isolation` on a cluster with active ComputeDomain workloads is not supported and is not enforced by the driver, drain and remove existing ComputeDomains first.
+
+#### Host IMEX readiness check (Unix domain socket required)
+
+Because there is no driver-managed daemon to report readiness under host-managed IMEX, the kubelet plugin validates the host `nvidia-imex` daemon itself at channel claim prepare time: it runs `nvidia-imex-ctl -q --u=<socket path>` chrooted into the driver root and requires a `READY` response before handing out a channel. A claim fails, and is retried, rather than succeeding silently, if the host daemon isn't reachable or ready.
+
+To enable it:
+
+1. On every participating GPU node, add to `/etc/nvidia-imex/config.cfg`:
+
+   ```text
+   IMEX_CMD_ENABLED=1
+   IMEX_CMD_UNIX_DOMAIN_PATH=/etc/nvidia-imex/imex_ctrl.sock
+   ```
+
+   then restart `nvidia-imex.service` so it creates the socket file (IMEX config changes require a restart to take effect).
+2. `nvidia-imex-ctl` must be present under the driver root alongside `nvidia-smi` (it ships with the `nvidia-imex` package).
+3. If a non-default socket path is used, set `resources.computeDomains.imex.hostSocketPath` (Helm value, plumbed to the kubelet plugin as `IMEX_HOST_SOCKET_PATH`) to match. It defaults to `/etc/nvidia-imex/imex_ctrl.sock`.
 
 ## Install prerequisites with NVIDIA GPU Operator
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind feature

#### What this PR does / why we need it:

This feature enables support for host managed IMEX daemons with the ComputeDomain driver. In this mode, the cluster admin is responsible for the configuration of the `nvidia-imex` service on the host which includes `nodes_config.cfg` management. The CD driver will manage allocation of IMEX channels to the workloads.

* Introducing a new feature gate `HostManagedIMEXDaemon` to enable this use case.
* Added necessary helm params to allow both `hostManaged` and `driverManaged` deployment modes.
* Introducing `channel` and `domain` based isolation strategy for multiple workloads running in the same IMEX domain.
* CD controller changes to skip creation of IMEX daemonset and a `daemon` resource claim template.
* CD plugin changes to skip readiness checks for the driver managed daemon and instead introduce readiness checks for the host managed daemon.
* Added validations that `channel` based isolation is not currently supported. In both deployment modes, only "domain" isolation is supported (which means only channel 0 is injected in both modes for all workloads in the same IMEX domain).
* Added pre-requisites in the doc for enabling this mode.

Co-authored-by: Davanum Srinivas <davanum@gmail.com>

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

Relates to https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1163

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
     Add support for host managed IMEX daemon with the ComputeDomain Driver
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [x] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
