### PR TITLE
docs: document Hugo version params in contribute guide

### DIFF
--- a/site/content/contribute/docs.md
+++ b/site/content/contribute/docs.md
@@ -51,6 +51,47 @@ When a new release is cut, the docs changes are:
 
 For reference, the release notes live in [`release-notes/`](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/tree/main/release-notes) at the repo root.
 
+## Using version site variables in docs
+
+Two version params are defined under `[params]` in
+[`site/hugo.toml`](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/main/site/hugo.toml):
+
+| Param | Example value | Use for |
+| --- | --- | --- |
+| `driver_version` | `0.4.1` (no `v` prefix) | Helm `--version` flags and any bare chart version |
+| `driver_release_tag` | `v0.4.1` (with `v` prefix) | GitHub source links to a tagged path |
+
+Use these params anywhere the docs refer to the current release:
+
+- **`driver_version`** — any command that takes `--version`, or prose that names the chart version.
+- **`driver_release_tag`** — any link to files or directories at a tagged release (for example `tree/{{< param driver_release_tag >}}/demo`), or prose that names the GitHub release tag.
+
+Do not hardcode version strings in docs content unless you are calling out behavior that is specific to a particular driver version (for example an upgrade note that applies only when moving from `0.3.x` to `0.4.0`).
+
+Reference the param with the Docsy `param` shortcode.
+
+In prose:
+
+```text
+Install driver release {{</* param driver_release_tag */>}} with chart version {{</* param "driver_version" */>}}.
+```
+
+In a fenced code block:
+
+```text
+helm install dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
+    --version {{</* param "driver_version" */>}} \
+    --create-namespace \
+    --namespace dra-driver-nvidia-gpu \
+    --set gpuResourcesEnabledOverride=true
+```
+
+For a link to a tagged source file, place `{{</* param driver_release_tag */>}}` in the GitHub URL after `/blob/`:
+
+[`values.yaml`](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/{{< param driver_release_tag >}}/deployments/helm/dra-driver-nvidia-gpu/values.yaml)
+
+When adding syntax examples to this contribute page, escape shortcode delimiters in `text` code blocks (`{{</* ... */>}}`) so Hugo shows the source literally instead of substituting the current version.
+
 ## Where to look for more details
 
 | If you need to know… | Look at |


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
The docs site defines `driver_version` and `driver_release_tag` in `site/hugo.toml` and uses them across install, upgrade, reference, and concept pages via the Docsy `param` shortcode. That convention was only briefly mentioned in the contribute guide.
This PR adds a **"Using version site variables in docs"** section to `site/content/contribute/docs.md` that documents:
- where the params are set and the difference between them (bare chart version vs. GitHub release tag)
- when to use each (`--version` flags, tagged source links, current-release prose)
- when hardcoded versions are still appropriate
- copy-paste examples for prose, fenced code blocks, and tagged GitHub links

#### Which issue(s) this PR is related to:

Fixes #1227

#### Special notes for your reviewer:

- Syntax examples on the contribute page use escaped shortcode delimiters (`{{</* ... */>}}`) so Hugo renders the source literally; real docs pages use unescaped shortcodes so the version is substituted at build time.
- The tagged-source link example uses a live link (same pattern as `site/content/docs/reference/helm-values.md`) rather than a `markdown`-highlighted code block, which truncates URLs containing `{{<`.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

```docs
Add contributor documentation for Hugo site version params (`driver_version`, `driver_release_tag`) in site/content/contribute/docs.md.
```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
