### PR TITLE
Scope issue-triage feature-gate detection to the Feature Gates field

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -19,6 +19,27 @@ jobs:
             const title = issue.title || '';
             const labelsToAdd = [];
 
+            // Extract the content of a single GitHub issue-form section by its
+            // heading. Issue forms render each field's label as a Markdown
+            // heading (e.g. "### Feature Gates (non-default settings)") followed
+            // by the user's answer, up to the next heading.
+            function getSection(markdown, heading) {
+              const lines = markdown.split(/\r?\n/);
+              const headingRegex = /^#{1,6}\s+(.*?)\s*$/;
+              let capturing = false;
+              const collected = [];
+              for (const line of lines) {
+                const match = line.match(headingRegex);
+                if (match) {
+                  if (capturing) break;
+                  if (match[1] === heading) capturing = true;
+                  continue;
+                }
+                if (capturing) collected.push(line);
+              }
+              return collected.join('\n').trim();
+            }
+
             // Component detection from issue form dropdown
             const componentMap = {
               'gpu-kubelet-plugin': 'component/gpu-kubelet-plugin',
@@ -51,8 +72,19 @@ jobs:
               'IMEXDaemonsWithDNSNames',
             ];
 
+            // Only inspect the dedicated "Feature Gates" form field, not the
+            // whole body. Otherwise gate names appearing in pasted logs or prose
+            // (e.g. the plugin's "Feature gates: map[...]" output) would wrongly
+            // trigger every feature-gate/* label. "_No response_" means the user
+            // left the field empty.
+            const featureGatesSection = getSection(body, 'Feature Gates (non-default settings)');
+            const featureGatesText =
+              featureGatesSection && featureGatesSection !== '_No response_'
+                ? featureGatesSection
+                : '';
+
             for (const gate of featureGates) {
-              if (body.includes(gate) || title.includes(gate)) {
+              if (featureGatesText.includes(gate) || title.includes(gate)) {
                 labelsToAdd.push(`feature-gate/${gate}`);
               }
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Issue Triage workflow (`.github/workflows/issue-triage.yml`) scanned the entire issue body for feature gate names. As a result, gate names that appear in pasted logs e.g. the kubelet plugin's `Feature gates: map[string]bool{...}`
startup output caused *every* matching `feature-gate/*` label to be applied, even when the reporter left the "Feature Gates (non-default settings)" field empty (`_No response_`).
This PR restricts feature-gate detection to the dedicated "Feature Gates (non-default settings)" issue-form field:
- Adds a small `getSection()` helper that extracts a single issue-form field's content by its rendered Markdown heading (up to the next heading).
- Only matches feature gates within that section (ignoring the `_No response_` placeholder). Title-based detection is preserved, so an issue titled `[Bug]: DynamicMIG: ...` still gets `feature-gate/DynamicMIG`. 
 Verified against the exact #1092 case: with the field empty and logs mentioning `ComputeDomainCliques`, `CrashOnNVLinkFabricErrors`, `DynamicMIG`, and `IMEXDaemonsWithDNSNames`, only `feature-gate/DynamicMIG` (from the title) is applied — matching how the issue was manually triaged.

#### Which issue(s) this PR is related to:

Fixes #1106

#### Special notes for your reviewer:

The triage logic lives inline in the workflow as a `github-script` step, so it isn't covered by unit tests. I validated the change by extracting the detection logic and running it against several sample issue bodies (empty field + gates in logs, gates selected in the field, gate only in title, and no feature-gates section). Only component/size detection continues to scan the full body, since those patterns are specific enough not to collide with log output.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

N/A

```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
