### PR TITLE
docs: migrate remaining wiki content into docs site

### DIFF
--- a/site/content/docs/guides/compute-domain-workloads.md
+++ b/site/content/docs/guides/compute-domain-workloads.md
@@ -103,3 +103,135 @@ featureGates:
 ```
 
 See [Feature gates](../reference/feature-gates/) for all available gates.
+
+## Multi-node `nvbandwidth` test (with MPI)
+
+A two-node [`nvbandwidth`](https://github.com/NVIDIA/nvbandwidth) test that consumes four GPUs on each node, run through the [MPI Operator](https://github.com/kubeflow/mpi-operator). This validates that `ComputeDomain` channels work correctly across nodes under real inter-GPU traffic.
+
+1. Install the MPI Operator:
+
+```bash
+kubectl create -f https://github.com/kubeflow/mpi-operator/releases/download/v0.6.0/mpi-operator.yaml
+```
+
+2. Create the spec file. The `MPIJob` worker pods use `podAffinity` on the `nvidia.com/gpu.clique` topology key so both workers land in the same NVLink domain:
+
+```yaml
+cat <<EOF > nvbandwidth-test-job.yaml
+---
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: nvbandwidth-test-compute-domain
+spec:
+  numNodes: 0
+  channel:
+    resourceClaimTemplate:
+      name: nvbandwidth-test-compute-domain-channel
+---
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: nvbandwidth-test
+spec:
+  slotsPerWorker: 4
+  launcherCreationPolicy: WaitForWorkersReady
+  runPolicy:
+    cleanPodPolicy: Running
+  sshAuthMountPath: /home/mpiuser/.ssh
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        metadata:
+          labels:
+            nvbandwidth-test-replica: mpi-launcher
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+          containers:
+          - image: ghcr.io/nvidia/k8s-samples:nvbandwidth-v0.7-8d103163
+            name: mpi-launcher
+            securityContext:
+              runAsUser: 1000
+            command:
+            - mpirun
+            args:
+            - --bind-to
+            - core
+            - --map-by
+            - ppr:4:node
+            - -np
+            - "8"
+            - --report-bindings
+            - -q
+            - nvbandwidth
+            - -t
+            - multinode_device_to_device_memcpy_read_ce
+    Worker:
+      replicas: 2
+      template:
+        metadata:
+          labels:
+            nvbandwidth-test-replica: mpi-worker
+        spec:
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: nvbandwidth-test-replica
+                    operator: In
+                    values:
+                    - mpi-worker
+                topologyKey: nvidia.com/gpu.clique
+          containers:
+          - image: ghcr.io/nvidia/k8s-samples:nvbandwidth-v0.7-8d103163
+            name: mpi-worker
+            securityContext:
+              runAsUser: 1000
+            command:
+            - /usr/sbin/sshd
+            args:
+            - -De
+            - -f
+            - /home/mpiuser/.sshd_config
+            resources:
+              limits:
+                nvidia.com/gpu: 4
+              claims:
+              - name: compute-domain-channel
+          resourceClaims:
+          - name: compute-domain-channel
+            resourceClaimTemplateName: nvbandwidth-test-compute-domain-channel
+EOF
+kubectl apply -f nvbandwidth-test-job.yaml
+```
+
+3. Inspect results. The launcher log should print an `nvbandwidth` matrix of device-to-device bandwidth across both nodes:
+
+```bash
+kubectl logs --tail=-1 -l job-name=nvbandwidth-test-launcher
+```
+
+Example output:
+
+```
+Running multinode_device_to_device_memcpy_read_ce.
+memcpy CE GPU(row) -> GPU(column) bandwidth (GB/s)
+           0         1         2         3         4         5         6         7
+ 0       N/A    798.02    798.25    798.02    798.02    797.88    797.73    797.95
+ ...
+SUM multinode_device_to_device_memcpy_read_ce 44685.29
+```
+
+4. Clean up:
+
+```bash
+kubectl delete -f nvbandwidth-test-job.yaml
+```

--- a/site/content/docs/guides/troubleshooting.md
+++ b/site/content/docs/guides/troubleshooting.md
@@ -1,0 +1,91 @@
+---
+title: Troubleshooting
+linkTitle: Troubleshooting
+weight: 60
+description: Collect diagnostic data and tune log verbosity when something goes wrong.
+---
+
+## Collecting data
+
+### Kubelet plugin logs
+
+Collect all kubelet plugin logs into a single file:
+
+```bash
+kubectl logs \
+    -n dra-driver-nvidia-gpu \
+    -l dra-driver-nvidia-gpu-component=kubelet-plugin \
+    --prefix \
+    --all-containers \
+    --timestamps \
+    --tail=-1 \
+    > dra-driver-dbg_plugins_$(date -u +"%Y-%m-%dT%H%M%SZ").log
+```
+
+In a larger-scale cluster this can fetch a lot of data. Keep `--prefix` and `--timestamps` — they're critical for correlating events across pods.
+
+### ComputeDomain daemon logs (for a specific ComputeDomain)
+
+Paste this shell function into your terminal:
+
+```bash
+get_all_cd_daemon_logs_for_cd_name() {
+  if [ -z "$*" ]; then echo "missing arg: ComputeDomain name"; return 1; fi
+  CD_NAME="$1"
+  CD_UID=$(kubectl describe computedomains.resource.nvidia.com "${CD_NAME}" | grep UID | awk '{print $2}')
+  CD_LABEL_KV="resource.nvidia.com/computeDomain=${CD_UID}"
+  _filename="dra-driver-dbg_cd-daemons_$(date -u +"%Y-%m-%dT%H%M%SZ").log.gz"
+  echo "fetching CD daemon logs for CD: $CD_LABEL_KV ($CD_NAME), creating $_filename"
+  kubectl logs \
+    -n dra-driver-nvidia-gpu \
+    -l "${CD_LABEL_KV}" \
+    --all-containers \
+    --timestamps \
+    --tail=-1 \
+    --prefix | gzip > "${_filename}"
+}
+```
+
+Run it for a specific `ComputeDomain`:
+
+```bash
+get_all_cd_daemon_logs_for_cd_name imex-channel-injection
+```
+
+## Controlling log verbosity
+
+### At install time
+
+Log verbosity can be set for all components using the `--set logVerbosity=<V>` parameter during `helm install` or `helm upgrade -i`.
+
+### Post-install
+
+Verbosity can be changed after deployment, per component, using the mechanisms below. None of the components pick up verbosity changes at runtime — a pod restart is always required.
+
+**Controller:**
+
+```bash
+kubectl set env deployment dra-driver-nvidia-gpu-controller -n dra-driver-nvidia-gpu LOG_VERBOSITY=6
+```
+
+This restarts the controller pod.
+
+**Kubelet plugins:**
+
+```bash
+kubectl set env ds dra-driver-nvidia-gpu-kubelet-plugin -n dra-driver-nvidia-gpu LOG_VERBOSITY=6
+```
+
+This restarts all kubelet plugin pods.
+
+**ComputeDomain daemons:**
+
+Set the verbosity of daemons started *in the future* (this restarts the controller pod):
+
+```bash
+kubectl set env deployment dra-driver-nvidia-gpu-controller -n dra-driver-nvidia-gpu LOG_VERBOSITY_CD_DAEMON=6
+```
+
+## Filing an issue
+
+If you can't resolve the problem, open an [issue in the DRA Driver repository](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues) and attach the logs collected above.

--- a/site/content/docs/install.md
+++ b/site/content/docs/install.md
@@ -200,6 +200,37 @@ dra-driver-nvidia-gpu-kubelet-plugin-5qhc7          2/2     Running   0         
 dra-driver-nvidia-gpu-webhook-6c9dd4956d-r4r7z      1/1     Running   0          25s
 ```
 
+## Optional: Install a development build
+
+Release builds land at `registry.k8s.io/dra-driver-nvidia`. Between releases, every merge to `main` (and to `release-*` branches) is also built and pushed to the staging registry `us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia`, tagged `<VERSION>-<short-SHA>` (for example `v0.5.0-dev-a1b2c3d4`), where `<VERSION>` comes from the repository's [`VERSION`](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/main/VERSION) file at that commit.
+
+{{% alert title="Note" %}}
+Staging images and charts are unversioned, unsupported builds meant for testing a specific commit. Do not run them in production.
+{{% /alert %}}
+
+1. Find the short SHA of the commit you want to test, and read the `VERSION` file at that commit:
+
+```bash
+COMMIT="$(git ls-remote https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu.git refs/heads/main | cut -c1-8)"
+VERSION="$(curl -sSfL https://raw.githubusercontent.com/kubernetes-sigs/dra-driver-nvidia-gpu/main/VERSION)"
+TAG="${VERSION}-${COMMIT}"
+echo "installing: ${TAG}"
+```
+
+2. Install (or upgrade) using the staging chart at that tag:
+
+```bash
+helm upgrade -i dra-driver-nvidia-gpu \
+    oci://us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
+    --version "${TAG#v}" \
+    --namespace dra-driver-nvidia-gpu \
+    --create-namespace \
+    --set gpuResourcesEnabledOverride=true \
+    --wait
+```
+
+Append any other `--set` flags you'd normally use (`nvidiaDriverRoot`, `resources.computeDomains.enabled=false`, and so on).
+
 ## Run a sample GPU allocation workload
 
 Deploy a sample workload that allocates a GPU through the DRA Driver and verifies it is shared correctly between containers. For additional examples, see the [`demo/` folder](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/tree/main/demo) in the repository.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
The GitHub wiki duplicates content that now lives (or should live) on the docs site, and the wiki is harder to keep in sync since it isn't reviewed as part of normal PRs. This PR migrates the pieces of wiki content that had no equivalent on the docs site yet, so the wiki can eventually be retired without losing anything:

- Added an "Optional: Install a development build" section to `install.md`, pointing at the current staging registry (`us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-nvidia`) and tag scheme. The wiki's version of this still referenced the pre-`kubernetes-sigs` `ghcr.io/nvidia/...` registry and is stale.
- Added a "Multi-node `nvbandwidth` test (with MPI)" section to`guides/compute-domain-workloads.md`, ported from the wiki's `Validate-setup-for-ComputeDomain-allocation` page, updated so `numNodes: 0` matches this doc's existing guidance that the field is deprecated.
- Added a new `guides/troubleshooting.md` page (log collection, log verbosity tuning), ported from the wiki's `Troubleshooting` page and updated to the current namespace (`dra-driver-nvidia-gpu`) and selector label (`dra-driver-nvidia-gpu-component=kubelet-plugin`).

The remaining wiki pages (`Installation`, `Validate-setup-for-GPU-allocation`, and the rest of `Validate-setup-for-ComputeDomain-allocation`) are now fully superseded by `install.md` and `guides/compute-domain-workloads.md` and can be deleted once this merges.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Part of #1239. This PR only migrates content; deleting/redirecting the wiki pages themselves requires wiki write access - that's a follow-up for whoever has access to it.

#### Special notes for your reviewer:
- Verified with a local `hugo --gc --minify` build (the same command Netlify runs) - all 35 pages render with no errors.
- No code, API, or Helm chart changes — `site/content/docs/**` only.

#### Does this PR introduce a user-facing change?

<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs
This PR migrates wiki content to docs site:
- site/content/docs/install.md
- site/content/docs/guides/compute-domain-workloads.md
- site/content/docs/guides/troubleshooting.md
```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
