### PR TITLE
invalidate and surface checkpoint failure

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -150,6 +150,12 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 			klog.Infof("Found previous checkpoint: %s", c)
 			cp, err := state.getCheckpoint()
 			if err != nil {
+				// Report and invalidate a corrupt checkpoint.
+				if errors.Is(err, cperrors.CorruptCheckpointError{}) {
+					klog.Errorf("Invalidating corrupt checkpoint: %v", err)
+					common.EmitCheckpointCorruptionEvent(ctx, config.clientsets.Core, DriverName, config.flags.nodeName, os.Getenv("POD_NAME"), config.flags.namespace, err)
+					break
+				}
 				return nil, fmt.Errorf("unable to get checkpoint: %w", err)
 			}
 			storedBootID := cp.GetNodeBootID()

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -150,13 +150,18 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 			klog.Infof("Found previous checkpoint: %s", c)
 			cp, err := state.getCheckpoint()
 			if err != nil {
-				// Report and invalidate a corrupt checkpoint.
-				if errors.Is(err, cperrors.CorruptCheckpointError{}) {
-					klog.Errorf("Invalidating corrupt checkpoint: %v", err)
-					common.EmitCheckpointCorruptionEvent(ctx, config.clientsets.Core, DriverName, config.flags.nodeName, os.Getenv("POD_NAME"), config.flags.namespace, err)
-					break
+				if !common.IsCheckpointCorruptionError(err) {
+					return nil, fmt.Errorf("unable to get checkpoint: %w", err)
 				}
-				return nil, fmt.Errorf("unable to get checkpoint: %w", err)
+
+				// ComputeDomain prepares do not always create a per-claim CDI
+				// spec, so there is no reliable checkpoint-independent signal
+				// that automatic recovery is safe. Surface the corruption and
+				// preserve the existing fatal startup behavior.
+				corruption := common.DescribeCheckpointCorruption(err)
+				message := fmt.Sprintf("Corrupt checkpoint detected (%s); automatic recovery is not supported", corruption)
+				common.EmitCheckpointCorruptionEvent(ctx, config.clientsets.Core, DriverName, config.flags.nodeName, os.Getenv("POD_NAME"), config.flags.namespace, message)
+				return nil, fmt.Errorf("cannot automatically recover corrupt checkpoint: %w", err)
 			}
 			storedBootID := cp.GetNodeBootID()
 			if storedBootID == "" { //nolint:gocritic,staticcheck

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -252,6 +252,12 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		if c == DriverPluginCheckpointFileBasename {
 			cp, err := state.getCheckpoint(ctx)
 			if err != nil {
+				// Report and invalidate a corrupt checkpoint.
+				if errors.Is(err, cperrors.CorruptCheckpointError{}) {
+					klog.Errorf("Invalidating corrupt checkpoint: %v", err)
+					common.EmitCheckpointCorruptionEvent(ctx, config.clientsets.Core, DriverName, config.flags.nodeName, os.Getenv("POD_NAME"), config.flags.namespace, err)
+					break
+				}
 				return nil, fmt.Errorf("unable to get checkpoint: %w", err)
 			}
 			storedBootID := cp.GetNodeBootID()

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -252,13 +252,29 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		if c == DriverPluginCheckpointFileBasename {
 			cp, err := state.getCheckpoint(ctx)
 			if err != nil {
-				// Report and invalidate a corrupt checkpoint.
-				if errors.Is(err, cperrors.CorruptCheckpointError{}) {
-					klog.Errorf("Invalidating corrupt checkpoint: %v", err)
-					common.EmitCheckpointCorruptionEvent(ctx, config.clientsets.Core, DriverName, config.flags.nodeName, os.Getenv("POD_NAME"), config.flags.namespace, err)
-					break
+				if !common.IsCheckpointCorruptionError(err) {
+					return nil, fmt.Errorf("unable to get checkpoint: %w", err)
 				}
-				return nil, fmt.Errorf("unable to get checkpoint: %w", err)
+
+				// The checkpoint cannot be trusted.
+				// Use per-claim CDI specs as evidence of prepared claims.
+				corruption := common.DescribeCheckpointCorruption(err)
+				hasPreparedClaimSpec, checkErr := common.HasClaimCDISpec(config.flags.cdiRoot, DriverName)
+				if checkErr != nil {
+					message := fmt.Sprintf("Corrupt checkpoint detected (%s); automatic recovery blocked because per-claim CDI specs could not be inspected: %v", corruption, checkErr)
+					common.EmitCheckpointCorruptionEvent(ctx, config.clientsets.Core, DriverName, config.flags.nodeName, os.Getenv("POD_NAME"), config.flags.namespace, message)
+					return nil, fmt.Errorf("cannot safely replace corrupt checkpoint because per-claim CDI specs could not be inspected: %w", errors.Join(err, checkErr))
+				}
+				if hasPreparedClaimSpec {
+					message := fmt.Sprintf("Corrupt checkpoint detected (%s); automatic recovery blocked because per-claim CDI specs indicate prepared claims", corruption)
+					common.EmitCheckpointCorruptionEvent(ctx, config.clientsets.Core, DriverName, config.flags.nodeName, os.Getenv("POD_NAME"), config.flags.namespace, message)
+					return nil, fmt.Errorf("cannot safely replace corrupt checkpoint because per-claim CDI specs indicate prepared claims: %w", err)
+				}
+
+				message := fmt.Sprintf("Corrupt checkpoint detected (%s); no per-claim CDI specs found, replacing checkpoint", corruption)
+				common.EmitCheckpointCorruptionEvent(ctx, config.clientsets.Core, DriverName, config.flags.nodeName, os.Getenv("POD_NAME"), config.flags.namespace, message)
+				klog.Error(message)
+				break
 			}
 			storedBootID := cp.GetNodeBootID()
 			if storedBootID == "" { //nolint:gocritic,staticcheck

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -258,6 +258,9 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 
 				// The checkpoint cannot be trusted.
 				// Use per-claim CDI specs as evidence of prepared claims.
+				// TODO: How to handle partially prepared device state?
+				// In case of a crash after device preparation but before CDI spec creation may
+				// leave partially prepared device state without CDI evidence.
 				corruption := common.DescribeCheckpointCorruption(err)
 				hasPreparedClaimSpec, checkErr := common.HasClaimCDISpec(config.flags.cdiRoot, DriverName)
 				if checkErr != nil {

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -158,6 +158,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: NAMESPACE
           valueFrom:
             fieldRef:
@@ -283,6 +287,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml
@@ -20,6 +20,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/internal/common/checkpoint.go
+++ b/internal/common/checkpoint.go
@@ -1,0 +1,78 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	cperrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
+	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
+)
+
+// IsCheckpointCorruptionError reports whether err indicates either soft
+// corruption (checksum mismatch) or hard corruption (invalid checkpoint JSON).
+func IsCheckpointCorruptionError(err error) bool {
+	if errors.Is(err, cperrors.CorruptCheckpointError{}) {
+		return true
+	}
+
+	var syntaxError *json.SyntaxError
+	if errors.As(err, &syntaxError) {
+		return true
+	}
+
+	var typeError *json.UnmarshalTypeError
+	return errors.As(err, &typeError)
+}
+
+// DescribeCheckpointCorruption returns an operator-facing description without
+// repeating the generic "checkpoint is corrupted" error text.
+func DescribeCheckpointCorruption(err error) string {
+	if errors.Is(err, cperrors.CorruptCheckpointError{}) {
+		return "checksum verification failed"
+	}
+
+	return fmt.Sprintf("invalid checkpoint JSON: %v", err)
+}
+
+// HasClaimCDISpec checks for per-claim CDI specs belonging to the driver.
+// These files persist independently of the checkpoint and are used as the
+// prepared-claim signal when the checkpoint itself cannot be trusted.
+func HasClaimCDISpec(cdiRoot string, driverName string) (bool, error) {
+	entries, err := os.ReadDir(cdiRoot)
+	if err != nil {
+		return false, fmt.Errorf("read CDI directory %q: %w", cdiRoot, err)
+	}
+
+	prefix := cdiapi.GenerateSpecName("k8s."+driverName, "claim") + "_"
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		extension := filepath.Ext(entry.Name())
+		if extension == ".yaml" || extension == ".json" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internal/common/checkpoint_test.go
+++ b/internal/common/checkpoint_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cperrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCheckpointCorruptionError(t *testing.T) {
+	var invalidJSON map[string]any
+	syntaxError := json.Unmarshal([]byte(`{"v2":`), &invalidJSON)
+
+	var invalidType struct {
+		Checksum int `json:"checksum"`
+	}
+	typeError := json.Unmarshal([]byte(`{"checksum":"invalid"}`), &invalidType)
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "soft corruption",
+			err:      cperrors.CorruptCheckpointError{},
+			expected: true,
+		},
+		{
+			name:     "wrapped hard corruption with invalid JSON",
+			err:      fmt.Errorf("read checkpoint: %w", syntaxError),
+			expected: true,
+		},
+		{
+			name:     "hard corruption with invalid field type",
+			err:      typeError,
+			expected: true,
+		},
+		{
+			name:     "unrelated filesystem error",
+			err:      errors.New("permission denied"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsCheckpointCorruptionError(tc.err))
+		})
+	}
+}
+
+func TestDescribeCheckpointCorruption(t *testing.T) {
+	var invalidJSON map[string]any
+	syntaxError := json.Unmarshal([]byte(`{"v2":`), &invalidJSON)
+
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "soft corruption",
+			err:      cperrors.CorruptCheckpointError{},
+			expected: "checksum verification failed",
+		},
+		{
+			name:     "hard corruption",
+			err:      syntaxError,
+			expected: "invalid checkpoint JSON: unexpected end of JSON input",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, DescribeCheckpointCorruption(tc.err))
+		})
+	}
+}
+
+func TestHasClaimCDISpec(t *testing.T) {
+	const driverName = "gpu.nvidia.com"
+
+	tests := []struct {
+		name     string
+		files    []string
+		expected bool
+	}{
+		{
+			name: "no specs",
+		},
+		{
+			name:     "claim YAML spec",
+			files:    []string{"k8s.gpu.nvidia.com-claim_claim-uid.yaml"},
+			expected: true,
+		},
+		{
+			name:     "claim JSON spec",
+			files:    []string{"k8s.gpu.nvidia.com-claim_claim-uid.json"},
+			expected: true,
+		},
+		{
+			name:  "unrelated base spec",
+			files: []string{"k8s.gpu.nvidia.com-device_base.yaml"},
+		},
+		{
+			name:  "other driver claim spec",
+			files: []string{"k8s.compute-domain.nvidia.com-claim_claim-uid.yaml"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cdiRoot := t.TempDir()
+			for _, name := range tc.files {
+				require.NoError(t, os.WriteFile(filepath.Join(cdiRoot, name), []byte("spec"), 0o600))
+			}
+
+			hasClaimSpec, err := HasClaimCDISpec(cdiRoot, driverName)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, hasClaimSpec)
+		})
+	}
+
+	t.Run("directory read error", func(t *testing.T) {
+		hasClaimSpec, err := HasClaimCDISpec(filepath.Join(t.TempDir(), "missing"), driverName)
+
+		assert.False(t, hasClaimSpec)
+		assert.ErrorContains(t, err, "read CDI directory")
+	})
+}

--- a/internal/common/events.go
+++ b/internal/common/events.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// EmitCheckpointCorruptionEvent reports checkpoint corruption against the
+// kubelet plugin Pod. Event creation is best-effort and must not prevent plugin
+// startup.
+func EmitCheckpointCorruptionEvent(
+	ctx context.Context,
+	core coreclientset.Interface,
+	component string,
+	nodeName string,
+	podName string,
+	namespace string,
+	corruptionErr error,
+) {
+	if core == nil {
+		klog.Warning("skip checkpoint corruption event: no core clientset available")
+		return
+	}
+	if podName == "" {
+		klog.Warning("skip checkpoint corruption event: pod name is empty")
+		return
+	}
+
+	now := metav1.Now()
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "checkpoint-corrupted-",
+			Namespace:    namespace,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Name:       podName,
+			Namespace:  namespace,
+		},
+		Reason:  "CheckpointCorrupted",
+		Message: fmt.Sprintf("On-disk checkpoint is corrupted and is being invalidated: %v", corruptionErr),
+		Type:    corev1.EventTypeWarning,
+		Source: corev1.EventSource{
+			Component: component,
+			Host:      nodeName,
+		},
+		FirstTimestamp: now,
+		LastTimestamp:  now,
+		Count:          1,
+	}
+
+	eventCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if _, err := core.CoreV1().Events(namespace).Create(
+		eventCtx,
+		event,
+		metav1.CreateOptions{},
+	); err != nil {
+		klog.Errorf(
+			"failed to emit checkpoint corruption event for pod %q: %v",
+			podName,
+			err,
+		)
+	}
+}

--- a/internal/common/events.go
+++ b/internal/common/events.go
@@ -18,10 +18,10 @@ package common
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -37,7 +37,7 @@ func EmitCheckpointCorruptionEvent(
 	nodeName string,
 	podName string,
 	namespace string,
-	corruptionErr error,
+	message string,
 ) {
 	if core == nil {
 		klog.Warning("skip checkpoint corruption event: no core clientset available")
@@ -51,8 +51,8 @@ func EmitCheckpointCorruptionEvent(
 	now := metav1.Now()
 	event := &corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "checkpoint-corrupted-",
-			Namespace:    namespace,
+			Name:      podName + "-checkpoint-corrupted",
+			Namespace: namespace,
 		},
 		InvolvedObject: corev1.ObjectReference{
 			APIVersion: "v1",
@@ -61,7 +61,7 @@ func EmitCheckpointCorruptionEvent(
 			Namespace:  namespace,
 		},
 		Reason:  "CheckpointCorrupted",
-		Message: fmt.Sprintf("On-disk checkpoint is corrupted and is being invalidated: %v", corruptionErr),
+		Message: message,
 		Type:    corev1.EventTypeWarning,
 		Source: corev1.EventSource{
 			Component: component,
@@ -79,7 +79,7 @@ func EmitCheckpointCorruptionEvent(
 		eventCtx,
 		event,
 		metav1.CreateOptions{},
-	); err != nil {
+	); err != nil && !apierrors.IsAlreadyExists(err) {
 		klog.Errorf(
 			"failed to emit checkpoint corruption event for pod %q: %v",
 			podName,

--- a/internal/common/events_test.go
+++ b/internal/common/events_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type eventRequest struct {
+	method string
+	path   string
+	event  *corev1.Event
+}
+
+func TestEmitCheckpointCorruptionEvent(t *testing.T) {
+	requests := make(chan eventRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		event := &corev1.Event{}
+		if err := json.NewDecoder(r.Body).Decode(event); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		requests <- eventRequest{method: r.Method, path: r.URL.Path, event: event}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(event); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := kubernetes.NewForConfig(&rest.Config{
+		Host: server.URL,
+		ContentConfig: rest.ContentConfig{
+			ContentType:        "application/json",
+			AcceptContentTypes: "application/json",
+		},
+	})
+	require.NoError(t, err)
+
+	EmitCheckpointCorruptionEvent(
+		context.Background(),
+		client,
+		"gpu.nvidia.com",
+		"node-a",
+		"gpu-kubelet-plugin-abcde",
+		"dra-driver-nvidia-gpu",
+		"Corrupt checkpoint detected (checksum verification failed)",
+	)
+
+	var request eventRequest
+	select {
+	case request = <-requests:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Event API request")
+	}
+	assert.Equal(t, http.MethodPost, request.method)
+	assert.Equal(t, "/api/v1/namespaces/dra-driver-nvidia-gpu/events", request.path)
+
+	event := request.event
+	assert.Equal(t, "gpu-kubelet-plugin-abcde-checkpoint-corrupted", event.Name)
+	assert.Equal(t, "dra-driver-nvidia-gpu", event.Namespace)
+	assert.Equal(t, corev1.EventTypeWarning, event.Type)
+	assert.Equal(t, "CheckpointCorrupted", event.Reason)
+	assert.Equal(t, "Corrupt checkpoint detected (checksum verification failed)", event.Message)
+	assert.Equal(t, int32(1), event.Count)
+	assert.Equal(t, "gpu.nvidia.com", event.Source.Component)
+	assert.Equal(t, "node-a", event.Source.Host)
+	assert.Equal(t, "v1", event.InvolvedObject.APIVersion)
+	assert.Equal(t, "Pod", event.InvolvedObject.Kind)
+	assert.Equal(t, "gpu-kubelet-plugin-abcde", event.InvolvedObject.Name)
+	assert.Equal(t, "dra-driver-nvidia-gpu", event.InvolvedObject.Namespace)
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Handles checksum-corrupted GPU and ComputeDomain kubelet-plugin checkpoints without leaving the plugin in `CrashLoopBackOff`.

When `GetCheckpoint` returns `CorruptCheckpointError`, the plugin now:

- Emits a `CheckpointCorrupted` Warning event against the kubelet-plugin Pod.
- Replaces the corrupted checkpoint with a fresh empty checkpoint.
- Continues startup.

Other checkpoint read errors remain fatal.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1100

#### Special notes for your reviewer:

Manually tested by:

1. Deploying an image containing the changes.
2. Modifying the V2 checksum while preserving valid checkpoint JSON.
3. Restarting the kubelet-plugin Pod.
4. Verifying checksum corruption was detected and logged.
5. Verifying a fresh empty checkpoint was created and the Pod reached `Running`.
6. Verifying a `CheckpointCorrupted` Warning event was emitted.
7. Restarting again with the fresh checkpoint and confirming normal startup.

Done using Cursor.

#### Does this PR introduce a user-facing change?

```release-note
Recover from checksum-corrupted kubelet-plugin checkpoints and emit a Warning event describing the corruption.