### PR TITLE
feat(compute-domain): allow setting nvidia.com/gpu.clique label on the node

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/computedomain.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain.go
@@ -49,6 +49,8 @@ const (
 	// so the kubelet plugin now owns setting it on systems where the DRA driver is enabled.
 	gpuCliqueLabelKey = "nvidia.com/gpu.clique"
 
+	gpuCliqueLabelRefreshInterval = 10 * time.Minute
+
 	informerResyncPeriod = 10 * time.Minute
 	cleanupInterval      = 10 * time.Minute
 
@@ -65,7 +67,11 @@ type ComputeDomainManager struct {
 	informer cache.SharedIndexInformer
 
 	configFilesRoot string
-	cliqueID        string
+
+	cliqueIDMu sync.RWMutex
+	cliqueID   string
+
+	getCliqueIDFunc func() (string, error)
 }
 
 type ComputeDomainDaemonSettings struct {
@@ -76,10 +82,15 @@ type ComputeDomainDaemonSettings struct {
 	nodesConfigPath string
 }
 
-func NewComputeDomainManager(config *Config, cliqueID string) *ComputeDomainManager {
+func NewComputeDomainManager(config *Config, getCliqueIDFunc func() (string, error)) (*ComputeDomainManager, error) {
 	factory := nvinformers.NewSharedInformerFactory(config.clientsets.Nvidia, informerResyncPeriod)
 	informer := factory.Resource().V1beta1().ComputeDomains().Informer()
 	configFilesRoot := filepath.Join(config.DriverPluginPath(), ComputeDomainDaemonConfigFilesDirName)
+
+	cliqueID, err := getCliqueIDFunc()
+	if err != nil {
+		return nil, fmt.Errorf("error getting cliqueID: %w", err)
+	}
 
 	m := &ComputeDomainManager{
 		config:          config,
@@ -87,9 +98,25 @@ func NewComputeDomainManager(config *Config, cliqueID string) *ComputeDomainMana
 		informer:        informer,
 		configFilesRoot: configFilesRoot,
 		cliqueID:        cliqueID,
+		getCliqueIDFunc: getCliqueIDFunc,
 	}
 
-	return m
+	return m, nil
+}
+
+// CliqueID returns the most recently known GPU clique ID. Safe for
+// concurrent use.
+func (m *ComputeDomainManager) CliqueID() string {
+	m.cliqueIDMu.RLock()
+	defer m.cliqueIDMu.RUnlock()
+	return m.cliqueID
+}
+
+// setCliqueID stores a newly observed GPU clique ID.
+func (m *ComputeDomainManager) setCliqueID(cliqueID string) {
+	m.cliqueIDMu.Lock()
+	defer m.cliqueIDMu.Unlock()
+	m.cliqueID = cliqueID
 }
 
 func (m *ComputeDomainManager) Start(ctx context.Context) (rerr error) {
@@ -127,18 +154,38 @@ func (m *ComputeDomainManager) Start(ctx context.Context) (rerr error) {
 		return fmt.Errorf("informer cache sync for ComputeDomains failed")
 	}
 
-	if err := m.SetGPUCliqueLabel(ctx); err != nil {
-		return fmt.Errorf("error setting %s node label: %w", gpuCliqueLabelKey, err)
+	if m.config.flags.gpuCliqueLabelEnabled {
+		if err := m.SetGPUCliqueLabel(ctx); err != nil {
+			return fmt.Errorf("error setting %s node label: %w", gpuCliqueLabelKey, err)
+		}
+	}
+
+	if m.getCliqueIDFunc != nil {
+		m.waitGroup.Add(1)
+		go func() {
+			defer m.waitGroup.Done()
+			m.periodicGPUCliqueIDRefresh(ctx)
+		}()
 	}
 
 	return nil
 }
 
+//nolint:contextcheck
 func (m *ComputeDomainManager) Stop() error {
 	if m.cancelContext != nil {
 		m.cancelContext()
 	}
 	m.waitGroup.Wait()
+
+	if m.config.flags.gpuCliqueLabelEnabled {
+		rmCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := m.RemoveGPUCliqueLabel(rmCtx); err != nil {
+			klog.Errorf("error removing %s node label: %v", gpuCliqueLabelKey, err)
+		}
+	}
+
 	return nil
 }
 
@@ -175,7 +222,7 @@ func (s *ComputeDomainDaemonSettings) GetCDIContainerEditsCommon(ctx context.Con
 	edits := &cdiapi.ContainerEdits{
 		ContainerEdits: &cdispec.ContainerEdits{
 			Env: []string{
-				fmt.Sprintf("CLIQUE_ID=%s", s.manager.cliqueID),
+				fmt.Sprintf("CLIQUE_ID=%s", s.manager.CliqueID()),
 				fmt.Sprintf("COMPUTE_DOMAIN_UUID=%s", cd.UID),
 				fmt.Sprintf("COMPUTE_DOMAIN_NAME=%s", cd.Name),
 				fmt.Sprintf("COMPUTE_DOMAIN_NAMESPACE=%s", cd.Namespace),
@@ -290,7 +337,7 @@ func (m *ComputeDomainManager) isCurrentNodeReadyInStatus(cd *nvapi.ComputeDomai
 
 // isCurrentNodeReadyInClique checks if the current node is marked as ready in the ComputeDomainClique.
 func (m *ComputeDomainManager) isCurrentNodeReadyInClique(ctx context.Context, cd *nvapi.ComputeDomain) bool {
-	cliqueName := fmt.Sprintf("%s.%s", cd.UID, m.cliqueID)
+	cliqueName := fmt.Sprintf("%s.%s", cd.UID, m.CliqueID())
 
 	clique, err := m.config.clientsets.Nvidia.ResourceV1beta1().ComputeDomainCliques(m.config.flags.namespace).Get(ctx, cliqueName, metav1.GetOptions{})
 	if err != nil {
@@ -380,18 +427,15 @@ func (m *ComputeDomainManager) RemoveNodeLabel(ctx context.Context, cdUID string
 // clique ID discovered from NVML at plugin startup. If no clique ID was
 // discovered (e.g. fabric not attached), the label is simply left unset.
 func (m *ComputeDomainManager) SetGPUCliqueLabel(ctx context.Context) error {
-	if !m.config.flags.gpuCliqueLabelEnabled {
-		return nil
-	}
-
-	if m.cliqueID == "" {
+	cliqueID := m.CliqueID()
+	if cliqueID == "" {
 		return nil
 	}
 
 	patch := map[string]any{
 		"metadata": map[string]any{
 			"labels": map[string]string{
-				gpuCliqueLabelKey: m.cliqueID,
+				gpuCliqueLabelKey: cliqueID,
 			},
 		},
 	}
@@ -402,7 +446,70 @@ func (m *ComputeDomainManager) SetGPUCliqueLabel(ctx context.Context) error {
 	}
 
 	if _, err := m.config.clientsets.Core.CoreV1().Nodes().Patch(ctx, m.config.flags.nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("error patching Node with label %s: %w", gpuCliqueLabelKey, err)
+		return fmt.Errorf("error patching node with label %s: %w", gpuCliqueLabelKey, err)
+	}
+
+	return nil
+}
+
+// RemoveGPUCliqueLabel removes the nvidia.com/gpu.clique node label, e.g. on
+// plugin shutdown.
+func (m *ComputeDomainManager) RemoveGPUCliqueLabel(ctx context.Context) error {
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				gpuCliqueLabelKey: nil,
+			},
+		},
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+
+	if _, err := m.config.clientsets.Core.CoreV1().Nodes().Patch(ctx, m.config.flags.nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("error removing Node label %s: %w", gpuCliqueLabelKey, err)
+	}
+
+	return nil
+}
+
+// periodicGPUCliqueIDRefresh periodically re-reads the GPU clique ID from
+// NVML and updates the nvidia.com/gpu.clique node label if it changed.
+func (m *ComputeDomainManager) periodicGPUCliqueIDRefresh(ctx context.Context) {
+	ticker := time.NewTicker(gpuCliqueLabelRefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := m.refreshGPUCliqueID(ctx); err != nil {
+				klog.Errorf("error refreshing %s node label: %v", gpuCliqueLabelKey, err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// refreshGPUCliqueLabel re-reads the GPU clique ID and, if it differs from
+// the last known value, updates the in-memory state and the node label.
+func (m *ComputeDomainManager) refreshGPUCliqueID(ctx context.Context) error {
+	newCliqueID, err := m.getCliqueIDFunc()
+	if err != nil {
+		return fmt.Errorf("error getting cliqueID: %w", err)
+	}
+
+	if oldCliqueID := m.CliqueID(); newCliqueID != "" && newCliqueID != oldCliqueID {
+		klog.Infof("GPU clique ID changed from %q to %q, updating %s node label", oldCliqueID, newCliqueID, gpuCliqueLabelKey)
+		m.setCliqueID(newCliqueID)
+	}
+
+	if m.config.flags.gpuCliqueLabelEnabled {
+		if err := m.SetGPUCliqueLabel(ctx); err != nil {
+			return fmt.Errorf("error updating %s node label: %w", gpuCliqueLabelKey, err)
+		}
 	}
 
 	return nil

--- a/cmd/compute-domain-kubelet-plugin/computedomain.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -39,6 +41,13 @@ import (
 
 const (
 	computeDomainLabelKey = "resource.nvidia.com/computeDomain"
+
+	// gpuCliqueLabelKey sets the node label historically set by
+	// gpu-feature-discovery (see
+	// https://github.com/NVIDIA/k8s-device-plugin/blob/main/docs/gpu-feature-discovery/README.md#generated-labels).
+	// gpu-feature-discovery that is bundled with the k8s-device-plugin is being deprecated,
+	// so the kubelet plugin now owns setting it on systems where the DRA driver is enabled.
+	gpuCliqueLabelKey = "nvidia.com/gpu.clique"
 
 	informerResyncPeriod = 10 * time.Minute
 	cleanupInterval      = 10 * time.Minute
@@ -116,6 +125,10 @@ func (m *ComputeDomainManager) Start(ctx context.Context) (rerr error) {
 
 	if !cache.WaitForCacheSync(ctx.Done(), m.informer.HasSynced) {
 		return fmt.Errorf("informer cache sync for ComputeDomains failed")
+	}
+
+	if err := m.SetGPUCliqueLabel(ctx); err != nil {
+		return fmt.Errorf("error setting %s node label: %w", gpuCliqueLabelKey, err)
 	}
 
 	return nil
@@ -358,6 +371,38 @@ func (m *ComputeDomainManager) RemoveNodeLabel(ctx context.Context, cdUID string
 
 	if _, err := m.config.clientsets.Core.CoreV1().Nodes().Update(ctx, newNode, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("error updating Node to remove label: %w", err)
+	}
+
+	return nil
+}
+
+// SetGPUCliqueLabel sets the nvidia.com/gpu.clique node label based on the
+// clique ID discovered from NVML at plugin startup. If no clique ID was
+// discovered (e.g. fabric not attached), the label is simply left unset.
+func (m *ComputeDomainManager) SetGPUCliqueLabel(ctx context.Context) error {
+	if !m.config.flags.gpuCliqueLabelEnabled {
+		return nil
+	}
+
+	if m.cliqueID == "" {
+		return nil
+	}
+
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]string{
+				gpuCliqueLabelKey: m.cliqueID,
+			},
+		},
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+
+	if _, err := m.config.clientsets.Core.CoreV1().Nodes().Patch(ctx, m.config.flags.nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("error patching Node with label %s: %w", gpuCliqueLabelKey, err)
 	}
 
 	return nil

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -108,14 +108,10 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		return nil, fmt.Errorf("unable to create CDI handler: %w", err)
 	}
 
-	// TODO: explore calling this not only during plugin startup because this
-	// information may change during runtime.
-	cliqueID, err := nvdevlib.getCliqueID()
+	computeDomainManager, err := NewComputeDomainManager(config, nvdevlib.getCliqueID)
 	if err != nil {
-		return nil, fmt.Errorf("error getting cliqueID: %w", err)
+		return nil, fmt.Errorf("unable to create computedomain manager: %v", err)
 	}
-
-	computeDomainManager := NewComputeDomainManager(config, cliqueID)
 
 	if err := cdi.CreateStandardDeviceSpecFile(allocatable); err != nil {
 		return nil, fmt.Errorf("unable to create base CDI spec file: %v", err)
@@ -657,7 +653,7 @@ func (s *DeviceState) applyComputeDomainChannelConfig(ctx context.Context, confi
 		return nil, fmt.Errorf("error asserting ComputeDomain Ready: %w", err)
 	}
 
-	if s.computeDomainManager.cliqueID == "" {
+	if s.computeDomainManager.CliqueID() == "" {
 		// Do not inject IMEX channel device nodes.
 		return &configState, nil
 	}
@@ -716,7 +712,7 @@ func (s *DeviceState) applyComputeDomainDaemonConfig(ctx context.Context, config
 	// Only inject dev nodes related to
 	// /proc/driver/nvidia/capabilities/fabric-imex-mgmt if IMEX is supported
 	// (if we want to start the IMEX daemon process in the CD daemon pod).
-	if s.computeDomainManager.cliqueID != "" {
+	if s.computeDomainManager.CliqueID() != "" {
 		nvcapPath := nvidiaCapFabricImexMgmtPath
 		if common.UsingAltProcDevices() {
 			nvcapPath = filepath.Join(s.config.flags.containerDriverRoot, "proc/driver/nvidia/capabilities/fabric-imex-mgmt")

--- a/cmd/compute-domain-kubelet-plugin/main.go
+++ b/cmd/compute-domain-kubelet-plugin/main.go
@@ -59,6 +59,7 @@ type Flags struct {
 	kubeletPluginsDirectoryPath   string
 	healthcheckPort               int
 	klogVerbosity                 int
+	gpuCliqueLabelEnabled         bool
 }
 
 type Config struct {
@@ -158,6 +159,13 @@ func newApp() *cli.App {
 			Value:       -1,
 			Destination: &flags.healthcheckPort,
 			EnvVars:     []string{"HEALTHCHECK_PORT"},
+		},
+		&cli.BoolFlag{
+			Name:        "gpu-clique-label-enabled",
+			Usage:       "Set the nvidia.com/gpu.clique node label, historically set by gpu-feature-discovery.",
+			Value:       false,
+			Destination: &flags.gpuCliqueLabelEnabled,
+			EnvVars:     []string{"GPU_CLIQUE_LABEL_ENABLED"},
 		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -175,6 +175,8 @@ spec:
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.computeDomains.healthcheckPort | quote }}
         {{- end }}
+        - name: GPU_CLIQUE_LABEL_ENABLED
+          value: {{ .Values.kubeletPlugin.containers.computeDomains.gpuCliqueLabelEnabled | quote }}
         {{- with .Values.kubeletPlugin.containers.computeDomains.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml
@@ -16,7 +16,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list", "watch", "update"]
+  verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -277,6 +277,9 @@ kubeletPlugin:
       # Port running a gRPC health service checked by a livenessProbe.
       # Set to a negative value to disable the service and the probe.
       healthcheckPort: 51515
+      # Set the nvidia.com/gpu.clique node label, historically set by
+      # gpu-feature-discovery. Disabled by default.
+      gpuCliqueLabelEnabled: false
     gpus:
       env: []
       securityContext:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

/kind feature

#### What this PR does / why we need it:

Currently GPU feature discovery (GFD) which is a component of the NVIDIA K8s device plugin, sets the label with a key `nvidia.com/gpu.clique` and value as `<cluster UUID>.<GPU clique ID>`. This label allows users to identify nodes belonging to the same GPU Clique (NVLink partition). However due to its tight dependency on k8s-device-plugin, on systems where DRA driver is enabled there is a plan to deprecate GFD. In the absence of GFD, this feature in the CD kubelet plugin will allow to maintain backward compatibility for workloads depending on that node label in their Pod spec.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

Fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1244

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
    The compute domain kubelet plugin will now allow setting the nvidia.com/gpu.clique label on the node during plugin startup (disabled by default).
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [x] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
