### PR TITLE
[Bugfix] Roll back failed VFIO device preparation

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -67,7 +67,7 @@ type DeviceState struct {
 	cdi                      *CDIHandler
 	tsManager                *TimeSlicingManager
 	mpsManager               *MpsManager
-	vfioPciManager           *VfioPciManager
+	vfioPciManager           vfioDeviceManager
 	checkpointCleanupManager *CheckpointCleanupManager
 	config                   *Config
 
@@ -82,6 +82,13 @@ type DeviceState struct {
 	// Checkpoint read/write lock, file-based for multi-process synchronization.
 	cplock *flock.Flock
 }
+
+type vfioDeviceManager interface {
+	Configure(context.Context, *VfioDeviceInfo) error
+	Unconfigure(context.Context, *VfioDeviceInfo) error
+}
+
+const vfioRollbackTimeout = 30 * time.Second
 
 func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	containerDriverRoot := root(config.flags.containerDriverRoot)
@@ -275,7 +282,7 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	// optimized into filling the gaps).
 	if exists && preparedClaim.CheckpointState == ClaimCheckpointStatePrepareStarted {
 		klog.V(4).Infof("Claim %s already in PrepareStarted state: attempt rollback before new prepare", ResourceClaimToString(claim))
-		if err := s.unpreparePartiallyPrepairedClaim(claimUID, preparedClaim, cp); err != nil {
+		if err := s.unpreparePartiallyPrepairedClaim(ctx, claimUID, preparedClaim, cp); err != nil {
 			return nil, fmt.Errorf("unprepare failed for partially prepared claim %s failed: %w", PreparedClaimToString(&preparedClaim, claimUID), err)
 		}
 	}
@@ -299,7 +306,8 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	preparedDevices, err := s.prepareDevices(ctx, claim)
 	klog.V(6).Infof("t_prep_core %.3f s (claim %s)", time.Since(tprep0).Seconds(), ResourceClaimToString(claim))
 	if err != nil {
-		return nil, fmt.Errorf("prepare devices failed: %w", err)
+		prepareErr := fmt.Errorf("prepare devices failed: %w", err)
+		return nil, s.rollbackFailedPrepare(ctx, claimUID, claim, cp, prepareErr)
 	}
 
 	// TODO: Remove this once partitionable device support is introduced for vfio devices.
@@ -318,7 +326,8 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 
 	tccsf0 := time.Now()
 	if err := s.cdi.CreateClaimSpecFile(claimUID, preparedDevices); err != nil {
-		return nil, fmt.Errorf("unable to create CDI spec file for claim: %w", err)
+		prepareErr := fmt.Errorf("unable to create CDI spec file for claim: %w", err)
+		return nil, s.rollbackFailedPrepare(ctx, claimUID, claim, cp, prepareErr)
 	}
 	klog.V(7).Infof("t_prep_ccsf %.3f s", time.Since(tccsf0).Seconds())
 
@@ -331,12 +340,43 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		}
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to update checkpoint: %w", err)
+		prepareErr := fmt.Errorf("unable to update checkpoint: %w", err)
+		return nil, s.rollbackFailedPrepare(ctx, claimUID, claim, cp, prepareErr)
 	}
 	klog.V(6).Infof("checkpoint updated for claim %v", claimUID)
 	klog.V(7).Infof("t_prep_ucp2 %.3f s", time.Since(tucp20).Seconds())
 
 	return preparedDevices.GetDevices(), nil
+}
+
+func (s *DeviceState) rollbackFailedPrepare(ctx context.Context, claimUID string, claim *resourceapi.ResourceClaim, checkpoint *Checkpoint, prepareErr error) error {
+	rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), vfioRollbackTimeout)
+	defer cancel()
+
+	if latestCheckpoint, err := s.getCheckpoint(rollbackCtx); err == nil {
+		checkpoint = latestCheckpoint
+		if persistedClaim, exists := checkpoint.V2.PreparedClaims[claimUID]; exists && persistedClaim.CheckpointState == ClaimCheckpointStatePrepareCompleted {
+			// CreateCheckpoint may report an error after the new checkpoint became
+			// visible. Do not roll back devices acknowledged as fully prepared.
+			return prepareErr
+		}
+	}
+
+	partialClaim := PreparedClaim{
+		CheckpointState: ClaimCheckpointStatePrepareStarted,
+		Status:          claim.Status,
+		Name:            claim.Name,
+		Namespace:       claim.Namespace,
+	}
+
+	rollbackErr := s.unpreparePartiallyPrepairedClaim(rollbackCtx, claimUID, partialClaim, checkpoint)
+	if err := s.cdi.DeleteClaimSpecFile(claimUID); err != nil {
+		rollbackErr = errors.Join(rollbackErr, fmt.Errorf("error deleting CDI spec during prepare rollback: %w", err))
+	}
+	if rollbackErr != nil {
+		return errors.Join(prepareErr, fmt.Errorf("prepare rollback failed: %w", rollbackErr))
+	}
+	return prepareErr
 }
 
 // DestroyUnknownMIGDevices() relies on the checkpoint as the source of truth.
@@ -450,7 +490,7 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 
 	switch pc.CheckpointState {
 	case ClaimCheckpointStatePrepareStarted:
-		if err := s.unpreparePartiallyPrepairedClaim(claimUID, pc, checkpoint); err != nil {
+		if err := s.unpreparePartiallyPrepairedClaim(ctx, claimUID, pc, checkpoint); err != nil {
 			return fmt.Errorf("unprepare failed for partially prepared claim %s failed: %w", claimRef.String(), err)
 		}
 	case ClaimCheckpointStatePrepareCompleted:
@@ -537,11 +577,14 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 // server) or for a claim that is not stale but that _we_ are currently
 // preparing. In both cases, the `checkpoint` data is fresh enough; there is no
 // other entity that currently legitimately owns the device represented in `pc`.
-func (s *DeviceState) unpreparePartiallyPrepairedClaim(cuid string, pc PreparedClaim, checkpoint *Checkpoint) error {
-	// For now, there's nothing to do when DynamicMIG is not enabled.
+func (s *DeviceState) unpreparePartiallyPrepairedClaim(ctx context.Context, cuid string, pc PreparedClaim, checkpoint *Checkpoint) error {
+	var cleanupErr error
+	if featuregates.Enabled(featuregates.PassthroughSupport) {
+		cleanupErr = errors.Join(cleanupErr, s.rollbackCheckpointedVfioDevices(ctx, pc))
+	}
+
 	if !featuregates.Enabled(featuregates.DynamicMIG) {
-		klog.Infof("unprepare noop: preparation started but not completed for claim %s (devices: %v)", PreparedClaimToString(&pc, cuid), pc.Status.Allocation.Devices.Results)
-		return nil
+		return cleanupErr
 	}
 
 	// When DynamicMIG is enabled, try to identify an orphaned MIG device
@@ -567,11 +610,11 @@ func (s *DeviceState) unpreparePartiallyPrepairedClaim(cuid string, pc PreparedC
 
 		klog.V(1).Infof("Device %s is a MIG device, DynamicMIG mode: deleteMigDevIfExistsAndNotUsedByCompletedClaim()", devname)
 		if err := s.deleteMigDevIfExistsAndNotUsedByCompletedClaim(ms, devname, completedClaims); err != nil {
-			return fmt.Errorf("deleteMigDevIfExistsAndNotUsedByCompletedClaim failed: %w", err)
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("deleteMigDevIfExistsAndNotUsedByCompletedClaim failed: %w", err))
 		}
 	}
 
-	return nil
+	return cleanupErr
 }
 
 func (s *DeviceState) createCheckpoint(ctx context.Context, cp *Checkpoint) error {
@@ -976,6 +1019,56 @@ func (s *DeviceState) unprepareVfioDevices(ctx context.Context, devices Prepared
 	return nil
 }
 
+func (s *DeviceState) rollbackCheckpointedVfioDevices(ctx context.Context, claim PreparedClaim) error {
+	if claim.Status.Allocation == nil {
+		return nil
+	}
+
+	var devices []*AllocatableDevice
+	var lookupErr error
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		if result.Driver != DriverName {
+			continue
+		}
+		device := s.perGPUAllocatable.GetAllocatableDevice(result.Device)
+		if device == nil {
+			// A partially prepared mixed claim may contain a dynamic MIG
+			// result which is no longer present in the allocatable map. That
+			// result is handled by the DynamicMIG cleanup below and must not
+			// prevent VFIO rollback. VFIO device names are stable and can be
+			// identified even when their allocatable is unexpectedly missing.
+			if strings.HasPrefix(result.Device, "gpu-vfio-") {
+				lookupErr = errors.Join(lookupErr, fmt.Errorf("allocatable not found for VFIO device %q", result.Device))
+			}
+			continue
+		}
+		if device.Type() == VfioDeviceType {
+			devices = append(devices, device)
+		}
+	}
+
+	return errors.Join(lookupErr, s.rollbackVfioDevices(ctx, devices, true))
+}
+
+func (s *DeviceState) rollbackVfioDevices(ctx context.Context, devices []*AllocatableDevice, rediscoverSiblings bool) error {
+	rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), vfioRollbackTimeout)
+	defer cancel()
+
+	var rollbackErr error
+	for _, device := range slices.Backward(devices) {
+		if err := s.vfioPciManager.Unconfigure(rollbackCtx, device.Vfio); err != nil {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("error rolling back VFIO device %q: %w", device.CanonicalName(), err))
+			continue
+		}
+		if rediscoverSiblings {
+			if err := s.discoverSiblingAllocatables(device); err != nil {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("error rediscovering siblings for VFIO device %q: %w", device.CanonicalName(), err))
+			}
+		}
+	}
+	return rollbackErr
+}
+
 // Discover all sibling devices on the parent GPU of the given device.
 //
 // When a GPU is prepared in passthrough mode as a vfio device, the GPU may no longer be used on the nvidia driver,
@@ -1120,19 +1213,31 @@ func (s *DeviceState) applyVfioDeviceConfig(ctx context.Context, config *configa
 	}
 
 	configState.containerEdits = commonEdits
-	// Configure the vfio-pci devices.
+	var vfioDevices []*AllocatableDevice
 	for _, r := range results {
 		device := s.perGPUAllocatable.GetAllocatableDevice(r.Device)
 		if device == nil {
 			return nil, fmt.Errorf("allocatable not found for vfio device %q", r.Device)
 		}
-		err := s.vfioPciManager.Configure(ctx, device.Vfio)
-		if err != nil {
-			return nil, fmt.Errorf("error configuring vfio device %q: %w", r.Device, err)
-		}
+		vfioDevices = append(vfioDevices, device)
+	}
+	if err := s.configureVfioDevices(ctx, vfioDevices); err != nil {
+		return nil, err
 	}
 
 	return &configState, nil
+}
+
+func (s *DeviceState) configureVfioDevices(ctx context.Context, devices []*AllocatableDevice) error {
+	var configuredDevices []*AllocatableDevice
+	for _, device := range devices {
+		if err := s.vfioPciManager.Configure(ctx, device.Vfio); err != nil {
+			configureErr := fmt.Errorf("error configuring vfio device %q: %w", device.CanonicalName(), err)
+			return errors.Join(configureErr, s.rollbackVfioDevices(ctx, configuredDevices, false))
+		}
+		configuredDevices = append(configuredDevices, device)
+	}
+	return nil
 }
 
 // GetOpaqueDeviceConfigs returns an ordered list of the configs contained in possibleConfigs for this driver.

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -49,8 +49,17 @@ type VfioPciManager struct {
 	sync.Mutex
 	containerDriverRoot string
 	hostDriverRoot      string
+	pciDevicesPath      string
 	nvlib               *deviceLib
 	nvidiaEnabled       bool
+}
+
+type vfioConfigureOperations interface {
+	disableGPUPersistenceMode(string) (bool, error)
+	enableGPUPersistenceMode(string) error
+	WaitForGPUFree(context.Context, *VfioDeviceInfo) error
+	verifyDisabledVFs(string) error
+	changeDriver(string, string) error
 }
 
 func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib *deviceLib, nvidiaEnabled bool) (*VfioPciManager, error) {
@@ -65,6 +74,7 @@ func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib 
 	vm := &VfioPciManager{
 		containerDriverRoot: containerDriverRoot,
 		hostDriverRoot:      hostDriverRoot,
+		pciDevicesPath:      pciDevicesPath,
 		nvlib:               nvlib,
 		nvidiaEnabled:       nvidiaEnabled,
 	}
@@ -136,7 +146,7 @@ func (vm *VfioPciManager) verifyDisabledVFs(pciBusID string) error {
 
 // Configure binds the GPU to the vfio-pci driver.
 func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) error {
-	driver, err := getDriver(pciDevicesPath, info.PciBusID)
+	driver, err := getDriver(vm.pciDevicesPath, info.PciBusID)
 	if err != nil {
 		return fmt.Errorf("error getting driver details for GPU %q: %w", info.PciBusID, err)
 	}
@@ -164,27 +174,46 @@ func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) e
 		return fmt.Errorf("error checking if module %q is loaded: %w", info.vfioModule, err)
 	}
 
-	// Disable GPU Persistence Mode.
-	err = vm.disableGPUPersistenceMode(info.PciBusID)
+	return configureVfioDevice(ctx, info, driver, vfioDriver, vm)
+}
+
+// configureVfioDevice applies all host mutations required to prepare one VFIO
+// device. If any mutation fails, it restores the original driver and persistence
+// mode before returning the error.
+func configureVfioDevice(ctx context.Context, info *VfioDeviceInfo, originalDriver, vfioDriver string, ops vfioConfigureOperations) (rerr error) {
+	persistenceModeDisabled, err := ops.disableGPUPersistenceMode(info.PciBusID)
 	if err != nil {
 		return fmt.Errorf("error disabling persistence mode for GPU %q: %w", info.PciBusID, err)
 	}
 
-	// Wait for other GPU clients to evacuate.
-	err = vm.WaitForGPUFree(ctx, info)
-	if err != nil {
+	defer func() {
+		if rerr == nil {
+			return
+		}
+
+		var rollbackErr error
+		if err := ops.changeDriver(info.PciBusID, originalDriver); err != nil {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("error restoring driver %q for GPU %q: %w", originalDriver, info.PciBusID, err))
+		}
+		if persistenceModeDisabled {
+			if err := ops.enableGPUPersistenceMode(info.PciBusID); err != nil {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("error restoring persistence mode for GPU %q: %w", info.PciBusID, err))
+			}
+		}
+		if rollbackErr != nil {
+			rerr = errors.Join(rerr, fmt.Errorf("VFIO prepare rollback failed: %w", rollbackErr))
+		}
+	}()
+
+	if err := ops.WaitForGPUFree(ctx, info); err != nil {
 		return fmt.Errorf("error waiting for GPU %q to be free: %w", info.PciBusID, err)
 	}
 
-	// Verify SRIOV VFs are disabled on the GPU.
-	err = vm.verifyDisabledVFs(info.PciBusID)
-	if err != nil {
+	if err := ops.verifyDisabledVFs(info.PciBusID); err != nil {
 		return fmt.Errorf("error verifying disabled VFs: %w", err)
 	}
 
-	// Change the GPU driver to vfio-pci (or variant).
-	err = vm.changeDriver(info.PciBusID, vfioDriver)
-	if err != nil {
+	if err := ops.changeDriver(info.PciBusID, vfioDriver); err != nil {
 		return fmt.Errorf("error changing driver for GPU %q: %w", info.PciBusID, err)
 	}
 
@@ -224,6 +253,9 @@ func (vm *VfioPciManager) Unconfigure(ctx context.Context, info *VfioDeviceInfo)
 // Get the current driver the GPU is bound to.
 func getDriver(pciDevicesPath, pciAddress string) (string, error) {
 	driverPath, err := os.Readlink(filepath.Join(pciDevicesPath, pciAddress, "driver"))
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
 	if err != nil {
 		return "", err
 	}
@@ -233,7 +265,7 @@ func getDriver(pciDevicesPath, pciAddress string) (string, error) {
 
 // Change the driver the GPU is bound to.
 func (vm *VfioPciManager) changeDriver(pciAddress, driver string) error {
-	currentDriver, err := getDriver(pciDevicesPath, pciAddress)
+	currentDriver, err := getDriver(vm.pciDevicesPath, pciAddress)
 	if err != nil {
 		return fmt.Errorf("error getting driver details for GPU %q: %w", pciAddress, err)
 	}
@@ -243,13 +275,44 @@ func (vm *VfioPciManager) changeDriver(pciAddress, driver string) error {
 		return nil
 	}
 
-	err = vm.nvlib.nvpasst.Unbind(pciAddress)
-	if err != nil {
-		return fmt.Errorf("error unbinding GPU %q from driver %q: %w", pciAddress, currentDriver, err)
+	if currentDriver != "" {
+		err = vm.nvlib.nvpasst.Unbind(pciAddress)
+		if err != nil {
+			unbindErr := fmt.Errorf("error unbinding GPU %q from driver %q: %w", pciAddress, currentDriver, err)
+			if restoreErr := vm.restoreDriver(pciAddress, currentDriver); restoreErr != nil {
+				return errors.Join(unbindErr, fmt.Errorf("error restoring original driver after unbind failure: %w", restoreErr))
+			}
+			return unbindErr
+		}
 	}
 
 	err = vm.nvlib.nvpasst.BindToDriver(pciAddress, driver)
 	if err != nil {
+		bindErr := fmt.Errorf("error binding GPU %q to driver %q: %w", pciAddress, driver, err)
+		if currentDriver != "" {
+			if restoreErr := vm.restoreDriver(pciAddress, currentDriver); restoreErr != nil {
+				return errors.Join(bindErr, fmt.Errorf("error restoring original driver after bind failure: %w", restoreErr))
+			}
+		}
+		return bindErr
+	}
+	return nil
+}
+
+func (vm *VfioPciManager) restoreDriver(pciAddress, driver string) error {
+	currentDriver, err := getDriver(vm.pciDevicesPath, pciAddress)
+	if err != nil {
+		return fmt.Errorf("error getting driver details for GPU %q: %w", pciAddress, err)
+	}
+	if currentDriver == driver {
+		return nil
+	}
+	if currentDriver != "" {
+		if err := vm.nvlib.nvpasst.Unbind(pciAddress); err != nil {
+			return fmt.Errorf("error unbinding GPU %q from driver %q: %w", pciAddress, currentDriver, err)
+		}
+	}
+	if err := vm.nvlib.nvpasst.BindToDriver(pciAddress, driver); err != nil {
 		return fmt.Errorf("error binding GPU %q to driver %q: %w", pciAddress, driver, err)
 	}
 	return nil
@@ -265,7 +328,7 @@ func (vm *VfioPciManager) enableGPUPersistenceMode(pciAddress string) error {
 }
 
 // Disable GPU Persistence Mode.
-func (vm *VfioPciManager) disableGPUPersistenceMode(pciAddress string) error {
+func (vm *VfioPciManager) disableGPUPersistenceMode(pciAddress string) (bool, error) {
 	// Obtain a lock to serialize persistence mode operations.
 	// This is a cautious approach to avoid any NVML race conditions.
 	vm.Lock()
@@ -275,17 +338,17 @@ func (vm *VfioPciManager) disableGPUPersistenceMode(pciAddress string) error {
 	_, err := os.Stat(filepath.Join(vm.containerDriverRoot, nvidiaPersistencedSocketPath))
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("error checking if nvidia-persistenced is running: %w", err)
+			return false, fmt.Errorf("error checking if nvidia-persistenced is running: %w", err)
 		}
 		klog.V(4).Infof("nvidia-persistenced is not running; nothing to do...")
-		return nil
+		return false, nil
 	}
 
 	err = vm.nvlib.disableGPUPersistenceMode(pciAddress)
 	if err != nil {
-		return fmt.Errorf("error disabling persistence mode for GPU %q: %w", pciAddress, err)
+		return false, fmt.Errorf("error disabling persistence mode for GPU %q: %w", pciAddress, err)
 	}
-	return nil
+	return true, nil
 }
 
 // Check if the expected kernel module is loaded.

--- a/cmd/gpu-kubelet-plugin/vfio-device_test.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+type fakeVfioConfigureOperations struct {
+	calls                   []string
+	persistenceModeDisabled bool
+	disableErr              error
+	waitErr                 error
+	verifyErr               error
+	changeErrs              map[string]error
+	enableErr               error
+}
+
+func (f *fakeVfioConfigureOperations) disableGPUPersistenceMode(string) (bool, error) {
+	f.calls = append(f.calls, "disable-persistence")
+	return f.persistenceModeDisabled, f.disableErr
+}
+
+func (f *fakeVfioConfigureOperations) enableGPUPersistenceMode(string) error {
+	f.calls = append(f.calls, "enable-persistence")
+	return f.enableErr
+}
+
+func (f *fakeVfioConfigureOperations) WaitForGPUFree(context.Context, *VfioDeviceInfo) error {
+	f.calls = append(f.calls, "wait-for-free")
+	return f.waitErr
+}
+
+func (f *fakeVfioConfigureOperations) verifyDisabledVFs(string) error {
+	f.calls = append(f.calls, "verify-vfs")
+	return f.verifyErr
+}
+
+func (f *fakeVfioConfigureOperations) changeDriver(_ string, driver string) error {
+	f.calls = append(f.calls, "change-driver:"+driver)
+	return f.changeErrs[driver]
+}
+
+func TestConfigureVfioDeviceRollsBackHostMutations(t *testing.T) {
+	testCases := map[string]struct {
+		ops           *fakeVfioConfigureOperations
+		expectedCalls []string
+		errorContains []string
+	}{
+		"wait failure restores persistence mode": {
+			ops: &fakeVfioConfigureOperations{
+				persistenceModeDisabled: true,
+				waitErr:                 errors.New("GPU is busy"),
+			},
+			expectedCalls: []string{
+				"disable-persistence",
+				"wait-for-free",
+				"change-driver:nvidia",
+				"enable-persistence",
+			},
+			errorContains: []string{"GPU is busy"},
+		},
+		"driver change failure reports rollback failures": {
+			ops: &fakeVfioConfigureOperations{
+				persistenceModeDisabled: true,
+				changeErrs: map[string]error{
+					"vfio-pci": errors.New("bind failed"),
+					"nvidia":   errors.New("driver restore failed"),
+				},
+				enableErr: errors.New("persistence restore failed"),
+			},
+			expectedCalls: []string{
+				"disable-persistence",
+				"wait-for-free",
+				"verify-vfs",
+				"change-driver:vfio-pci",
+				"change-driver:nvidia",
+				"enable-persistence",
+			},
+			errorContains: []string{"bind failed", "driver restore failed", "persistence restore failed"},
+		},
+		"success keeps the prepared state": {
+			ops: &fakeVfioConfigureOperations{persistenceModeDisabled: true},
+			expectedCalls: []string{
+				"disable-persistence",
+				"wait-for-free",
+				"verify-vfs",
+				"change-driver:vfio-pci",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := configureVfioDevice(
+				context.Background(),
+				&VfioDeviceInfo{PciBusID: "0000:01:00.0"},
+				"nvidia",
+				"vfio-pci",
+				tc.ops,
+			)
+
+			if len(tc.errorContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, message := range tc.errorContains {
+					require.ErrorContains(t, err, message)
+				}
+			}
+			require.Equal(t, tc.expectedCalls, tc.ops.calls)
+		})
+	}
+}
+
+type fakeNvPassthrough struct {
+	devicePath string
+	bindErrs   map[string]error
+}
+
+func (f *fakeNvPassthrough) FindBestVFIOVariant(string) (string, error) { return "vfio_pci", nil }
+func (f *fakeNvPassthrough) BindToVFIODriver(string) error              { return nil }
+
+func (f *fakeNvPassthrough) BindToDriver(_ string, driver string) error {
+	if err := f.bindErrs[driver]; err != nil {
+		return err
+	}
+	return os.Symlink(filepath.Join("/sys/bus/pci/drivers", driver), filepath.Join(f.devicePath, "driver"))
+}
+
+func (f *fakeNvPassthrough) Unbind(string) error {
+	if err := os.Remove(filepath.Join(f.devicePath, "driver")); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func TestChangeDriverRestoresOriginalDriverAfterBindFailure(t *testing.T) {
+	const pciAddress = "0000:01:00.0"
+	pciDevicesRoot := t.TempDir()
+	devicePath := filepath.Join(pciDevicesRoot, pciAddress)
+	require.NoError(t, os.MkdirAll(devicePath, 0o755))
+	require.NoError(t, os.Symlink("/sys/bus/pci/drivers/nvidia", filepath.Join(devicePath, "driver")))
+
+	nvpasst := &fakeNvPassthrough{
+		devicePath: devicePath,
+		bindErrs: map[string]error{
+			"vfio-pci": errors.New("injected vfio bind failure"),
+		},
+	}
+	manager := &VfioPciManager{
+		pciDevicesPath: pciDevicesRoot,
+		nvlib:          &deviceLib{nvpasst: nvpasst},
+	}
+
+	err := manager.changeDriver(pciAddress, "vfio-pci")
+	require.ErrorContains(t, err, "injected vfio bind failure")
+
+	driver, driverErr := getDriver(pciDevicesRoot, pciAddress)
+	require.NoError(t, driverErr)
+	require.Equal(t, "nvidia", driver)
+}
+
+type fakeVfioDeviceManager struct {
+	configureCalls   []string
+	unconfigureCalls []string
+	configureErrs    map[string]error
+	unconfigureErrs  map[string]error
+}
+
+func (f *fakeVfioDeviceManager) Configure(_ context.Context, info *VfioDeviceInfo) error {
+	f.configureCalls = append(f.configureCalls, info.PciBusID)
+	return f.configureErrs[info.PciBusID]
+}
+
+func (f *fakeVfioDeviceManager) Unconfigure(_ context.Context, info *VfioDeviceInfo) error {
+	f.unconfigureCalls = append(f.unconfigureCalls, info.PciBusID)
+	return f.unconfigureErrs[info.PciBusID]
+}
+
+func TestConfigureVfioDevicesRollsBackPreviouslyConfiguredDevices(t *testing.T) {
+	manager := &fakeVfioDeviceManager{
+		configureErrs: map[string]error{
+			"0000:03:00.0": errors.New("injected third device failure"),
+		},
+		unconfigureErrs: map[string]error{},
+	}
+	state := &DeviceState{vfioPciManager: manager}
+
+	devices := make([]*AllocatableDevice, 3)
+	for index := range devices {
+		devices[index] = &AllocatableDevice{Vfio: &VfioDeviceInfo{
+			PciBusID: fmt.Sprintf("0000:0%d:00.0", index+1),
+			index:    index,
+		}}
+	}
+
+	err := state.configureVfioDevices(context.Background(), devices)
+	require.ErrorContains(t, err, "injected third device failure")
+	require.Equal(t, []string{"0000:01:00.0", "0000:02:00.0", "0000:03:00.0"}, manager.configureCalls)
+	require.Equal(t, []string{"0000:02:00.0", "0000:01:00.0"}, manager.unconfigureCalls)
+}
+
+func TestRollbackVfioDevicesAttemptsEveryDevice(t *testing.T) {
+	manager := &fakeVfioDeviceManager{
+		configureErrs: map[string]error{},
+		unconfigureErrs: map[string]error{
+			"0000:02:00.0": errors.New("injected rollback failure"),
+		},
+	}
+	state := &DeviceState{vfioPciManager: manager}
+	devices := []*AllocatableDevice{
+		{Vfio: &VfioDeviceInfo{PciBusID: "0000:01:00.0", index: 0}},
+		{Vfio: &VfioDeviceInfo{PciBusID: "0000:02:00.0", index: 1}},
+		{Vfio: &VfioDeviceInfo{PciBusID: "0000:03:00.0", index: 2}},
+	}
+
+	err := state.rollbackVfioDevices(context.Background(), devices, false)
+	require.ErrorContains(t, err, "injected rollback failure")
+	require.Equal(t, []string{"0000:03:00.0", "0000:02:00.0", "0000:01:00.0"}, manager.unconfigureCalls)
+}
+
+func TestRollbackCheckpointedVfioDevicesIgnoresMissingNonVfioAllocatables(t *testing.T) {
+	state := &DeviceState{
+		perGPUAllocatable: &PerGPUAllocatableDevices{allocatablesMap: map[PCIBusID]AllocatableDevices{}},
+		vfioPciManager:    &fakeVfioDeviceManager{},
+	}
+
+	claimWithResult := func(deviceName string) PreparedClaim {
+		return PreparedClaim{Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{Devices: resourceapi.DeviceAllocationResult{
+				Results: []resourceapi.DeviceRequestAllocationResult{{
+					Driver: DriverName,
+					Device: deviceName,
+				}},
+			}},
+		}}
+	}
+
+	require.NoError(t, state.rollbackCheckpointedVfioDevices(context.Background(), claimWithResult("gpu-0")))
+	require.ErrorContains(t, state.rollbackCheckpointedVfioDevices(context.Background(), claimWithResult("gpu-vfio-0")), "allocatable not found for VFIO device")
+}


### PR DESCRIPTION
Fixes #1255

## Summary

- Make each VFIO device preparation transactional: restore the original driver and persistence mode when a later step fails.
- Restore the original driver when an unbind succeeds but binding the requested VFIO driver fails.
- Roll back previously configured devices in reverse order when a multi-device prepare fails, and continue attempting rollback after an individual rollback error.
- Roll back VFIO devices and transient CDI state when CDI generation or final checkpoint persistence fails.
- Recover VFIO devices recorded in PrepareStarted checkpoints during retry and Unprepare, including when DynamicMIG is disabled.
- Preserve the original preparation error while reporting rollback failures.

## Tests

- go test ./api/... ./pkg/... ./cmd/compute-domain-controller ./cmd/compute-domain-daemon ./cmd/compute-domain-kubelet-plugin
- gofmt and git diff --check
- Added fault-injection tests for persistence rollback, driver restoration, reverse multi-device rollback, continued rollback after an error, and checkpointed VFIO lookup handling.

The full cmd/gpu-kubelet-plugin test package could not run on macOS because the vendored Kubernetes deviceattribute PCI helpers are Linux-only. The package should be verified by the Linux CI/Prow jobs.

```release-note
NONE
```