### PR TITLE
Health check with dyn mig

### DIFF
--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"sync"
 
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/klog/v2"
@@ -54,10 +55,11 @@ type AllocatableDevice struct {
 	// taints holds DRA device taints set by the health monitor. Published
 	// as part of the device's ResourceSlice entry so the scheduler and
 	// kubelet honour them per KEP-5055.
-	taints []resourceapi.DeviceTaint
+	taintsMu sync.RWMutex
+	taints   []resourceapi.DeviceTaint
 }
 
-func (d AllocatableDevice) Type() string {
+func (d *AllocatableDevice) Type() string {
 	if d.Gpu != nil {
 		return GpuDeviceType
 	}
@@ -73,7 +75,7 @@ func (d AllocatableDevice) Type() string {
 	return UnknownDeviceType
 }
 
-func (d AllocatableDevice) IsStaticOrDynMigDevice() bool {
+func (d *AllocatableDevice) IsStaticOrDynMigDevice() bool {
 	switch d.Type() {
 	case MigStaticDeviceType, MigDynamicDeviceType:
 		return true
@@ -115,7 +117,7 @@ func (d *AllocatableDevice) GetDevice() resourceapi.Device {
 // allocatable devices are abstract devices that do not have a UUID before
 // actualization -- hence, the idea of `AllocatableDevices` implementing
 // UUIDProvider is brittle.
-func (d AllocatableDevice) UUID() string {
+func (d *AllocatableDevice) UUID() string {
 	if d.Gpu != nil {
 		return d.Gpu.UUID
 	}
@@ -317,6 +319,8 @@ func (d *PerGPUAllocatableDevices) RemoveSiblingDevices(device *AllocatableDevic
 // Taints returns a copy of the device's taints to prevent data races
 // when being read concurrently by the ResourceSlice builder.
 func (d *AllocatableDevice) Taints() []resourceapi.DeviceTaint {
+	d.taintsMu.RLock()
+	defer d.taintsMu.RUnlock()
 	return slices.Clone(d.taints)
 }
 
@@ -326,6 +330,8 @@ func (d *AllocatableDevice) Taints() []resourceapi.DeviceTaint {
 // (e.g., XID 48 followed by XID 63), the value is overwritten and only the most recent event data is retained.
 // Returns true if the taint set was modified.
 func (d *AllocatableDevice) AddOrUpdateTaint(taint *resourceapi.DeviceTaint) bool {
+	d.taintsMu.Lock()
+	defer d.taintsMu.Unlock()
 	for i, existing := range d.taints {
 		if existing.Key == taint.Key {
 

--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -55,6 +55,8 @@ type AllocatableDevice struct {
 	// taints holds DRA device taints set by the health monitor. Published
 	// as part of the device's ResourceSlice entry so the scheduler and
 	// kubelet honour them per KEP-5055.
+	// taintsMu protects taints from concurrent access by the health-event handler
+	// and ResourceSlice generation.
 	taintsMu sync.RWMutex
 	taints   []resourceapi.DeviceTaint
 }

--- a/cmd/gpu-kubelet-plugin/device_health.go
+++ b/cmd/gpu-kubelet-plugin/device_health.go
@@ -109,6 +109,8 @@ type devicePlacementRegistry interface {
 	UnregisterDevicePlacement(parentUUID string, gi, ci uint32)
 }
 
+// migDeviceResolver finds the concrete MIG device currently implementing an
+// abstract Dynamic MIG profile and placement.
 type migDeviceResolver interface {
 	FindMigDevBySpec(*MigSpecTuple) (*MigLiveTuple, error)
 }
@@ -153,6 +155,9 @@ func newNvmlDeviceHealthMonitor(config *Config, perGPUAllocatable *PerGPUAllocat
 	return m, nil
 }
 
+// RegisterEvents creates the NVML event set and starts recording events for
+// every physical parent GPU. It intentionally does not start the wait loop, so
+// registration can complete before the kubelet server accepts requests.
 func (m *nvmlDeviceHealthMonitor) RegisterEvents() (rerr error) {
 	if ret := m.nvmllib.Init(); ret != nvml.SUCCESS {
 		return fmt.Errorf("failed to initialize NVML: %v", ret)
@@ -177,6 +182,7 @@ func (m *nvmlDeviceHealthMonitor) RegisterEvents() (rerr error) {
 	return nil
 }
 
+// Start launches the NVML event wait loop after RegisterEvents has completed.
 func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) error {
 	if m.eventSet == nil {
 		return fmt.Errorf("NVML events have not been registered")
@@ -514,6 +520,10 @@ func (m *nvmlDeviceHealthMonitor) lookupDevicePlacement(parentUUID string, gi, c
 	return m.deviceByPlacement.get(parentUUID, gi, ci)
 }
 
+// rebuildHealthPlacementsFromCheckpoint validates every completed Dynamic MIG
+// claim against live NVML state before registering any placement. Validation is
+// fail-closed: no checkpoint data is rewritten and no replacement device is
+// adopted when profile, placement, tuple, or MIG UUID differs.
 func rebuildHealthPlacementsFromCheckpoint(registry devicePlacementRegistry, resolver migDeviceResolver, perGPU *PerGPUAllocatableDevices, cp *Checkpoint) error {
 	if registry == nil || cp == nil || cp.V2 == nil {
 		return nil
@@ -531,7 +541,7 @@ func rebuildHealthPlacementsFromCheckpoint(registry devicePlacementRegistry, res
 		ci         uint32
 		device     *AllocatableDevice
 	}
-	type incarnationKey struct {
+	type migIdentityKey struct {
 		parentUUID string
 		gi         int
 		ci         int
@@ -539,7 +549,7 @@ func rebuildHealthPlacementsFromCheckpoint(registry devicePlacementRegistry, res
 	}
 
 	var placements []placement
-	owners := make(map[incarnationKey]string)
+	owners := make(map[migIdentityKey]string)
 	for claimUID, pc := range cp.V2.PreparedClaims {
 		if pc.CheckpointState != ClaimCheckpointStatePrepareCompleted {
 			continue
@@ -570,12 +580,12 @@ func rebuildHealthPlacementsFromCheckpoint(registry devicePlacementRegistry, res
 					return fmt.Errorf("live MIG device for completed claim %s (%s) is missing",
 						claimUID, pd.Mig.Device.DeviceName)
 				}
-				if err := validateMigIncarnation(pd.Mig.Concrete, live); err != nil {
+				if err := validateMigIdentity(pd.Mig.Concrete, live); err != nil {
 					return fmt.Errorf("completed claim %s (%s): %w",
 						claimUID, pd.Mig.Device.DeviceName, err)
 				}
 
-				key := incarnationKey{live.ParentUUID, live.GIID, live.CIID, live.MigUUID}
+				key := migIdentityKey{live.ParentUUID, live.GIID, live.CIID, live.MigUUID}
 				if owner, exists := owners[key]; exists {
 					return fmt.Errorf("completed claims %s and %s resolve to the same live MIG device %s at parentUUID=%s GI=%d CI=%d",
 						owner, claimUID, live.MigUUID, live.ParentUUID, live.GIID, live.CIID)
@@ -597,16 +607,18 @@ func rebuildHealthPlacementsFromCheckpoint(registry devicePlacementRegistry, res
 	return nil
 }
 
-func validateMigIncarnation(expected, live *MigLiveTuple) error {
+// validateMigIdentity requires the live device to match the checkpoint's
+// physical parent, GI, CI, and MIG UUID exactly.
+func validateMigIdentity(expected, live *MigLiveTuple) error {
 	if expected == nil || live == nil {
-		return fmt.Errorf("cannot validate nil MIG incarnation (expected=%v live=%v)", expected != nil, live != nil)
+		return fmt.Errorf("cannot validate nil MIG identity (expected=%v live=%v)", expected != nil, live != nil)
 	}
 	if expected.ParentUUID != live.ParentUUID ||
 		expected.GIID != live.GIID ||
 		expected.CIID != live.CIID ||
 		expected.MigUUID != live.MigUUID {
 		return fmt.Errorf(
-			"MIG incarnation mismatch: expected parentUUID=%s GI=%d CI=%d migUUID=%s, got parentUUID=%s GI=%d CI=%d migUUID=%s",
+			"MIG identity mismatch: expected parentUUID=%s GI=%d CI=%d migUUID=%s, got parentUUID=%s GI=%d CI=%d migUUID=%s",
 			expected.ParentUUID, expected.GIID, expected.CIID, expected.MigUUID,
 			live.ParentUUID, live.GIID, live.CIID, live.MigUUID,
 		)

--- a/cmd/gpu-kubelet-plugin/device_health.go
+++ b/cmd/gpu-kubelet-plugin/device_health.go
@@ -100,6 +100,19 @@ func healthEventToTaint(monitor deviceHealthMonitor, event *DeviceHealthEvent) *
 // For a full device the returned 3-tuple is the device's uuid and (FullGPUInstanceID) 0xFFFFFFFF for the other two elements.
 type devicePlacementMap map[string]map[uint32]map[uint32]*AllocatableDevice
 
+// devicePlacementRegistry tracks live (parentUUID, GI, CI) -> allocatable device
+// mappings for dynamically created MIG partitions. Static MIG and full GPU
+// entries are populated at monitor startup; dynamic MIG entries are added and
+// removed at prepare/unprepare time.
+type devicePlacementRegistry interface {
+	RegisterDevicePlacement(parentUUID string, gi, ci uint32, dev *AllocatableDevice)
+	UnregisterDevicePlacement(parentUUID string, gi, ci uint32)
+}
+
+type migDeviceResolver interface {
+	FindMigDevBySpec(*MigSpecTuple) (*MigLiveTuple, error)
+}
+
 type nvmlDeviceHealthMonitor struct {
 	nvmllib           nvml.Interface
 	eventSet          nvml.EventSet
@@ -107,6 +120,11 @@ type nvmlDeviceHealthMonitor struct {
 	deviceByPlacement devicePlacementMap
 	skippedXids       map[uint64]bool
 	wg                sync.WaitGroup
+	placementMu       sync.RWMutex
+	// allocatableByParent is the immutable inventory of all advertised devices
+	// grouped by physical GPU. Unlike deviceByPlacement, it includes dynamic MIG
+	// devices which have not yet been prepared.
+	allocatableByParent map[string][]*AllocatableDevice
 }
 
 func newNvmlDeviceHealthMonitor(config *Config, perGPUAllocatable *PerGPUAllocatableDevices, nvdevlib *deviceLib) (*nvmlDeviceHealthMonitor, error) {
@@ -124,16 +142,18 @@ func newNvmlDeviceHealthMonitor(config *Config, perGPUAllocatable *PerGPUAllocat
 		return nil, fmt.Errorf("perGPUAllocatable is nil")
 	}
 	all := perGPUAllocatable.GetAllDevices()
+	placementMap := getDevicePlacementMap(all)
 	m := &nvmlDeviceHealthMonitor{
-		nvmllib:           nvdevlib.nvmllib,
-		unhealthy:         make(chan *DeviceHealthEvent, len(all)),
-		deviceByPlacement: getDevicePlacementMap(all),
-		skippedXids:       xidsToSkip(config.flags.additionalXidsToIgnore),
+		nvmllib:             nvdevlib.nvmllib,
+		unhealthy:           make(chan *DeviceHealthEvent, len(all)),
+		deviceByPlacement:   placementMap,
+		allocatableByParent: getAllocatableByParent(all),
+		skippedXids:         xidsToSkip(config.flags.additionalXidsToIgnore),
 	}
 	return m, nil
 }
 
-func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
+func (m *nvmlDeviceHealthMonitor) RegisterEvents() (rerr error) {
 	if ret := m.nvmllib.Init(); ret != nvml.SUCCESS {
 		return fmt.Errorf("failed to initialize NVML: %v", ret)
 	}
@@ -154,7 +174,13 @@ func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
 
 	klog.V(4).Info("registering NVML events for device health monitor")
 	m.registerEventsForDevices()
+	return nil
+}
 
+func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) error {
+	if m.eventSet == nil {
+		return fmt.Errorf("NVML events have not been registered")
+	}
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
@@ -165,31 +191,35 @@ func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
 	return nil
 }
 
+// registerEventsForDevices registers NVML events once per physical GPU. NVML
+// (XID) events are delivered at the physical-GPU level (with GI/CI fields on
+// the event for MIG), so registration is on the parent GPU handle and covers
+// all of its (static or dynamic) partitions.
 func (m *nvmlDeviceHealthMonitor) registerEventsForDevices() {
 	eventMask := uint64(nvml.EventTypeXidCriticalError | nvml.EventTypeDoubleBitEccError | nvml.EventTypeSingleBitEccError)
 
-	for parentUUID, giMap := range m.deviceByPlacement {
+	for parentUUID, devices := range m.allocatableByParent {
 		gpu, ret := m.nvmllib.DeviceGetHandleByUUID(parentUUID)
 		if ret != nvml.SUCCESS {
 			klog.Warningf("Unable to get device handle from UUID[%s]: %v; marking devices as unmonitored", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			m.sendBatchedHealthEvent(devices, HealthEventUnmonitored)
 			continue
 		}
 
 		supportedEvents, ret := gpu.GetSupportedEventTypes()
 		if ret != nvml.SUCCESS {
 			klog.Warningf("unable to determine the supported events for %s: %v; marking devices as unmonitored", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			m.sendBatchedHealthEvent(devices, HealthEventUnmonitored)
 			continue
 		}
 
 		ret = gpu.RegisterEvents(eventMask&supportedEvents, m.eventSet)
 		if ret == nvml.ERROR_NOT_SUPPORTED {
 			klog.Warningf("Device %v is too old to support healthchecking.", parentUUID)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			m.sendBatchedHealthEvent(devices, HealthEventUnmonitored)
 		} else if ret != nvml.SUCCESS {
 			klog.Warningf("unable to register events for %s: %v; marking devices as unmonitored", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			m.sendBatchedHealthEvent(devices, HealthEventUnmonitored)
 		}
 	}
 }
@@ -255,13 +285,13 @@ func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
 				m.sendHealthEventForAllDevices(HealthEventGPULost)
 				continue
 			}
-			affectedDevice := m.deviceByPlacement.get(eventUUID, gi, ci)
+			affectedDevice := m.lookupDevicePlacement(eventUUID, gi, ci)
 			if affectedDevice == nil {
 				klog.V(6).Infof("Ignoring event for unexpected device (UUID:%s, GI:%d, CI:%d)", eventUUID, gi, ci)
 				continue
 			}
 
-			klog.V(4).Infof("Sending XID=%d health event for device %s", xid, affectedDevice.UUID())
+			klog.V(4).Infof("Sending XID=%d health event for device %s", xid, affectedDevice.CanonicalName())
 			m.unhealthy <- &DeviceHealthEvent{
 				Devices:   []*AllocatableDevice{affectedDevice},
 				EventType: HealthEventXID,
@@ -280,45 +310,21 @@ func (m *nvmlDeviceHealthMonitor) Unhealthy() <-chan *DeviceHealthEvent {
 // update.
 func (m *nvmlDeviceHealthMonitor) sendHealthEventForAllDevices(eventType DeviceHealthEventType) {
 	var devices []*AllocatableDevice
-	for _, giMap := range m.deviceByPlacement {
-		devices = append(devices, flattenMIGDeviceMap(giMap)...)
+	for _, parentDevices := range m.allocatableByParent {
+		devices = append(devices, parentDevices...)
 	}
 	m.sendBatchedHealthEvent(devices, eventType)
 }
 
-// sendHealthEventForDevices aggregates all devices under a single parent GPU
-// into one batched DeviceHealthEvent.
-func (m *nvmlDeviceHealthMonitor) sendHealthEventForDevices(giMap map[uint32]map[uint32]*AllocatableDevice, eventType DeviceHealthEventType) {
-	m.sendBatchedHealthEvent(flattenMIGDeviceMap(giMap), eventType)
-}
-
-// flattenMIGDeviceMap flattens a GI→CI device map into a slice.
-func flattenMIGDeviceMap(giMap map[uint32]map[uint32]*AllocatableDevice) []*AllocatableDevice {
-	var devices []*AllocatableDevice
-	for _, ciMap := range giMap {
-		for _, dev := range ciMap {
-			devices = append(devices, dev)
-		}
-	}
-	return devices
-}
-
 // sendBatchedHealthEvent sends a single DeviceHealthEvent containing all
-// affected devices. Uses a non-blocking send to protect the monitor goroutine
-// from deadlocks when the channel is full.
+// affected devices.
 func (m *nvmlDeviceHealthMonitor) sendBatchedHealthEvent(devices []*AllocatableDevice, eventType DeviceHealthEventType) {
 	if len(devices) == 0 {
 		return
 	}
-	event := &DeviceHealthEvent{
+	m.unhealthy <- &DeviceHealthEvent{
 		Devices:   devices,
 		EventType: eventType,
-	}
-	select {
-	case m.unhealthy <- event:
-		klog.V(6).Infof("Sent batched %s health event for %d device(s)", eventType, len(devices))
-	default:
-		klog.Errorf("Health event channel full; dropping batched %s event for %d device(s)", eventType, len(devices))
 	}
 }
 
@@ -446,4 +452,164 @@ func (m *nvmlDeviceHealthMonitor) IsEventNonFatal(event *DeviceHealthEvent) bool
 		return m.skippedXids[event.EventData]
 	}
 	return false
+}
+
+func getAllocatableByParent(allocatable AllocatableDevices) map[string][]*AllocatableDevice {
+	byParent := make(map[string][]*AllocatableDevice)
+	for _, d := range allocatable {
+		var parentUUID string
+		switch d.Type() {
+		case GpuDeviceType:
+			parentUUID = d.Gpu.UUID
+		case MigStaticDeviceType:
+			parentUUID = d.MigStatic.parent.UUID
+		case MigDynamicDeviceType:
+			parentUUID = d.MigDynamic.Parent.UUID
+		default:
+			continue
+		}
+		if parentUUID == "" {
+			continue
+		}
+		byParent[parentUUID] = append(byParent[parentUUID], d)
+	}
+	return byParent
+}
+
+func (m *nvmlDeviceHealthMonitor) RegisterDevicePlacement(parentUUID string, gi, ci uint32, dev *AllocatableDevice) {
+	if m == nil || dev == nil || parentUUID == "" {
+		return
+	}
+	m.placementMu.Lock()
+	defer m.placementMu.Unlock()
+	m.deviceByPlacement.addDevice(parentUUID, gi, ci, dev)
+}
+
+func (m *nvmlDeviceHealthMonitor) UnregisterDevicePlacement(parentUUID string, gi, ci uint32) {
+	if m == nil || parentUUID == "" {
+		return
+	}
+	m.placementMu.Lock()
+	defer m.placementMu.Unlock()
+	giMap, ok := m.deviceByPlacement[parentUUID]
+	if !ok {
+		return
+	}
+	ciMap, ok := giMap[gi]
+	if !ok {
+		return
+	}
+	delete(ciMap, ci)
+	if len(ciMap) == 0 {
+		delete(giMap, gi)
+	}
+	if len(giMap) == 0 {
+		delete(m.deviceByPlacement, parentUUID)
+	}
+}
+
+func (m *nvmlDeviceHealthMonitor) lookupDevicePlacement(parentUUID string, gi, ci uint32) *AllocatableDevice {
+	m.placementMu.RLock()
+	defer m.placementMu.RUnlock()
+	return m.deviceByPlacement.get(parentUUID, gi, ci)
+}
+
+func rebuildHealthPlacementsFromCheckpoint(registry devicePlacementRegistry, resolver migDeviceResolver, perGPU *PerGPUAllocatableDevices, cp *Checkpoint) error {
+	if registry == nil || cp == nil || cp.V2 == nil {
+		return nil
+	}
+	if resolver == nil {
+		return fmt.Errorf("MIG device resolver is nil")
+	}
+	if perGPU == nil {
+		return fmt.Errorf("per-GPU allocatable device inventory is nil")
+	}
+
+	type placement struct {
+		parentUUID string
+		gi         uint32
+		ci         uint32
+		device     *AllocatableDevice
+	}
+	type incarnationKey struct {
+		parentUUID string
+		gi         int
+		ci         int
+		migUUID    string
+	}
+
+	var placements []placement
+	owners := make(map[incarnationKey]string)
+	for claimUID, pc := range cp.V2.PreparedClaims {
+		if pc.CheckpointState != ClaimCheckpointStatePrepareCompleted {
+			continue
+		}
+		for _, group := range pc.PreparedDevices {
+			for _, pd := range group.Devices {
+				if pd.Mig == nil {
+					continue
+				}
+				if pd.Mig.Concrete == nil || pd.Mig.Device == nil {
+					return fmt.Errorf("completed claim %s has incomplete MIG checkpoint data", claimUID)
+				}
+				allocatable := perGPU.GetAllocatableDevice(DeviceName(pd.Mig.Device.DeviceName))
+				if allocatable == nil {
+					return fmt.Errorf("completed claim %s references device %s but no allocatable device was found",
+						claimUID, pd.Mig.Device.DeviceName)
+				}
+				if allocatable.Type() != MigDynamicDeviceType {
+					continue
+				}
+
+				live, err := resolver.FindMigDevBySpec(allocatable.MigDynamic.Tuple())
+				if err != nil {
+					return fmt.Errorf("resolve live MIG device for completed claim %s (%s): %w",
+						claimUID, pd.Mig.Device.DeviceName, err)
+				}
+				if live == nil {
+					return fmt.Errorf("live MIG device for completed claim %s (%s) is missing",
+						claimUID, pd.Mig.Device.DeviceName)
+				}
+				if err := validateMigIncarnation(pd.Mig.Concrete, live); err != nil {
+					return fmt.Errorf("completed claim %s (%s): %w",
+						claimUID, pd.Mig.Device.DeviceName, err)
+				}
+
+				key := incarnationKey{live.ParentUUID, live.GIID, live.CIID, live.MigUUID}
+				if owner, exists := owners[key]; exists {
+					return fmt.Errorf("completed claims %s and %s resolve to the same live MIG device %s at parentUUID=%s GI=%d CI=%d",
+						owner, claimUID, live.MigUUID, live.ParentUUID, live.GIID, live.CIID)
+				}
+				owners[key] = claimUID
+				placements = append(placements, placement{
+					parentUUID: live.ParentUUID,
+					gi:         uint32(live.GIID),
+					ci:         uint32(live.CIID),
+					device:     allocatable,
+				})
+			}
+		}
+	}
+
+	for _, p := range placements {
+		registry.RegisterDevicePlacement(p.parentUUID, p.gi, p.ci, p.device)
+	}
+	return nil
+}
+
+func validateMigIncarnation(expected, live *MigLiveTuple) error {
+	if expected == nil || live == nil {
+		return fmt.Errorf("cannot validate nil MIG incarnation (expected=%v live=%v)", expected != nil, live != nil)
+	}
+	if expected.ParentUUID != live.ParentUUID ||
+		expected.GIID != live.GIID ||
+		expected.CIID != live.CIID ||
+		expected.MigUUID != live.MigUUID {
+		return fmt.Errorf(
+			"MIG incarnation mismatch: expected parentUUID=%s GI=%d CI=%d migUUID=%s, got parentUUID=%s GI=%d CI=%d migUUID=%s",
+			expected.ParentUUID, expected.GIID, expected.CIID, expected.MigUUID,
+			live.ParentUUID, live.GIID, live.CIID, live.MigUUID,
+		)
+	}
+	return nil
 }

--- a/cmd/gpu-kubelet-plugin/device_health_test.go
+++ b/cmd/gpu-kubelet-plugin/device_health_test.go
@@ -18,8 +18,11 @@ package main
 
 import (
 	"context"
+	"strconv"
+	"sync"
 	"testing"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	resourceapi "k8s.io/api/resource/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +32,63 @@ import (
 // mockHealthMonitor implements deviceHealthMonitor for testing healthEventToTaint.
 type mockHealthMonitor struct {
 	nonFatalXids map[uint64]bool
+}
+
+type fakeMigDeviceResolver struct {
+	live      *MigLiveTuple
+	err       error
+	requested []*MigSpecTuple
+}
+
+type fakeHealthEventSet struct {
+	nvml.EventSet
+}
+
+type fakeHealthDevice struct {
+	nvml.Device
+	registerCalls int
+}
+
+func (d *fakeHealthDevice) GetSupportedEventTypes() (uint64, nvml.Return) {
+	return uint64(nvml.EventTypeXidCriticalError), nvml.SUCCESS
+}
+
+func (d *fakeHealthDevice) RegisterEvents(_ uint64, _ nvml.EventSet) nvml.Return {
+	d.registerCalls++
+	return nvml.SUCCESS
+}
+
+type fakeHealthNVML struct {
+	nvml.Interface
+	device         nvml.Device
+	eventSet       nvml.EventSet
+	initCalls      int
+	eventSetCalls  int
+	deviceGetCalls int
+}
+
+func (l *fakeHealthNVML) Init() nvml.Return {
+	l.initCalls++
+	return nvml.SUCCESS
+}
+
+func (l *fakeHealthNVML) Shutdown() nvml.Return {
+	return nvml.SUCCESS
+}
+
+func (l *fakeHealthNVML) EventSetCreate() (nvml.EventSet, nvml.Return) {
+	l.eventSetCalls++
+	return l.eventSet, nvml.SUCCESS
+}
+
+func (l *fakeHealthNVML) DeviceGetHandleByUUID(_ string) (nvml.Device, nvml.Return) {
+	l.deviceGetCalls++
+	return l.device, nvml.SUCCESS
+}
+
+func (r *fakeMigDeviceResolver) FindMigDevBySpec(spec *MigSpecTuple) (*MigLiveTuple, error) {
+	r.requested = append(r.requested, spec)
+	return r.live, r.err
 }
 
 func (m *mockHealthMonitor) Start(context.Context) error          { return nil }
@@ -142,6 +202,30 @@ func TestAddOrUpdateTaint_TimeAddedResetOnChange(t *testing.T) {
 	})
 
 	assert.Nil(t, dev.Taints()[0].TimeAdded, "TimeAdded should be nil so the API server sets a fresh timestamp")
+}
+
+func TestTaintsConcurrentReadWrite(t *testing.T) {
+	dev := &AllocatableDevice{}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range 1000 {
+			dev.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+				Key:    TaintKeyXID,
+				Value:  strconv.Itoa(i),
+				Effect: resourceapi.DeviceTaintEffectNoSchedule,
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			_ = dev.Taints()
+		}
+	}()
+	wg.Wait()
+	require.Len(t, dev.Taints(), 1)
 }
 
 func TestHealthEventToTaint(t *testing.T) {
@@ -283,4 +367,233 @@ func TestIsEventNonFatal(t *testing.T) {
 			assert.Equal(t, tc.expected, m.IsEventNonFatal(tc.event))
 		})
 	}
+}
+
+func TestRegisterUnregisterDevicePlacement(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0}
+	dynamicDev := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent}}
+	m := &nvmlDeviceHealthMonitor{deviceByPlacement: make(devicePlacementMap)}
+
+	m.RegisterDevicePlacement(parent.UUID, 3, 4, dynamicDev)
+	require.Equal(t, dynamicDev, m.lookupDevicePlacement(parent.UUID, 3, 4))
+	m.UnregisterDevicePlacement(parent.UUID, 3, 4)
+	require.Nil(t, m.lookupDevicePlacement(parent.UUID, 3, 4))
+}
+
+func TestGetDevicePlacementMapPreservesStaticMIGRouting(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0}
+	fullGPU := &AllocatableDevice{Gpu: parent}
+	staticMIG := &AllocatableDevice{
+		MigStatic: &MigDeviceInfo{
+			parent: parent,
+			gIInfo: &nvml.GpuInstanceInfo{Id: 3},
+			cIInfo: &nvml.ComputeInstanceInfo{Id: 4},
+		},
+	}
+
+	placements := getDevicePlacementMap(AllocatableDevices{
+		"gpu":    fullGPU,
+		"static": staticMIG,
+	})
+
+	require.Equal(t, fullGPU, placements.get(parent.UUID, FullGPUInstanceID, FullGPUInstanceID))
+	require.Equal(t, staticMIG, placements.get(parent.UUID, 3, 4))
+}
+
+func TestHealthMonitorStartRequiresRegisteredEvents(t *testing.T) {
+	m := &nvmlDeviceHealthMonitor{}
+	require.ErrorContains(t, m.Start(context.Background()), "events have not been registered")
+}
+
+func TestRegisterEventsRegistersEachParentBeforeStart(t *testing.T) {
+	device := &fakeHealthDevice{}
+	eventSet := &fakeHealthEventSet{}
+	nvmllib := &fakeHealthNVML{device: device, eventSet: eventSet}
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0}
+	m := &nvmlDeviceHealthMonitor{
+		nvmllib:   nvmllib,
+		unhealthy: make(chan *DeviceHealthEvent, 1),
+		allocatableByParent: map[string][]*AllocatableDevice{
+			parent.UUID: {&AllocatableDevice{Gpu: parent}},
+		},
+	}
+
+	require.NoError(t, m.RegisterEvents())
+	require.Equal(t, eventSet, m.eventSet)
+	require.Equal(t, 1, nvmllib.initCalls)
+	require.Equal(t, 1, nvmllib.eventSetCalls)
+	require.Equal(t, 1, nvmllib.deviceGetCalls)
+	require.Equal(t, 1, device.registerCalls)
+}
+
+func TestRegisterHealthPlacementWithoutRegistryIsNoop(t *testing.T) {
+	state := &DeviceState{}
+	require.NotPanics(t, func() {
+		state.registerHealthPlacement("GPU-parent-1", 3, 4, &AllocatableDevice{})
+	})
+}
+
+func TestRebuildHealthPlacementsFromCheckpoint(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0, pciBusID: "0000:01:00.0"}
+	dynamicDev := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent}}
+	perGPU := &PerGPUAllocatableDevices{
+		allocatablesMap: map[PCIBusID]AllocatableDevices{
+			parent.pciBusID: {"dynamic-1": dynamicDev},
+		},
+	}
+	expected := &MigLiveTuple{ParentUUID: parent.UUID, GIID: 3, CIID: 4, MigUUID: "MIG-1"}
+	cp := checkpointWithDynamicMIGClaims(expected, "dynamic-1", "claim-1")
+	resolver := &fakeMigDeviceResolver{live: expected}
+	m := &nvmlDeviceHealthMonitor{deviceByPlacement: make(devicePlacementMap)}
+
+	err := rebuildHealthPlacementsFromCheckpoint(m, resolver, perGPU, cp)
+
+	require.NoError(t, err)
+	require.Len(t, resolver.requested, 1)
+	assert.Equal(t, dynamicDev.MigDynamic.Tuple(), resolver.requested[0])
+	require.Equal(t, dynamicDev, m.lookupDevicePlacement(parent.UUID, 3, 4))
+}
+
+func TestValidateMigIdentity(t *testing.T) {
+	expected := &MigLiveTuple{ParentUUID: "GPU-parent-1", GIID: 3, CIID: 4, MigUUID: "MIG-1"}
+	tests := []struct {
+		name string
+		live *MigLiveTuple
+	}{
+		{name: "parent UUID mismatch", live: &MigLiveTuple{ParentUUID: "GPU-parent-2", GIID: 3, CIID: 4, MigUUID: "MIG-1"}},
+		{name: "GI mismatch", live: &MigLiveTuple{ParentUUID: "GPU-parent-1", GIID: 5, CIID: 4, MigUUID: "MIG-1"}},
+		{name: "CI mismatch", live: &MigLiveTuple{ParentUUID: "GPU-parent-1", GIID: 3, CIID: 5, MigUUID: "MIG-1"}},
+		{name: "MIG UUID mismatch", live: &MigLiveTuple{ParentUUID: "GPU-parent-1", GIID: 3, CIID: 4, MigUUID: "MIG-2"}},
+	}
+
+	require.NoError(t, validateMigIdentity(expected, expected))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.ErrorContains(t, validateMigIdentity(expected, tc.live), "MIG identity mismatch")
+		})
+	}
+}
+
+func TestRebuildHealthPlacementsRejectsInvalidState(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0, pciBusID: "0000:01:00.0"}
+	dynamicDev := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent}}
+	perGPU := &PerGPUAllocatableDevices{
+		allocatablesMap: map[PCIBusID]AllocatableDevices{
+			parent.pciBusID: {"dynamic-1": dynamicDev},
+		},
+	}
+	expected := &MigLiveTuple{ParentUUID: parent.UUID, GIID: 3, CIID: 4, MigUUID: "MIG-1"}
+
+	t.Run("missing live device", func(t *testing.T) {
+		m := &nvmlDeviceHealthMonitor{deviceByPlacement: make(devicePlacementMap)}
+		err := rebuildHealthPlacementsFromCheckpoint(
+			m, &fakeMigDeviceResolver{}, perGPU,
+			checkpointWithDynamicMIGClaims(expected, "dynamic-1", "claim-1"),
+		)
+		require.ErrorContains(t, err, "is missing")
+		require.Nil(t, m.lookupDevicePlacement(parent.UUID, 3, 4))
+	})
+
+	t.Run("reused tuple with different UUID", func(t *testing.T) {
+		m := &nvmlDeviceHealthMonitor{deviceByPlacement: make(devicePlacementMap)}
+		replacement := *expected
+		replacement.MigUUID = "MIG-replacement"
+		err := rebuildHealthPlacementsFromCheckpoint(
+			m, &fakeMigDeviceResolver{live: &replacement}, perGPU,
+			checkpointWithDynamicMIGClaims(expected, "dynamic-1", "claim-1"),
+		)
+		require.ErrorContains(t, err, "MIG identity mismatch")
+		require.Nil(t, m.lookupDevicePlacement(parent.UUID, 3, 4))
+	})
+
+	t.Run("duplicate completed claims", func(t *testing.T) {
+		m := &nvmlDeviceHealthMonitor{deviceByPlacement: make(devicePlacementMap)}
+		err := rebuildHealthPlacementsFromCheckpoint(
+			m, &fakeMigDeviceResolver{live: expected}, perGPU,
+			checkpointWithDynamicMIGClaims(expected, "dynamic-1", "claim-1", "claim-2"),
+		)
+		require.ErrorContains(t, err, "resolve to the same live MIG device")
+		require.Nil(t, m.lookupDevicePlacement(parent.UUID, 3, 4))
+	})
+}
+
+func checkpointWithDynamicMIGClaims(concrete *MigLiveTuple, deviceName string, claimUIDs ...string) *Checkpoint {
+	claims := make(PreparedClaimsByUIDV2)
+	for _, claimUID := range claimUIDs {
+		claims[claimUID] = PreparedClaimV2{
+			CheckpointState: ClaimCheckpointStatePrepareCompleted,
+			PreparedDevices: PreparedDevices{
+				&PreparedDeviceGroup{
+					Devices: PreparedDeviceList{
+						{
+							Mig: &PreparedMigDevice{
+								Concrete: concrete,
+								Device:   &CheckpointedDevice{DeviceName: deviceName},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	return &Checkpoint{V2: &CheckpointV2{PreparedClaims: claims}}
+}
+
+func TestGetAllocatableByParent(t *testing.T) {
+	parent1 := &GpuInfo{UUID: "GPU-parent-1", minor: 0}
+	parent2 := &GpuInfo{UUID: "GPU-parent-2", minor: 1}
+	fullGPU := &AllocatableDevice{Gpu: parent1}
+	staticMIG := &AllocatableDevice{MigStatic: &MigDeviceInfo{parent: parent1}}
+	dynamic1 := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent1}}
+	dynamic2 := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent1}}
+	dynamicOnly := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent2}}
+	vfio := &AllocatableDevice{Vfio: &VfioDeviceInfo{UUID: "VFIO-1"}}
+
+	byParent := getAllocatableByParent(AllocatableDevices{
+		"gpu":          fullGPU,
+		"static":       staticMIG,
+		"dynamic-1":    dynamic1,
+		"dynamic-2":    dynamic2,
+		"dynamic-only": dynamicOnly,
+		"vfio":         vfio,
+	})
+
+	require.Len(t, byParent, 2)
+	assert.ElementsMatch(t, []*AllocatableDevice{fullGPU, staticMIG, dynamic1, dynamic2}, byParent[parent1.UUID])
+	assert.ElementsMatch(t, []*AllocatableDevice{dynamicOnly}, byParent[parent2.UUID])
+}
+
+func TestSendHealthEventForAllDevicesWhilePlacementsChange(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0}
+	fullGPU := &AllocatableDevice{Gpu: parent}
+	liveDynamic := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent}}
+	uninstantiatedDynamic := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent}}
+	all := AllocatableDevices{
+		"gpu":            fullGPU,
+		"live":           liveDynamic,
+		"uninstantiated": uninstantiatedDynamic,
+	}
+	m := &nvmlDeviceHealthMonitor{
+		unhealthy:           make(chan *DeviceHealthEvent, 1),
+		deviceByPlacement:   make(devicePlacementMap),
+		allocatableByParent: getAllocatableByParent(all),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			m.RegisterDevicePlacement(parent.UUID, 3, 4, liveDynamic)
+			m.UnregisterDevicePlacement(parent.UUID, 3, 4)
+		}
+	}()
+
+	for range 100 {
+		m.sendHealthEventForAllDevices(HealthEventGPULost)
+		event := <-m.unhealthy
+		assert.Equal(t, HealthEventGPULost, event.EventType)
+		assert.ElementsMatch(t, []*AllocatableDevice{fullGPU, liveDynamic, uninstantiatedDynamic}, event.Devices)
+	}
+	wg.Wait()
 }

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -79,6 +79,8 @@ type DeviceState struct {
 	nvdevlib          *deviceLib
 	checkpointManager checkpointmanager.CheckpointManager
 
+	healthPlacementRegistry devicePlacementRegistry
+
 	// Checkpoint read/write lock, file-based for multi-process synchronization.
 	cplock *flock.Flock
 }
@@ -877,6 +879,8 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 					Concrete: migdev.LiveTuple(),
 					Device:   device,
 				}
+				lt := migdev.LiveTuple()
+				s.registerHealthPlacement(lt.ParentUUID, lt.GIID, lt.CIID, allocatableDevice)
 			case VfioDeviceType:
 				preparedDevice.Vfio = &PreparedVfioDevice{
 					Info:   allocatableDevice.Vfio,
@@ -931,6 +935,7 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, dev
 						klog.Warningf("Error deleting MIG device %s: %s", device.Mig.Device.DeviceName, err)
 						return fmt.Errorf("error deleting MIG device %s: %w", device.Mig.Device.DeviceName, err)
 					}
+					s.unregisterHealthPlacement(mig)
 				} else {
 					klog.V(4).Infof("Unprepare: static MIG: noop (MIG %s)", device.Mig.Concrete.MigUUID)
 				}
@@ -1284,6 +1289,7 @@ func (s *DeviceState) deleteMigDevIfExistsAndNotUsedByCompletedClaim(ms *MigSpec
 	if err := s.nvdevlib.deleteMigDevice(mlt); err != nil {
 		return fmt.Errorf("MIG device deletion failed: %w", err)
 	}
+	s.unregisterHealthPlacement(mlt)
 
 	return nil
 }
@@ -1317,6 +1323,29 @@ func syncPreparedDevicesGaugeFromCheckpoint(nodeName string, cp *Checkpoint) {
 			drametrics.SetPreparedDevicesCounts(nodeName, DriverName, dt, count)
 		}
 	}
+}
+
+func (s *DeviceState) SetHealthPlacementRegistry(registry devicePlacementRegistry) {
+	s.healthPlacementRegistry = registry
+	klog.V(2).Infof("health: placement registry ready")
+}
+
+func (s *DeviceState) registerHealthPlacement(parentUUID string, gi, ci int, dev *AllocatableDevice) {
+	if s.healthPlacementRegistry == nil {
+		return
+	}
+	if dev == nil || parentUUID == "" {
+		klog.Warningf("health: placement registration skipped (dev=%v parentUUID=%q)", dev != nil, parentUUID)
+		return
+	}
+	s.healthPlacementRegistry.RegisterDevicePlacement(parentUUID, uint32(gi), uint32(ci), dev)
+}
+
+func (s *DeviceState) unregisterHealthPlacement(concrete *MigLiveTuple) {
+	if s.healthPlacementRegistry == nil || concrete == nil || concrete.ParentUUID == "" {
+		return
+	}
+	s.healthPlacementRegistry.UnregisterDevicePlacement(concrete.ParentUUID, uint32(concrete.GIID), uint32(concrete.CIID))
 }
 
 // AddDeviceTaint adds or updates a DRA device taint on the given device under

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -128,6 +128,38 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		useSplitResourceSlices: useSplitSlices,
 	}
 
+	// Create the health monitor and wire the placement registry before
+	// kubeletplugin.Start(). Start() brings the Prepare/Unprepare gRPC server
+	// online immediately; if a Prepare runs before the registry is set, dynamic
+	// MIG placements are silently dropped and XID events are ignored.
+	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
+		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
+		}
+		driver.deviceHealthMonitor = deviceHealthMonitor
+		state.SetHealthPlacementRegistry(deviceHealthMonitor)
+
+		// Restore concrete dynamic MIG placements before either the NVML event
+		// loop or the kubelet Prepare/Unprepare server can observe them.
+		if featuregates.Enabled(featuregates.DynamicMIG) {
+			cp, err := state.getCheckpoint(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read checkpoint for health placement rebuild: %w", err)
+			}
+			if err := rebuildHealthPlacementsFromCheckpoint(deviceHealthMonitor, state.nvdevlib, state.perGPUAllocatable, cp); err != nil {
+				return nil, fmt.Errorf("failed to rebuild health placements from checkpoint: %w", err)
+			}
+		}
+
+		// Start recording parent GPU events before the kubelet server can
+		// accept Prepare requests. NVML retains recorded events until the wait
+		// loop starts after the kubelet helper is available.
+		if err := deviceHealthMonitor.RegisterEvents(); err != nil {
+			return nil, fmt.Errorf("failed to register NVML device events: %w", err)
+		}
+	}
+
 	opts := []kubeletplugin.Option{
 		kubeletplugin.KubeClient(driver.client),
 		kubeletplugin.NodeName(config.flags.nodeName),
@@ -155,14 +187,9 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	driver.healthcheck = healthcheck
 
 	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
-		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
-		}
-		if err := deviceHealthMonitor.Start(ctx); err != nil {
+		if err := driver.deviceHealthMonitor.Start(ctx); err != nil {
 			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
 		}
-		driver.deviceHealthMonitor = deviceHealthMonitor
 
 		driver.wg.Add(1)
 		go func() {
@@ -510,7 +537,7 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
 			taint := healthEventToTaint(d.deviceHealthMonitor, event)
 			modified := false
 			for _, dev := range event.Devices {
-				klog.Warningf("Received %s health event for device %s", event.EventType, dev.UUID())
+				klog.Warningf("Received %s health event for device %s", event.EventType, dev.CanonicalName())
 				if d.state.AddDeviceTaint(dev, taint) {
 					modified = true
 				}
@@ -519,16 +546,24 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
 				continue
 			}
 
-			var resourceSlice resourceslice.Slice
-			for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
-				for _, dev := range devices {
-					d := dev.GetDevice()
-
-					taints := dev.Taints()
-					if len(taints) > 0 {
-						d.Taints = taints
+			var resources resourceslice.DriverResources
+			if featuregates.Enabled(featuregates.DynamicMIG) {
+				resources = d.GenerateDriverResources(nodeName)
+			} else {
+				var resourceSlice resourceslice.Slice
+				for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
+					for _, dev := range devices {
+						apiDev := dev.GetDevice()
+						if taints := dev.Taints(); len(taints) > 0 {
+							apiDev.Taints = taints
+						}
+						resourceSlice.Devices = append(resourceSlice.Devices, apiDev)
 					}
-					resourceSlice.Devices = append(resourceSlice.Devices, d)
+				}
+				resources = resourceslice.DriverResources{
+					Pools: map[string]resourceslice.Pool{
+						nodeName: {Slices: []resourceslice.Slice{resourceSlice}},
+					},
 				}
 			}
 
@@ -543,14 +578,8 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
 			// This is a temporary compromise while device taints/tolerations (KEP-5055)
 			// are available as a Beta feature. An interim improvement could be adding
 			// a retry/backoff or switch to patch updates instead of full republish.
-			klog.V(4).Infof("Republishing ResourceSlice: %d device(s) tainted with %s=%q (effect=%s)",
+			klog.V(2).Infof("health: republishing ResourceSlice: %d device(s) tainted with %s=%q (effect=%s)",
 				len(event.Devices), taint.Key, taint.Value, taint.Effect)
-
-			resources := resourceslice.DriverResources{
-				Pools: map[string]resourceslice.Pool{
-					nodeName: {Slices: []resourceslice.Slice{resourceSlice}},
-				},
-			}
 
 			// NOTE: GPU_LOST and unmonitored events are already batched at the
 			// sender (all affected devices arrive in a single DeviceHealthEvent).

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -1045,6 +1045,12 @@ func (l deviceLib) createMigDevice(migspec *MigSpec) (*MigDeviceInfo, error) {
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting UUID from CI info/device for CI %d: %v", ciInfo.Id, ret)
 	}
+	uuid, err = resolveCreatedMigUUID(uuid, gpu.UUID, int(giInfo.Id), int(ciInfo.Id), func() (*MigLiveTuple, error) {
+		return l.FindMigDevBySpec(migspec.Tuple())
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	// This now probably needs consolidation with the new types MigLiveTuple and
 	// MigSpecTuple. Things get confusing.
@@ -1065,6 +1071,32 @@ func (l deviceLib) createMigDevice(migspec *MigSpec) (*MigDeviceInfo, error) {
 
 	klog.V(6).Infof("%s: MIG device created on %s: %+v", logpfx, gpu.String(), migDevInfo.LiveTuple())
 	return migDevInfo, nil
+}
+
+func resolveCreatedMigUUID(candidateUUID, parentUUID string, expectedGI, expectedCI int, findLive func() (*MigLiveTuple, error)) (string, error) {
+	if candidateUUID != parentUUID {
+		return candidateUUID, nil
+	}
+
+	// Some drivers return the parent GPU handle in ComputeInstanceInfo.Device.
+	// In that case GetUUID() yields GPU-... instead of the MIG incarnation UUID.
+	// Resolve the just-created profile/placement through the existing discovery
+	// path and verify that it is the same GI/CI before checkpointing.
+	live, err := findLive()
+	if err != nil {
+		return "", fmt.Errorf("resolve UUID for newly created MIG device: %w", err)
+	}
+	if live == nil {
+		return "", fmt.Errorf("newly created MIG device was not found by profile and placement")
+	}
+	if live.GIID != expectedGI || live.CIID != expectedCI {
+		return "", fmt.Errorf("newly created MIG tuple mismatch: expected GI=%d CI=%d, got GI=%d CI=%d",
+			expectedGI, expectedCI, live.GIID, live.CIID)
+	}
+	if live.MigUUID == "" || live.MigUUID == parentUUID {
+		return "", fmt.Errorf("newly created MIG device has invalid UUID %q", live.MigUUID)
+	}
+	return live.MigUUID, nil
 }
 
 // Assume long-lived NVML session.
@@ -1114,21 +1146,6 @@ func (l deviceLib) deleteMigDevice(miglt *MigLiveTuple) error {
 	// Remainder, with `gi` actually being valid.
 	ci, cires := gi.GetComputeInstanceById(ciId)
 
-	// Here we could compare the actual MIG UUID with an expected MIG UUID,
-	// to be extra sure that this we want to proceed with deletion.
-	// ciInfo, res := ci.GetInfo()
-	// if res != nvml.SUCCESS {
-	// 	return fmt.Errorf("error calling ci.GetInfo(): %v", ret)
-	// }
-
-	// actualMigUUID, res := nvml.DeviceGetUUID(ciInfo.Device)
-	// if res != nvml.SUCCESS {
-	// 	return fmt.Errorf("nvml.DeviceGetUUID() failed: %v", ret)
-	// }
-	// if actualMigUUID != expectedMigUUID {
-	// 	return fmt.Errorf("UUID mismatch upon deletion: expected: %s actual: %s", expectedMigUUID, actualMigUUID)
-	// }
-
 	// Can never be `ERROR_NOT_SUPPORTED` at this point. Can be UNINITIALIZED,
 	// INVALID_ARGUMENT, NO_PERMISSION: for those three, it's worth erroring out
 	// here (to be retried later).
@@ -1136,11 +1153,29 @@ func (l deviceLib) deleteMigDevice(miglt *MigLiveTuple) error {
 		return fmt.Errorf("error getting Compute instance handle for MIG device %s: %v", migStr, ret)
 	}
 
-	// A previous, partial cleanup may actually have already deleted that. Seen
-	// in practice. Ignore, and proceed with deleting GPU instance below.
+	// A previous partial cleanup may already have deleted the CI. Only continue
+	// when no concrete UUID was checkpointed; a completed device with a UUID
+	// must fail closed instead of deleting a potentially reused GI tuple.
 	if cires == nvml.ERROR_NOT_FOUND {
+		if miglt.MigUUID != "" {
+			return fmt.Errorf("refusing to delete %s: expected compute instance UUID %s was not found", migStr, miglt.MigUUID)
+		}
 		klog.Infof("Delete %s: CI not found, ignore", migStr)
 	} else {
+		if miglt.MigUUID != "" {
+			ciInfo, ret := ci.GetInfo()
+			if ret != nvml.SUCCESS {
+				return fmt.Errorf("error getting Compute instance info for %s: %v", migStr, ret)
+			}
+			actualMigUUID, ret := ciInfo.Device.GetUUID()
+			if ret != nvml.SUCCESS {
+				return fmt.Errorf("error getting live MIG UUID for %s: %v", migStr, ret)
+			}
+			if actualMigUUID != miglt.MigUUID {
+				return fmt.Errorf("refusing to delete reused MIG tuple parentUUID=%s GI=%d CI=%d: expected UUID %s, got %s",
+					parentUUID, giId, ciId, miglt.MigUUID, actualMigUUID)
+			}
+		}
 		ret := ci.Destroy()
 		if ret != nvml.SUCCESS {
 			return fmt.Errorf("error destroying Compute instance: %v", ret)

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -1073,15 +1073,16 @@ func (l deviceLib) createMigDevice(migspec *MigSpec) (*MigDeviceInfo, error) {
 	return migDevInfo, nil
 }
 
+// resolveCreatedMigUUID returns the concrete MIG UUID for a newly created
+// device. If ComputeInstanceInfo.Device resolves to the physical parent GPU,
+// GetUUID returns GPU-... instead of MIG-.... In that case, fall back to
+// profile/placement discovery and verify the discovered GI and CI before
+// accepting its UUID.
 func resolveCreatedMigUUID(candidateUUID, parentUUID string, expectedGI, expectedCI int, findLive func() (*MigLiveTuple, error)) (string, error) {
 	if candidateUUID != parentUUID {
 		return candidateUUID, nil
 	}
 
-	// Some drivers return the parent GPU handle in ComputeInstanceInfo.Device.
-	// In that case GetUUID() yields GPU-... instead of the MIG incarnation UUID.
-	// Resolve the just-created profile/placement through the existing discovery
-	// path and verify that it is the same GI/CI before checkpointing.
 	live, err := findLive()
 	if err != nil {
 		return "", fmt.Errorf("resolve UUID for newly created MIG device: %w", err)

--- a/cmd/gpu-kubelet-plugin/nvlib_test.go
+++ b/cmd/gpu-kubelet-plugin/nvlib_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDeleteNVML struct {
+	nvml.Interface
+	parent nvml.Device
+}
+
+func (l *fakeDeleteNVML) InitWithFlags(uint32) nvml.Return {
+	return nvml.SUCCESS
+}
+
+func (l *fakeDeleteNVML) Shutdown() nvml.Return {
+	return nvml.SUCCESS
+}
+
+func (l *fakeDeleteNVML) DeviceGetHandleByUUID(string) (nvml.Device, nvml.Return) {
+	return l.parent, nvml.SUCCESS
+}
+
+type fakeDeleteParent struct {
+	nvml.Device
+	gi nvml.GpuInstance
+}
+
+func (d *fakeDeleteParent) GetGpuInstanceById(int) (nvml.GpuInstance, nvml.Return) {
+	return d.gi, nvml.SUCCESS
+}
+
+type fakeDeleteGI struct {
+	nvml.GpuInstance
+	ci    nvml.ComputeInstance
+	ciRet nvml.Return
+}
+
+func (g *fakeDeleteGI) GetComputeInstanceById(int) (nvml.ComputeInstance, nvml.Return) {
+	return g.ci, g.ciRet
+}
+
+type fakeDeleteCI struct {
+	nvml.ComputeInstance
+	device    nvml.Device
+	destroyed bool
+}
+
+func (c *fakeDeleteCI) GetInfo() (nvml.ComputeInstanceInfo, nvml.Return) {
+	return nvml.ComputeInstanceInfo{Device: c.device}, nvml.SUCCESS
+}
+
+func (c *fakeDeleteCI) Destroy() nvml.Return {
+	c.destroyed = true
+	return nvml.SUCCESS
+}
+
+type fakeDeleteMIGDevice struct {
+	nvml.Device
+	uuid string
+}
+
+func (d *fakeDeleteMIGDevice) GetUUID() (string, nvml.Return) {
+	return d.uuid, nvml.SUCCESS
+}
+
+func TestResolveCreatedMigUUID(t *testing.T) {
+	t.Run("direct MIG UUID", func(t *testing.T) {
+		called := false
+		uuid, err := resolveCreatedMigUUID("MIG-direct", "GPU-parent", 3, 4, func() (*MigLiveTuple, error) {
+			called = true
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "MIG-direct", uuid)
+		require.False(t, called)
+	})
+
+	t.Run("parent UUID falls back to live discovery", func(t *testing.T) {
+		uuid, err := resolveCreatedMigUUID("GPU-parent", "GPU-parent", 3, 4, func() (*MigLiveTuple, error) {
+			return &MigLiveTuple{ParentUUID: "GPU-parent", GIID: 3, CIID: 4, MigUUID: "MIG-live"}, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "MIG-live", uuid)
+	})
+
+	t.Run("fallback tuple mismatch", func(t *testing.T) {
+		_, err := resolveCreatedMigUUID("GPU-parent", "GPU-parent", 3, 4, func() (*MigLiveTuple, error) {
+			return &MigLiveTuple{ParentUUID: "GPU-parent", GIID: 7, CIID: 0, MigUUID: "MIG-other"}, nil
+		})
+		require.ErrorContains(t, err, "newly created MIG tuple mismatch")
+	})
+}
+
+func TestDeleteMigDeviceRejectsReusedTuple(t *testing.T) {
+	liveDevice := &fakeDeleteMIGDevice{uuid: "MIG-replacement"}
+	ci := &fakeDeleteCI{device: liveDevice}
+	gi := &fakeDeleteGI{ci: ci, ciRet: nvml.SUCCESS}
+	parent := &fakeDeleteParent{gi: gi}
+	lib := &deviceLib{nvmllib: &fakeDeleteNVML{parent: parent}}
+
+	err := lib.deleteMigDevice(&MigLiveTuple{
+		ParentUUID: "GPU-parent-1",
+		GIID:       3,
+		CIID:       4,
+		MigUUID:    "MIG-expected",
+	})
+
+	require.ErrorContains(t, err, "refusing to delete reused MIG tuple")
+	require.False(t, ci.destroyed)
+}
+
+func TestDeleteMigDeviceRejectsMissingExpectedCI(t *testing.T) {
+	gi := &fakeDeleteGI{ciRet: nvml.ERROR_NOT_FOUND}
+	parent := &fakeDeleteParent{gi: gi}
+	lib := &deviceLib{nvmllib: &fakeDeleteNVML{parent: parent}}
+
+	err := lib.deleteMigDevice(&MigLiveTuple{
+		ParentUUID: "GPU-parent-1",
+		GIID:       3,
+		CIID:       4,
+		MigUUID:    "MIG-expected",
+	})
+
+	require.ErrorContains(t, err, "expected compute instance UUID MIG-expected was not found")
+}

--- a/cmd/gpu-kubelet-plugin/partitions.go
+++ b/cmd/gpu-kubelet-plugin/partitions.go
@@ -215,17 +215,23 @@ func (i MigSpec) PartConsumesCounters() []resourceapi.DeviceCounterConsumption {
 
 // A variant of the legacy `GetDevice()`, for the Partitionable Devices paradigm.
 func (d *AllocatableDevice) PartGetDevice() resourceapi.Device {
+	var dev resourceapi.Device
 	switch d.Type() {
 	case GpuDeviceType:
-		return d.Gpu.PartGetDevice()
+		dev = d.Gpu.PartGetDevice()
 	case MigStaticDeviceType:
 		panic("PartGetDevice() called for MigStaticDeviceType")
 	case MigDynamicDeviceType:
-		return d.MigDynamic.PartGetDevice()
+		dev = d.MigDynamic.PartGetDevice()
 	case VfioDeviceType:
 		panic("not yet implemented")
+	default:
+		panic("unexpected type for AllocatableDevice")
 	}
-	panic("unexpected type for AllocatableDevice")
+	if taints := d.Taints(); len(taints) > 0 {
+		dev.Taints = taints
+	}
+	return dev
 }
 
 // Insert one counter for each memory slice consumed, as given by the `start`

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -202,10 +202,6 @@ func ValidateFeatureGates() error {
 		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", DynamicMIG, PassthroughSupport)
 	}
 
-	if Enabled(DynamicMIG) && Enabled(NVMLDeviceHealthCheck) {
-		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", DynamicMIG, NVMLDeviceHealthCheck)
-	}
-
 	if Enabled(DynamicMIG) && Enabled(MPSSupport) {
 		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", DynamicMIG, MPSSupport)
 	}

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -470,11 +470,10 @@ func TestValidateFeatureGates(t *testing.T) {
 			description:  "should fail when both DynamicMIG and PassthroughSupport are enabled",
 		},
 		{
-			name:         "DynamicMIG enabled with NVMLDeviceHealthCheck",
-			fgMap:        map[featuregate.Feature]bool{DynamicMIG: true, NVMLDeviceHealthCheck: true},
-			expectError:  true,
-			errorMessage: "feature gate DynamicMIG is currently mutually exclusive with NVMLDeviceHealthCheck",
-			description:  "should fail when both DynamicMIG and NVMLDeviceHealthCheck are enabled",
+			name:        "DynamicMIG enabled with NVMLDeviceHealthCheck",
+			fgMap:       map[featuregate.Feature]bool{DynamicMIG: true, NVMLDeviceHealthCheck: true},
+			expectError: false,
+			description: "should be valid: NVML health checking is supported alongside DynamicMIG",
 		},
 		{
 			name:         "DynamicMIG enabled with MPSSupport",

--- a/site/content/docs/reference/feature-gates.md
+++ b/site/content/docs/reference/feature-gates.md
@@ -47,7 +47,6 @@ The following feature gate combinations are mutually exclusive and cannot be ena
 | Combination | Reason |
 |---|---|
 | `DynamicMIG` + `PassthroughSupport` | Mutually exclusive |
-| `DynamicMIG` + `NVMLDeviceHealthCheck` | Mutually exclusive |
 | `DynamicMIG` + `MPSSupport` | Mutually exclusive |
 | `PassthroughSupport` + `NVMLDeviceHealthCheck` | Mutually exclusive |
 | `MPSSupport` + `NVMLDeviceHealthCheck` | Mutually exclusive |


### PR DESCRIPTION

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature
-->

#### What this PR does / why we need it:
Enables healthchecking of dynamically created devices

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1164

#### Special notes for your reviewer:

- This enables DynamicMIG and NVMLDeviceHealthCheck to be used together.
- NVML events are registered once on each physical parent GPU before the kubelet plugin starts accepting Prepare requests. MIG XIDs continue to use the same exact (parent UUID, GI, CI) attribution as static MIG.
- Dynamic MIG placement mappings are added during Prepare, removed during Unprepare/rollback, and restored from the node-local checkpoint after restart.
- Restart restoration preserves the existing checkpoint-as-source-of-truth contract.
- Device taint reads and writes are synchronized.

Cursor assisted with the PR.

#### Does this PR introduce a user-facing change?
Yes. DynamicMIG and NVMLDeviceHealthCheck can now be enabled together.
```release-note
Added NVML health monitoring support for Dynamic MIG devices, including DRA device taint propagation.
```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally

- [x] Tests added or updated for the change

Validated live on GH200 with:
- Dynamic MIG creation and XID 43 propagation.
- ResourceSlice taint publication.
- Plugin restart with an active prepared claim.
- Checkpoint restoration using matching parent UUID, GI, CI, and MIG UUID.
- XID propagation after restart.