### PR TITLE
Healthchecking of FG,SM and DM

### DIFF
--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -97,23 +97,24 @@ func (d *AllocatableDevice) CanonicalName() string {
 }
 
 func (d *AllocatableDevice) GetDevice(config *Config) resourceapi.Device {
+	var dev resourceapi.Device
 	switch d.Type() {
 	case GpuDeviceType:
-		dev := d.Gpu.GetDevice()
+		dev = d.Gpu.GetDevice()
 		applyConsumableShares(&dev, config)
-		return dev
 	case MigStaticDeviceType:
-		dev := d.MigStatic.GetDevice()
+		dev = d.MigStatic.GetDevice()
 		applyConsumableShares(&dev, config)
-		return dev
 	case MigDynamicDeviceType:
 		panic("GetDevice() must currently not be called for MigDynamicDeviceType")
 	case VfioDeviceType:
 		// VFIO passthrough devices do not support consumable shares.
-		return d.Vfio.GetDevice()
+		dev = d.Vfio.GetDevice()
 	default:
 		panic("unexpected type for AllocatableDevice")
 	}
+	dev.Taints = d.Taints()
+	return dev
 }
 
 // UUID() is here for `AllocatableDevices` to implement the `UUIDProvider`
@@ -371,4 +372,72 @@ func (d *AllocatableDevice) AddOrUpdateTaint(taint *resourceapi.DeviceTaint) boo
 	// 3. Key doesn't exist yet, append the dereferenced struct
 	d.taints = append(d.taints, *taint)
 	return true
+}
+
+// RemoveTaint removes the taint with the specified key. It returns true when a
+// taint was removed.
+func (d *AllocatableDevice) RemoveTaint(key string) (resourceapi.DeviceTaint, bool) {
+	for i, taint := range d.taints {
+		if taint.Key == key {
+			d.taints = slices.Delete(d.taints, i, i+1)
+			return taint, true
+		}
+	}
+	return resourceapi.DeviceTaint{}, false
+}
+
+func (d AllocatableDevices) GetGPUDeviceByUUID(uuid string) *AllocatableDevice {
+	for _, device := range d {
+		if device.Type() == GpuDeviceType &&
+			device.Gpu.UUID == uuid {
+			return device
+		}
+	}
+
+	return nil
+}
+
+func (d AllocatableDevices) GetMigStaticDeviceByLiveTuple(tuple *MigLiveTuple) *AllocatableDevice {
+	if tuple == nil {
+		return nil
+	}
+	for _, device := range d {
+		if device.Type() != MigStaticDeviceType {
+			continue
+		}
+		migTuple := device.MigStatic.LiveTuple()
+		if migTuple.ParentUUID == tuple.ParentUUID &&
+			migTuple.GIID == tuple.GIID &&
+			migTuple.CIID == tuple.CIID {
+			return device
+		}
+	}
+
+	return nil
+}
+
+func (d AllocatableDevices) GetMigDynamicDeviceByTuple(tuple *MigSpecTuple) *AllocatableDevice {
+	if tuple == nil {
+		return nil
+	}
+	for _, device := range d {
+		if device.Type() != MigDynamicDeviceType {
+			continue
+		}
+		migTuple := device.MigDynamic.Tuple()
+		if migTuple.ParentPCIBusID == tuple.ParentPCIBusID &&
+			migTuple.ProfileID == tuple.ProfileID &&
+			migTuple.PlacementStart == tuple.PlacementStart {
+			return device
+		}
+	}
+	return nil
+}
+
+func (d AllocatableDevices) List() []*AllocatableDevice {
+	deviceList := make([]*AllocatableDevice, 0, len(d))
+	for _, device := range d {
+		deviceList = append(deviceList, device)
+	}
+	return deviceList
 }

--- a/cmd/gpu-kubelet-plugin/device_health.go
+++ b/cmd/gpu-kubelet-plugin/device_health.go
@@ -96,15 +96,12 @@ func healthEventToTaint(monitor deviceHealthMonitor, event *DeviceHealthEvent) *
 	}
 }
 
-// For a MIG device the placement is defined by the 3-tuple <parent UUID, GI, CI>.
-// For a full device the returned 3-tuple is the device's uuid and (FullGPUInstanceID) 0xFFFFFFFF for the other two elements.
-type devicePlacementMap map[string]map[uint32]map[uint32]*AllocatableDevice
-
 type nvmlDeviceHealthMonitor struct {
 	nvmllib           nvml.Interface
 	eventSet          nvml.EventSet
 	unhealthy         chan *DeviceHealthEvent
-	deviceByPlacement devicePlacementMap
+	perGPUAllocatable *PerGPUAllocatableDevices
+	gpuInfosByUUID    map[string]*GpuInfo
 	skippedXids       map[uint64]bool
 	wg                sync.WaitGroup
 }
@@ -127,13 +124,16 @@ func newNvmlDeviceHealthMonitor(config *Config, perGPUAllocatable *PerGPUAllocat
 	m := &nvmlDeviceHealthMonitor{
 		nvmllib:           nvdevlib.nvmllib,
 		unhealthy:         make(chan *DeviceHealthEvent, len(all)),
-		deviceByPlacement: getDevicePlacementMap(all),
+		perGPUAllocatable: perGPUAllocatable,
+		gpuInfosByUUID:    nvdevlib.gpuInfosByUUID,
 		skippedXids:       xidsToSkip(config.flags.additionalXidsToIgnore),
 	}
 	return m, nil
 }
 
-func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
+// RegisterEvents creates the NVML event set and starts recording events for
+// every physical parent GPU before the kubelet server accepts requests.
+func (m *nvmlDeviceHealthMonitor) RegisterEvents() (rerr error) {
 	if ret := m.nvmllib.Init(); ret != nvml.SUCCESS {
 		return fmt.Errorf("failed to initialize NVML: %v", ret)
 	}
@@ -154,7 +154,14 @@ func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
 
 	klog.V(4).Info("registering NVML events for device health monitor")
 	m.registerEventsForDevices()
+	return nil
+}
 
+// Start launches the NVML event wait loop after RegisterEvents has completed.
+func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) error {
+	if m.eventSet == nil {
+		return fmt.Errorf("NVML events have not been registered")
+	}
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
@@ -168,28 +175,28 @@ func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
 func (m *nvmlDeviceHealthMonitor) registerEventsForDevices() {
 	eventMask := uint64(nvml.EventTypeXidCriticalError | nvml.EventTypeDoubleBitEccError | nvml.EventTypeSingleBitEccError)
 
-	for parentUUID, giMap := range m.deviceByPlacement {
-		gpu, ret := m.nvmllib.DeviceGetHandleByUUID(parentUUID)
+	for pciBusID, devices := range m.perGPUAllocatable.allocatablesMap {
+		gpu, ret := m.nvmllib.DeviceGetHandleByPciBusId(string(pciBusID))
 		if ret != nvml.SUCCESS {
-			klog.Warningf("Unable to get device handle from UUID[%s]: %v; marking devices as unmonitored", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("Unable to get device handle from PCI Bus ID[%s]: %v; marking devices as unmonitored", pciBusID, ret)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 			continue
 		}
 
 		supportedEvents, ret := gpu.GetSupportedEventTypes()
 		if ret != nvml.SUCCESS {
-			klog.Warningf("unable to determine the supported events for %s: %v; marking devices as unmonitored", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("unable to determine the supported events for %s: %v; marking devices as unmonitored", pciBusID, ret)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 			continue
 		}
 
 		ret = gpu.RegisterEvents(eventMask&supportedEvents, m.eventSet)
 		if ret == nvml.ERROR_NOT_SUPPORTED {
-			klog.Warningf("Device %v is too old to support healthchecking.", parentUUID)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("Device %v is too old to support healthchecking.", pciBusID)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 		} else if ret != nvml.SUCCESS {
-			klog.Warningf("unable to register events for %s: %v; marking devices as unmonitored", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("unable to register events for %s: %v; marking devices as unmonitored", pciBusID, ret)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 		}
 	}
 }
@@ -255,7 +262,13 @@ func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
 				m.sendHealthEventForAllDevices(HealthEventGPULost)
 				continue
 			}
-			affectedDevice := m.deviceByPlacement.get(eventUUID, gi, ci)
+			affectedDevice, err := m.resolveDeviceForEvent(eventUUID, gi, ci)
+			// An error indicates inconsistent UUID/PCI inventory. A nil device
+			// without an error means the event's GI/CI is not available.
+			if err != nil {
+				klog.Warningf("Unable to resolve XID=%d event for UUID:%s, GI:%d, CI:%d: %v", xid, eventUUID, gi, ci, err)
+				continue
+			}
 			if affectedDevice == nil {
 				klog.V(6).Infof("Ignoring event for unexpected device (UUID:%s, GI:%d, CI:%d)", eventUUID, gi, ci)
 				continue
@@ -279,28 +292,57 @@ func (m *nvmlDeviceHealthMonitor) Unhealthy() <-chan *DeviceHealthEvent {
 // single batched DeviceHealthEvent so the consumer makes one ResourceSlice
 // update.
 func (m *nvmlDeviceHealthMonitor) sendHealthEventForAllDevices(eventType DeviceHealthEventType) {
-	var devices []*AllocatableDevice
-	for _, giMap := range m.deviceByPlacement {
-		devices = append(devices, flattenMIGDeviceMap(giMap)...)
-	}
-	m.sendBatchedHealthEvent(devices, eventType)
+	m.sendBatchedHealthEvent(deviceList(m.perGPUAllocatable.GetAllDevices()), eventType)
 }
 
 // sendHealthEventForDevices aggregates all devices under a single parent GPU
 // into one batched DeviceHealthEvent.
-func (m *nvmlDeviceHealthMonitor) sendHealthEventForDevices(giMap map[uint32]map[uint32]*AllocatableDevice, eventType DeviceHealthEventType) {
-	m.sendBatchedHealthEvent(flattenMIGDeviceMap(giMap), eventType)
+func (m *nvmlDeviceHealthMonitor) sendHealthEventForDevices(devices AllocatableDevices, eventType DeviceHealthEventType) {
+	m.sendBatchedHealthEvent(deviceList(devices), eventType)
 }
 
-// flattenMIGDeviceMap flattens a GI→CI device map into a slice.
-func flattenMIGDeviceMap(giMap map[uint32]map[uint32]*AllocatableDevice) []*AllocatableDevice {
-	var devices []*AllocatableDevice
-	for _, ciMap := range giMap {
-		for _, dev := range ciMap {
-			devices = append(devices, dev)
+func (m *nvmlDeviceHealthMonitor) resolveDeviceForEvent(parentUUID string, gi, ci uint32) (*AllocatableDevice, error) {
+	parent, ok := m.gpuInfosByUUID[parentUUID]
+	if !ok {
+		return nil, fmt.Errorf("parent GPU UUID %s is not in the discovered GPU inventory", parentUUID)
+	}
+	return resolveEventDeviceByPCIBusID(m.perGPUAllocatable, parentUUID, parent.pciBusID, gi, ci)
+}
+
+func resolveEventDeviceByPCIBusID(perGPU *PerGPUAllocatableDevices, parentUUID, pciBusID string, gi, ci uint32) (*AllocatableDevice, error) {
+	devices, ok := perGPU.allocatablesMap[pciBusID]
+	if !ok {
+		return nil, fmt.Errorf(
+			"PCI Bus ID %s for parent GPU UUID %s is not in the allocatable inventory",
+			pciBusID, parentUUID,
+		)
+	}
+
+	for _, dev := range devices {
+		switch dev.Type() {
+		case GpuDeviceType:
+			if dev.Gpu.UUID == parentUUID &&
+				gi == FullGPUInstanceID &&
+				ci == FullGPUInstanceID {
+				return dev, nil
+			}
+
+		case MigStaticDeviceType:
+			if dev.MigStatic.parent.UUID == parentUUID &&
+				uint32(dev.MigStatic.gIInfo.Id) == gi &&
+				uint32(dev.MigStatic.cIInfo.Id) == ci {
+				return dev, nil
+			}
+
+		default:
+			klog.V(6).Infof(
+				"Skipping unsupported device type %s while resolving event for UUID:%s, GI:%d, CI:%d",
+				dev.Type(), parentUUID, gi, ci,
+			)
 		}
 	}
-	return devices
+
+	return nil, nil
 }
 
 // sendBatchedHealthEvent sends a single DeviceHealthEvent containing all
@@ -322,69 +364,12 @@ func (m *nvmlDeviceHealthMonitor) sendBatchedHealthEvent(devices []*AllocatableD
 	}
 }
 
-// The purpose of this function is to allow for a O(1) lookup of
-// AllocatableDevice by ([parent]UUID, GI, CI) when processing health events. It
-// currently assumes that this is constant for the lifetime of the healthchecker
-// which does not hold for Dynamic MIG. This will have to be resolved once we
-// support device health checking with dynamic MIG.
-func getDevicePlacementMap(allocatable AllocatableDevices) devicePlacementMap {
-	placementMap := make(devicePlacementMap)
-
-	for _, d := range allocatable {
-		var parentUUID string
-		var giID, ciID uint32
-
-		switch d.Type() {
-		case GpuDeviceType:
-			parentUUID = d.UUID()
-			if parentUUID == "" {
-				continue
-			}
-			giID = FullGPUInstanceID
-			ciID = FullGPUInstanceID
-
-		case MigStaticDeviceType:
-			parentUUID = d.MigStatic.parent.UUID
-
-			// Note(JP): it's unclear why we handle this case here (and why do
-			// we think this can be empty?)
-			if parentUUID == "" {
-				continue
-			}
-			giID = d.MigStatic.gIInfo.Id
-			ciID = d.MigStatic.cIInfo.Id
-
-		default:
-			// This may be a problem; and should be logged
-			klog.V(4).Infof("getDevicePlacementMap: skipping device with type: %s", d.Type())
-			continue
-		}
-		placementMap.addDevice(parentUUID, giID, ciID, d)
+func deviceList(devices AllocatableDevices) []*AllocatableDevice {
+	values := make([]*AllocatableDevice, 0, len(devices))
+	for _, dev := range devices {
+		values = append(values, dev)
 	}
-	return placementMap
-}
-
-func (p devicePlacementMap) addDevice(parentUUID string, giID uint32, ciID uint32, d *AllocatableDevice) {
-	if _, ok := p[parentUUID]; !ok {
-		p[parentUUID] = make(map[uint32]map[uint32]*AllocatableDevice)
-	}
-	if _, ok := p[parentUUID][giID]; !ok {
-		p[parentUUID][giID] = make(map[uint32]*AllocatableDevice)
-	}
-	p[parentUUID][giID][ciID] = d
-}
-
-func (p devicePlacementMap) get(uuid string, gi, ci uint32) *AllocatableDevice {
-	giMap, ok := p[uuid]
-	if !ok {
-		return nil
-	}
-
-	ciMap, ok := giMap[gi]
-	if !ok {
-		return nil
-	}
-	return ciMap[ci]
+	return values
 }
 
 // getAdditionalXids returns a list of additional Xids to skip from the specified string.

--- a/cmd/gpu-kubelet-plugin/device_health.go
+++ b/cmd/gpu-kubelet-plugin/device_health.go
@@ -96,15 +96,12 @@ func healthEventToTaint(monitor deviceHealthMonitor, event *DeviceHealthEvent) *
 	}
 }
 
-// For a MIG device the placement is defined by the 3-tuple <parent UUID, GI, CI>.
-// For a full device the returned 3-tuple is the device's uuid and (FullGPUInstanceID) 0xFFFFFFFF for the other two elements.
-type devicePlacementMap map[string]map[uint32]map[uint32]*AllocatableDevice
-
 type nvmlDeviceHealthMonitor struct {
 	nvmllib           nvml.Interface
 	eventSet          nvml.EventSet
 	unhealthy         chan *DeviceHealthEvent
-	deviceByPlacement devicePlacementMap
+	perGPUAllocatable *PerGPUAllocatableDevices
+	gpuInfosByUUID    map[string]*GpuInfo
 	skippedXids       map[uint64]bool
 	wg                sync.WaitGroup
 }
@@ -127,13 +124,16 @@ func newNvmlDeviceHealthMonitor(config *Config, perGPUAllocatable *PerGPUAllocat
 	m := &nvmlDeviceHealthMonitor{
 		nvmllib:           nvdevlib.nvmllib,
 		unhealthy:         make(chan *DeviceHealthEvent, len(all)),
-		deviceByPlacement: getDevicePlacementMap(all),
+		perGPUAllocatable: perGPUAllocatable,
+		gpuInfosByUUID:    nvdevlib.gpuInfosByUUID,
 		skippedXids:       xidsToSkip(config.flags.additionalXidsToIgnore),
 	}
 	return m, nil
 }
 
-func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
+// RegisterEvents creates the NVML event set and starts recording events for
+// every physical parent GPU before the kubelet server accepts requests.
+func (m *nvmlDeviceHealthMonitor) RegisterEvents() (rerr error) {
 	if ret := m.nvmllib.Init(); ret != nvml.SUCCESS {
 		return fmt.Errorf("failed to initialize NVML: %w", ret)
 	}
@@ -154,7 +154,14 @@ func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
 
 	klog.V(4).Info("registering NVML events for device health monitor")
 	m.registerEventsForDevices()
+	return nil
+}
 
+// Start launches the NVML event wait loop after RegisterEvents has completed.
+func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) error {
+	if m.eventSet == nil {
+		return fmt.Errorf("NVML events have not been registered")
+	}
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
@@ -168,28 +175,28 @@ func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
 func (m *nvmlDeviceHealthMonitor) registerEventsForDevices() {
 	eventMask := uint64(nvml.EventTypeXidCriticalError | nvml.EventTypeDoubleBitEccError | nvml.EventTypeSingleBitEccError)
 
-	for parentUUID, giMap := range m.deviceByPlacement {
-		gpu, ret := m.nvmllib.DeviceGetHandleByUUID(parentUUID)
+	for pciBusID, devices := range m.perGPUAllocatable.allocatablesMap {
+		gpu, ret := m.nvmllib.DeviceGetHandleByPciBusId(string(pciBusID))
 		if ret != nvml.SUCCESS {
-			klog.Warningf("Unable to get device handle from UUID[%s]: %v; marking devices as unmonitored", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("Unable to get device handle from PCI Bus ID[%s]: %v; marking devices as unmonitored", pciBusID, ret)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 			continue
 		}
 
 		supportedEvents, ret := gpu.GetSupportedEventTypes()
 		if ret != nvml.SUCCESS {
-			klog.Warningf("unable to determine the supported events for %s: %v; marking devices as unmonitored", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("unable to determine the supported events for %s: %v; marking devices as unmonitored", pciBusID, ret)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 			continue
 		}
 
 		ret = gpu.RegisterEvents(eventMask&supportedEvents, m.eventSet)
 		if ret == nvml.ERROR_NOT_SUPPORTED {
-			klog.Warningf("Device %v is too old to support healthchecking.", parentUUID)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("Device %v is too old to support healthchecking.", pciBusID)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 		} else if ret != nvml.SUCCESS {
-			klog.Warningf("unable to register events for %s: %v; marking devices as unmonitored", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("unable to register events for %s: %v; marking devices as unmonitored", pciBusID, ret)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 		}
 	}
 }
@@ -255,7 +262,13 @@ func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
 				m.sendHealthEventForAllDevices(HealthEventGPULost)
 				continue
 			}
-			affectedDevice := m.deviceByPlacement.get(eventUUID, gi, ci)
+			affectedDevice, err := m.resolveDeviceForEvent(eventUUID, gi, ci)
+			// An error indicates inconsistent UUID/PCI inventory. A nil device
+			// without an error means the event's GI/CI is not available.
+			if err != nil {
+				klog.Warningf("Unable to resolve XID=%d event for UUID:%s, GI:%d, CI:%d: %v", xid, eventUUID, gi, ci, err)
+				continue
+			}
 			if affectedDevice == nil {
 				klog.V(6).Infof("Ignoring event for unexpected device (UUID:%s, GI:%d, CI:%d)", eventUUID, gi, ci)
 				continue
@@ -279,28 +292,57 @@ func (m *nvmlDeviceHealthMonitor) Unhealthy() <-chan *DeviceHealthEvent {
 // single batched DeviceHealthEvent so the consumer makes one ResourceSlice
 // update.
 func (m *nvmlDeviceHealthMonitor) sendHealthEventForAllDevices(eventType DeviceHealthEventType) {
-	var devices []*AllocatableDevice
-	for _, giMap := range m.deviceByPlacement {
-		devices = append(devices, flattenMIGDeviceMap(giMap)...)
-	}
-	m.sendBatchedHealthEvent(devices, eventType)
+	m.sendBatchedHealthEvent(deviceList(m.perGPUAllocatable.GetAllDevices()), eventType)
 }
 
 // sendHealthEventForDevices aggregates all devices under a single parent GPU
 // into one batched DeviceHealthEvent.
-func (m *nvmlDeviceHealthMonitor) sendHealthEventForDevices(giMap map[uint32]map[uint32]*AllocatableDevice, eventType DeviceHealthEventType) {
-	m.sendBatchedHealthEvent(flattenMIGDeviceMap(giMap), eventType)
+func (m *nvmlDeviceHealthMonitor) sendHealthEventForDevices(devices AllocatableDevices, eventType DeviceHealthEventType) {
+	m.sendBatchedHealthEvent(deviceList(devices), eventType)
 }
 
-// flattenMIGDeviceMap flattens a GI→CI device map into a slice.
-func flattenMIGDeviceMap(giMap map[uint32]map[uint32]*AllocatableDevice) []*AllocatableDevice {
-	var devices []*AllocatableDevice
-	for _, ciMap := range giMap {
-		for _, dev := range ciMap {
-			devices = append(devices, dev)
+func (m *nvmlDeviceHealthMonitor) resolveDeviceForEvent(parentUUID string, gi, ci uint32) (*AllocatableDevice, error) {
+	parent, ok := m.gpuInfosByUUID[parentUUID]
+	if !ok {
+		return nil, fmt.Errorf("parent GPU UUID %s is not in the discovered GPU inventory", parentUUID)
+	}
+	return resolveEventDeviceByPCIBusID(m.perGPUAllocatable, parentUUID, parent.pciBusID, gi, ci)
+}
+
+func resolveEventDeviceByPCIBusID(perGPU *PerGPUAllocatableDevices, parentUUID, pciBusID string, gi, ci uint32) (*AllocatableDevice, error) {
+	devices, ok := perGPU.allocatablesMap[pciBusID]
+	if !ok {
+		return nil, fmt.Errorf(
+			"PCI Bus ID %s for parent GPU UUID %s is not in the allocatable inventory",
+			pciBusID, parentUUID,
+		)
+	}
+
+	for _, dev := range devices {
+		switch dev.Type() {
+		case GpuDeviceType:
+			if dev.Gpu.UUID == parentUUID &&
+				gi == FullGPUInstanceID &&
+				ci == FullGPUInstanceID {
+				return dev, nil
+			}
+
+		case MigStaticDeviceType:
+			if dev.MigStatic.parent.UUID == parentUUID &&
+				uint32(dev.MigStatic.gIInfo.Id) == gi &&
+				uint32(dev.MigStatic.cIInfo.Id) == ci {
+				return dev, nil
+			}
+
+		default:
+			klog.V(6).Infof(
+				"Skipping unsupported device type %s while resolving event for UUID:%s, GI:%d, CI:%d",
+				dev.Type(), parentUUID, gi, ci,
+			)
 		}
 	}
-	return devices
+
+	return nil, nil
 }
 
 // sendBatchedHealthEvent sends a single DeviceHealthEvent containing all
@@ -322,69 +364,12 @@ func (m *nvmlDeviceHealthMonitor) sendBatchedHealthEvent(devices []*AllocatableD
 	}
 }
 
-// The purpose of this function is to allow for a O(1) lookup of
-// AllocatableDevice by ([parent]UUID, GI, CI) when processing health events. It
-// currently assumes that this is constant for the lifetime of the healthchecker
-// which does not hold for Dynamic MIG. This will have to be resolved once we
-// support device health checking with dynamic MIG.
-func getDevicePlacementMap(allocatable AllocatableDevices) devicePlacementMap {
-	placementMap := make(devicePlacementMap)
-
-	for _, d := range allocatable {
-		var parentUUID string
-		var giID, ciID uint32
-
-		switch d.Type() {
-		case GpuDeviceType:
-			parentUUID = d.UUID()
-			if parentUUID == "" {
-				continue
-			}
-			giID = FullGPUInstanceID
-			ciID = FullGPUInstanceID
-
-		case MigStaticDeviceType:
-			parentUUID = d.MigStatic.parent.UUID
-
-			// Note(JP): it's unclear why we handle this case here (and why do
-			// we think this can be empty?)
-			if parentUUID == "" {
-				continue
-			}
-			giID = d.MigStatic.gIInfo.Id
-			ciID = d.MigStatic.cIInfo.Id
-
-		default:
-			// This may be a problem; and should be logged
-			klog.V(4).Infof("getDevicePlacementMap: skipping device with type: %s", d.Type())
-			continue
-		}
-		placementMap.addDevice(parentUUID, giID, ciID, d)
+func deviceList(devices AllocatableDevices) []*AllocatableDevice {
+	values := make([]*AllocatableDevice, 0, len(devices))
+	for _, dev := range devices {
+		values = append(values, dev)
 	}
-	return placementMap
-}
-
-func (p devicePlacementMap) addDevice(parentUUID string, giID uint32, ciID uint32, d *AllocatableDevice) {
-	if _, ok := p[parentUUID]; !ok {
-		p[parentUUID] = make(map[uint32]map[uint32]*AllocatableDevice)
-	}
-	if _, ok := p[parentUUID][giID]; !ok {
-		p[parentUUID][giID] = make(map[uint32]*AllocatableDevice)
-	}
-	p[parentUUID][giID][ciID] = d
-}
-
-func (p devicePlacementMap) get(uuid string, gi, ci uint32) *AllocatableDevice {
-	giMap, ok := p[uuid]
-	if !ok {
-		return nil
-	}
-
-	ciMap, ok := giMap[gi]
-	if !ok {
-		return nil
-	}
-	return ciMap[ci]
+	return values
 }
 
 // getAdditionalXids returns a list of additional Xids to skip from the specified string.

--- a/cmd/gpu-kubelet-plugin/device_health.go
+++ b/cmd/gpu-kubelet-plugin/device_health.go
@@ -26,6 +26,8 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 )
 
 const (
@@ -262,7 +264,7 @@ func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
 				m.sendHealthEventForAllDevices(HealthEventGPULost)
 				continue
 			}
-			affectedDevice, err := m.resolveDeviceForEvent(eventUUID, gi, ci)
+			affectedDevice, err := m.resolveDeviceByEventAddress(eventUUID, event.Device, gi, ci)
 			// An error indicates inconsistent UUID/PCI inventory. A nil device
 			// without an error means the event's GI/CI is not available.
 			if err != nil {
@@ -274,7 +276,7 @@ func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
 				continue
 			}
 
-			klog.V(4).Infof("Sending XID=%d health event for device %s", xid, affectedDevice.UUID())
+			klog.V(4).Infof("Sending XID=%d health event for device %s", xid, affectedDevice.CanonicalName())
 			m.unhealthy <- &DeviceHealthEvent{
 				Devices:   []*AllocatableDevice{affectedDevice},
 				EventType: HealthEventXID,
@@ -292,57 +294,92 @@ func (m *nvmlDeviceHealthMonitor) Unhealthy() <-chan *DeviceHealthEvent {
 // single batched DeviceHealthEvent so the consumer makes one ResourceSlice
 // update.
 func (m *nvmlDeviceHealthMonitor) sendHealthEventForAllDevices(eventType DeviceHealthEventType) {
-	m.sendBatchedHealthEvent(deviceList(m.perGPUAllocatable.GetAllDevices()), eventType)
+	m.sendBatchedHealthEvent(m.perGPUAllocatable.GetAllDevices().List(), eventType)
 }
 
 // sendHealthEventForDevices aggregates all devices under a single parent GPU
 // into one batched DeviceHealthEvent.
 func (m *nvmlDeviceHealthMonitor) sendHealthEventForDevices(devices AllocatableDevices, eventType DeviceHealthEventType) {
-	m.sendBatchedHealthEvent(deviceList(devices), eventType)
+	m.sendBatchedHealthEvent(devices.List(), eventType)
 }
 
-func (m *nvmlDeviceHealthMonitor) resolveDeviceForEvent(parentUUID string, gi, ci uint32) (*AllocatableDevice, error) {
+// NVML identifies a MIG-scoped event by the tuple (parent UUID, GPU instance
+// ID, compute instance ID). A full-GPU event reports FullGPUInstanceID for both
+// the GPU instance ID and compute instance ID.
+//
+// resolveDeviceByEventAddress maps this address, extracted from an NVML event,
+// to an advertised allocatable device.
+func (m *nvmlDeviceHealthMonitor) resolveDeviceByEventAddress(parentUUID string, eventDevice nvml.Device, gi, ci uint32) (*AllocatableDevice, error) {
 	parent, ok := m.gpuInfosByUUID[parentUUID]
 	if !ok {
-		return nil, fmt.Errorf("parent GPU UUID %s is not in the discovered GPU inventory", parentUUID)
+		return nil, fmt.Errorf("failed to find parent GPU UUID %s in the discovered GPU inventory", parentUUID)
 	}
-	return resolveEventDeviceByPCIBusID(m.perGPUAllocatable, parentUUID, parent.pciBusID, gi, ci)
+
+	devices, ok := m.perGPUAllocatable.allocatablesMap[parent.pciBusID]
+	if !ok {
+		return nil, fmt.Errorf("failed to find PCI Bus ID %s for parent GPU UUID %s in the allocatable inventory", parent.pciBusID, parent.UUID)
+	}
+
+	switch {
+	case gi == FullGPUInstanceID && ci == FullGPUInstanceID:
+		return devices.GetGPUDeviceByUUID(parentUUID), nil
+
+	case gi != FullGPUInstanceID && ci != FullGPUInstanceID:
+		if featuregates.Enabled(featuregates.DynamicMIG) {
+			spec, err := resolveMigEvent(eventDevice, parent, gi, ci)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve Dynamic MIG device for parent %s, GI=%d, CI=%d: %w", parentUUID, gi, ci, err)
+			}
+			return devices.GetMigDynamicDeviceByTuple(spec), nil
+		}
+
+		return devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+			ParentUUID: parentUUID,
+			GIID:       int(gi),
+			CIID:       int(ci),
+		}), nil
+
+	default:
+		// A GI can exist without a CI, but it does not represent a usable,
+		// allocatable MIG device. Similar to device plugin, treat an event
+		// as MIG-scoped only when both GI and CI are present.
+		//
+		// See:
+		// https://github.com/NVIDIA/k8s-device-plugin/blob/main/internal/rm/health.go#L160
+		// https://docs.nvidia.com/deploy/nvml-api/structnvmlEventData__t.html
+		// https://docs.nvidia.com/datacenter/tesla/mig-user-guide/latest/getting-started-with-mig.html#creating-gpu-instances
+		klog.V(6).Infof("Ignoring NVML event with inconsistent instance address for parent UUID %s: GI=%d, CI=%d", parentUUID, gi, ci)
+		return nil, nil
+	}
 }
 
-func resolveEventDeviceByPCIBusID(perGPU *PerGPUAllocatableDevices, parentUUID, pciBusID string, gi, ci uint32) (*AllocatableDevice, error) {
-	devices, ok := perGPU.allocatablesMap[pciBusID]
-	if !ok {
-		return nil, fmt.Errorf(
-			"PCI Bus ID %s for parent GPU UUID %s is not in the allocatable inventory",
-			pciBusID, parentUUID,
-		)
+// resolveMigEvent translates the live GI/CI address reported by NVML into the
+// abstract profile and placement used to advertise a Dynamic MIG device.
+func resolveMigEvent(device nvml.Device, parent *GpuInfo, giID, ciID uint32) (*MigSpecTuple, error) {
+	gi, ret := device.GetGpuInstanceById(int(giID))
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to get GPU instance %d: %w", giID, ret)
+	}
+	giInfo, ret := gi.GetInfo()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to get info for GPU instance %d: %w", giID, ret)
 	}
 
-	for _, dev := range devices {
-		switch dev.Type() {
-		case GpuDeviceType:
-			if dev.Gpu.UUID == parentUUID &&
-				gi == FullGPUInstanceID &&
-				ci == FullGPUInstanceID {
-				return dev, nil
-			}
-
-		case MigStaticDeviceType:
-			if dev.MigStatic.parent.UUID == parentUUID &&
-				uint32(dev.MigStatic.gIInfo.Id) == gi &&
-				uint32(dev.MigStatic.cIInfo.Id) == ci {
-				return dev, nil
-			}
-
-		default:
-			klog.V(6).Infof(
-				"Skipping unsupported device type %s while resolving event for UUID:%s, GI:%d, CI:%d",
-				dev.Type(), parentUUID, gi, ci,
-			)
-		}
+	_, ret = gi.GetComputeInstanceById(int(ciID))
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to get compute instance %d in GPU instance %d: %w", ciID, giID, ret)
 	}
 
-	return nil, nil
+	klog.V(6).Infof(
+		"Resolved Dynamic MIG event (UUID:%s, GI:%d, CI:%d) to profile ID %d, placement start %d",
+		parent.UUID, giID, ciID, giInfo.ProfileId, giInfo.Placement.Start,
+	)
+	return &MigSpecTuple{
+		ParentMinor:    parent.minor,
+		ParentPCIBusID: parent.pciBusID,
+		ProfileID:      int(giInfo.ProfileId),
+		PlacementStart: int(giInfo.Placement.Start),
+	}, nil
 }
 
 // sendBatchedHealthEvent sends a single DeviceHealthEvent containing all
@@ -362,14 +399,6 @@ func (m *nvmlDeviceHealthMonitor) sendBatchedHealthEvent(devices []*AllocatableD
 	default:
 		klog.Errorf("Health event channel full; dropping batched %s event for %d device(s)", eventType, len(devices))
 	}
-}
-
-func deviceList(devices AllocatableDevices) []*AllocatableDevice {
-	values := make([]*AllocatableDevice, 0, len(devices))
-	for _, dev := range devices {
-		values = append(values, dev)
-	}
-	return values
 }
 
 // getAdditionalXids returns a list of additional Xids to skip from the specified string.

--- a/cmd/gpu-kubelet-plugin/device_health_test.go
+++ b/cmd/gpu-kubelet-plugin/device_health_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	resourceapi "k8s.io/api/resource/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -283,4 +284,123 @@ func TestIsEventNonFatal(t *testing.T) {
 			assert.Equal(t, tc.expected, m.IsEventNonFatal(tc.event))
 		})
 	}
+}
+
+func TestResolveEventDeviceByPCIBusID(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0, pciBusID: "0000:01:00.0"}
+	fullGPU := &AllocatableDevice{Gpu: parent}
+	staticMIG := &AllocatableDevice{
+		MigStatic: &MigDeviceInfo{
+			parent: parent,
+			gIInfo: &nvml.GpuInstanceInfo{Id: 2},
+			cIInfo: &nvml.ComputeInstanceInfo{Id: 3},
+		},
+	}
+	perGPU := &PerGPUAllocatableDevices{
+		allocatablesMap: map[PCIBusID]AllocatableDevices{
+			parent.pciBusID: {
+				"gpu":     fullGPU,
+				"static":  staticMIG,
+				"unknown": {},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		gi   uint32
+		ci   uint32
+		want *AllocatableDevice
+	}{
+		{name: "full GPU", gi: FullGPUInstanceID, ci: FullGPUInstanceID, want: fullGPU},
+		{name: "static MIG", gi: 2, ci: 3, want: staticMIG},
+		{name: "unknown placement", gi: 7, ci: 0, want: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveEventDeviceByPCIBusID(perGPU, parent.UUID, parent.pciBusID, tc.gi, tc.ci)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestResolveDeviceForEventUsesGPUUUIDIndex(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0, pciBusID: "0000:01:00.0"}
+	staticMIG := &AllocatableDevice{
+		MigStatic: &MigDeviceInfo{
+			parent: parent,
+			gIInfo: &nvml.GpuInstanceInfo{Id: 2},
+			cIInfo: &nvml.ComputeInstanceInfo{Id: 3},
+		},
+	}
+	monitor := &nvmlDeviceHealthMonitor{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				parent.pciBusID: {
+					"static": staticMIG,
+				},
+			},
+		},
+		gpuInfosByUUID: map[string]*GpuInfo{parent.UUID: parent},
+	}
+	got, err := monitor.resolveDeviceForEvent(parent.UUID, 2, 3)
+	require.NoError(t, err)
+	require.Equal(t, staticMIG, got)
+
+	_, err = monitor.resolveDeviceForEvent("GPU-unknown", 2, 3)
+	require.ErrorContains(t, err, "not in the discovered GPU inventory")
+}
+
+func TestResolveEventDeviceByPCIBusIDRejectsWrongParent(t *testing.T) {
+	parent := &GpuInfo{
+		UUID:     "GPU-parent-1",
+		pciBusID: "0000:01:00.0",
+	}
+	otherParent := &GpuInfo{
+		UUID:     "GPU-parent-2",
+		pciBusID: parent.pciBusID,
+	}
+
+	perGPU := &PerGPUAllocatableDevices{
+		allocatablesMap: map[PCIBusID]AllocatableDevices{
+			parent.pciBusID: {
+				"wrong-gpu": {
+					Gpu: otherParent,
+				},
+				"wrong-static-mig": {
+					MigStatic: &MigDeviceInfo{
+						parent: otherParent,
+						gIInfo: &nvml.GpuInstanceInfo{Id: 2},
+						cIInfo: &nvml.ComputeInstanceInfo{Id: 3},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := resolveEventDeviceByPCIBusID(
+		perGPU,
+		parent.UUID,
+		parent.pciBusID,
+		FullGPUInstanceID,
+		FullGPUInstanceID,
+	)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	got, err = resolveEventDeviceByPCIBusID(
+		perGPU,
+		parent.UUID,
+		parent.pciBusID,
+		2,
+		3,
+	)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestHealthMonitorStartRequiresRegisteredEvents(t *testing.T) {
+	m := &nvmlDeviceHealthMonitor{}
+	require.ErrorContains(t, m.Start(context.Background()), "events have not been registered")
 }

--- a/cmd/gpu-kubelet-plugin/device_health_test.go
+++ b/cmd/gpu-kubelet-plugin/device_health_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	nvdev "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	resourceapi "k8s.io/api/resource/v1"
 
@@ -143,6 +144,32 @@ func TestAddOrUpdateTaint_TimeAddedResetOnChange(t *testing.T) {
 	})
 
 	assert.Nil(t, dev.Taints()[0].TimeAdded, "TimeAdded should be nil so the API server sets a fresh timestamp")
+}
+
+func TestPartGetDeviceIncludesHealthTaints(t *testing.T) {
+	parent := &GpuInfo{
+		UUID:                  "GPU-parent-1",
+		minor:                 0,
+		cudaComputeCapability: "9.0",
+		driverVersion:         "580.0",
+		cudaDriverVersion:     "13.0",
+	}
+	dev := &AllocatableDevice{MigDynamic: &MigSpec{
+		Parent:        parent,
+		Profile:       &nvdev.MigProfileInfo{G: 1, GB: 5, GIProfileID: 19},
+		GIProfileInfo: nvml.GpuInstanceProfileInfo{Id: 19},
+		Placement:     nvml.GpuInstancePlacement{Start: 0, Size: 1},
+	}}
+	taint := &resourceapi.DeviceTaint{
+		Key:    TaintKeyXID,
+		Value:  "43",
+		Effect: resourceapi.DeviceTaintEffectNone,
+	}
+	require.True(t, dev.AddOrUpdateTaint(taint))
+
+	got := dev.PartGetDevice(nil)
+	require.Len(t, got.Taints, 1)
+	assert.Equal(t, *taint, got.Taints[0])
 }
 
 func TestHealthEventToTaint(t *testing.T) {
@@ -286,53 +313,76 @@ func TestIsEventNonFatal(t *testing.T) {
 	}
 }
 
-func TestResolveEventDeviceByPCIBusID(t *testing.T) {
+func TestAllocatableDevicesFindByAddress(t *testing.T) {
 	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0, pciBusID: "0000:01:00.0"}
 	fullGPU := &AllocatableDevice{Gpu: parent}
 	staticMIG := &AllocatableDevice{
 		MigStatic: &MigDeviceInfo{
-			parent: parent,
-			gIInfo: &nvml.GpuInstanceInfo{Id: 2},
-			cIInfo: &nvml.ComputeInstanceInfo{Id: 3},
-		},
+			ParentUUID: parent.UUID,
+			GIID:       2,
+			CIID:       3,
+			parent:     parent},
 	}
-	perGPU := &PerGPUAllocatableDevices{
-		allocatablesMap: map[PCIBusID]AllocatableDevices{
-			parent.pciBusID: {
-				"gpu":     fullGPU,
-				"static":  staticMIG,
-				"unknown": {},
-			},
-		},
+	devices := AllocatableDevices{
+		"gpu":    fullGPU,
+		"static": staticMIG,
 	}
+
+	assert.Equal(t, fullGPU, devices.GetGPUDeviceByUUID(parent.UUID))
+	assert.Nil(t, devices.GetGPUDeviceByUUID("GPU-unknown"))
+	assert.Equal(t, staticMIG, devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+		ParentUUID: parent.UUID,
+		GIID:       2,
+		CIID:       3,
+	}))
+	assert.Nil(t, devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+		ParentUUID: parent.UUID,
+		GIID:       2,
+		CIID:       4,
+	}))
+	assert.Nil(t, devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+		ParentUUID: "GPU-unknown",
+		GIID:       2,
+		CIID:       3,
+	}))
+	assert.Nil(t, devices.GetMigStaticDeviceByLiveTuple(nil))
+}
+
+func TestAllocatableDevicesFindDynamicMIGBySpec(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0, pciBusID: "0000:01:00.0"}
+	dynamicMIG := &AllocatableDevice{MigDynamic: &MigSpec{
+		Parent:        parent,
+		GIProfileInfo: nvml.GpuInstanceProfileInfo{Id: 19},
+		Placement:     nvml.GpuInstancePlacement{Start: 0},
+	}}
+	devices := AllocatableDevices{"dynamic": dynamicMIG}
 
 	tests := []struct {
 		name string
-		gi   uint32
-		ci   uint32
+		spec *MigSpecTuple
 		want *AllocatableDevice
 	}{
-		{name: "full GPU", gi: FullGPUInstanceID, ci: FullGPUInstanceID, want: fullGPU},
-		{name: "static MIG", gi: 2, ci: 3, want: staticMIG},
-		{name: "unknown placement", gi: 7, ci: 0, want: nil},
+		{name: "exact match", spec: &MigSpecTuple{ParentPCIBusID: parent.pciBusID, ProfileID: 19, PlacementStart: 0}, want: dynamicMIG},
+		{name: "profile mismatch", spec: &MigSpecTuple{ParentPCIBusID: parent.pciBusID, ProfileID: 14, PlacementStart: 0}},
+		{name: "placement mismatch", spec: &MigSpecTuple{ParentPCIBusID: parent.pciBusID, ProfileID: 19, PlacementStart: 1}},
+		{name: "parent mismatch", spec: &MigSpecTuple{ParentPCIBusID: "0000:02:00.0", ProfileID: 19, PlacementStart: 0}},
+		{name: "nil spec"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := resolveEventDeviceByPCIBusID(perGPU, parent.UUID, parent.pciBusID, tc.gi, tc.ci)
-			require.NoError(t, err)
-			require.Equal(t, tc.want, got)
+			assert.Equal(t, tc.want, devices.GetMigDynamicDeviceByTuple(tc.spec))
 		})
 	}
 }
 
-func TestResolveDeviceForEventUsesGPUUUIDIndex(t *testing.T) {
+func TestResolveDeviceByEventAddressUsesGPUUUIDIndex(t *testing.T) {
 	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0, pciBusID: "0000:01:00.0"}
 	staticMIG := &AllocatableDevice{
 		MigStatic: &MigDeviceInfo{
-			parent: parent,
-			gIInfo: &nvml.GpuInstanceInfo{Id: 2},
-			cIInfo: &nvml.ComputeInstanceInfo{Id: 3},
-		},
+			ParentUUID: parent.UUID,
+			GIID:       2,
+			CIID:       3,
+			parent:     parent},
 	}
 	monitor := &nvmlDeviceHealthMonitor{
 		perGPUAllocatable: &PerGPUAllocatableDevices{
@@ -344,15 +394,21 @@ func TestResolveDeviceForEventUsesGPUUUIDIndex(t *testing.T) {
 		},
 		gpuInfosByUUID: map[string]*GpuInfo{parent.UUID: parent},
 	}
-	got, err := monitor.resolveDeviceForEvent(parent.UUID, 2, 3)
+
+	got, err := monitor.resolveDeviceByEventAddress(parent.UUID, nil, 2, 3)
 	require.NoError(t, err)
 	require.Equal(t, staticMIG, got)
 
-	_, err = monitor.resolveDeviceForEvent("GPU-unknown", 2, 3)
-	require.ErrorContains(t, err, "not in the discovered GPU inventory")
+	got, err = monitor.resolveDeviceByEventAddress(parent.UUID, nil, FullGPUInstanceID, 3)
+	require.Nil(t, got)
+	require.NoError(t, err)
+
+	_, err = monitor.resolveDeviceByEventAddress("GPU-unknown", nil, 2, 3)
+	require.ErrorContains(t, err, "failed to find parent GPU UUID")
+
 }
 
-func TestResolveEventDeviceByPCIBusIDRejectsWrongParent(t *testing.T) {
+func TestAllocatableDevicesFindRejectsWrongParent(t *testing.T) {
 	parent := &GpuInfo{
 		UUID:     "GPU-parent-1",
 		pciBusID: "0000:01:00.0",
@@ -362,45 +418,85 @@ func TestResolveEventDeviceByPCIBusIDRejectsWrongParent(t *testing.T) {
 		pciBusID: parent.pciBusID,
 	}
 
-	perGPU := &PerGPUAllocatableDevices{
-		allocatablesMap: map[PCIBusID]AllocatableDevices{
-			parent.pciBusID: {
-				"wrong-gpu": {
-					Gpu: otherParent,
-				},
-				"wrong-static-mig": {
-					MigStatic: &MigDeviceInfo{
-						parent: otherParent,
-						gIInfo: &nvml.GpuInstanceInfo{Id: 2},
-						cIInfo: &nvml.ComputeInstanceInfo{Id: 3},
-					},
-				},
+	devices := AllocatableDevices{
+		"wrong-gpu": {
+			Gpu: otherParent,
+		},
+		"wrong-static-mig": {
+			MigStatic: &MigDeviceInfo{
+				ParentUUID: otherParent.UUID,
+				GIID:       2,
+				CIID:       3,
+				parent:     otherParent,
 			},
 		},
 	}
-
-	got, err := resolveEventDeviceByPCIBusID(
-		perGPU,
-		parent.UUID,
-		parent.pciBusID,
-		FullGPUInstanceID,
-		FullGPUInstanceID,
-	)
-	require.NoError(t, err)
-	require.Nil(t, got)
-
-	got, err = resolveEventDeviceByPCIBusID(
-		perGPU,
-		parent.UUID,
-		parent.pciBusID,
-		2,
-		3,
-	)
-	require.NoError(t, err)
-	require.Nil(t, got)
+	require.Nil(t, devices.GetGPUDeviceByUUID(parent.UUID))
+	require.Nil(t, devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+		ParentUUID: parent.UUID,
+		GIID:       2,
+		CIID:       3,
+	}))
 }
 
 func TestHealthMonitorStartRequiresRegisteredEvents(t *testing.T) {
 	m := &nvmlDeviceHealthMonitor{}
 	require.ErrorContains(t, m.Start(context.Background()), "events have not been registered")
+}
+
+func TestGetDeviceIncludesHealthTaints(t *testing.T) {
+	dev := &AllocatableDevice{Gpu: &GpuInfo{
+		UUID:                  "GPU-1",
+		minor:                 0,
+		cudaComputeCapability: "9.0",
+		driverVersion:         "580.0",
+		cudaDriverVersion:     "13.0",
+	}}
+	taint := &resourceapi.DeviceTaint{
+		Key:    TaintKeyXID,
+		Value:  "43",
+		Effect: resourceapi.DeviceTaintEffectNone,
+	}
+	require.True(t, dev.AddOrUpdateTaint(taint))
+
+	got := dev.GetDevice(nil)
+
+	require.Len(t, got.Taints, 1)
+	assert.Equal(t, *taint, got.Taints[0])
+}
+func TestClearDynamicMIGXIDTaint(t *testing.T) {
+	dynamic := &AllocatableDevice{MigDynamic: &MigSpec{}}
+	dynamic.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+		Key:   TaintKeyXID,
+		Value: "43",
+	})
+	dynamic.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+		Key: TaintKeyGPULost,
+	})
+
+	static := &AllocatableDevice{MigStatic: &MigDeviceInfo{}}
+	static.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+		Key:   TaintKeyXID,
+		Value: "43",
+	})
+
+	state := &DeviceState{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				"0000:01:00.0": {
+					"dynamic": dynamic,
+					"static":  static,
+				},
+			},
+		},
+	}
+
+	state.clearDynamicMIGXIDTaint("dynamic")
+	state.clearDynamicMIGXIDTaint("static")
+
+	require.Len(t, dynamic.Taints(), 1)
+	assert.Equal(t, TaintKeyGPULost, dynamic.Taints()[0].Key)
+
+	require.Len(t, static.Taints(), 1)
+	assert.Equal(t, TaintKeyXID, static.Taints()[0].Key)
 }

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -490,14 +490,18 @@ func (s *DeviceState) DestroyUnknownMIGDevices(ctx context.Context) {
 	klog.Infof("%s: done", logpfx)
 }
 
-func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.NamespacedObject) error {
+// Unprepare returns true when cleanup removes a Dynamic MIG XID taint and the
+// caller must republish the ResourceSlice.
+// TODO: May be replace this bool with a general resource-change result if Unprepare
+// starts reporting other changes that require republishing.
+func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.NamespacedObject) (bool, error) {
 	s.Lock()
 	defer s.Unlock()
 	klog.V(6).Infof("Unprepare() for claim '%s'", claimRef.String())
 
 	checkpoint, err := s.getCheckpoint(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to get checkpoint: %w", err)
+		return false, fmt.Errorf("unable to get checkpoint: %v", err)
 	}
 
 	claimUID := string(claimRef.UID)
@@ -508,20 +512,22 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 		// Prepare+Checkpoint are done transactionally). Note that
 		// claimRef.String() contains namespace, name, UID.
 		klog.V(2).Infof("Unprepare noop: claim not found in checkpoint data: %v", claimRef.String())
-		return nil
+		return false, nil
 	}
 
+	var taintRemoved bool
 	switch pc.CheckpointState {
 	case ClaimCheckpointStatePrepareStarted:
 		if err := s.unpreparePartiallyPreparedClaim(ctx, claimUID, pc, checkpoint); err != nil {
-			return fmt.Errorf("unprepare failed for partially prepared claim %s failed: %w", claimRef.String(), err)
+			return false, fmt.Errorf("unprepare failed for partially prepared claim %s failed: %w", claimRef.String(), err)
 		}
 	case ClaimCheckpointStatePrepareCompleted:
-		if err := s.unprepareDevices(ctx, claimUID, pc.PreparedDevices, checkpoint); err != nil {
-			return fmt.Errorf("unprepare devices failed for claim %s: %w", claimRef.String(), err)
+		taintRemoved, err = s.unprepareDevices(ctx, claimUID, pc.PreparedDevices, checkpoint)
+		if err != nil {
+			return false, fmt.Errorf("unprepare devices failed for claim %s: %w", claimRef.String(), err)
 		}
 	default:
-		return fmt.Errorf("unsupported ClaimCheckpointState: %v", pc.CheckpointState)
+		return false, fmt.Errorf("unsupported ClaimCheckpointState: %v", pc.CheckpointState)
 	}
 
 	// TODO: Remove this once partitionable device support is introduced for vfio devices.
@@ -556,13 +562,13 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 			// back on the nvidia driver) with fresh Fabric Manager info.
 			err := s.discoverSiblingAllocatables(allocatableDevice)
 			if err != nil {
-				return fmt.Errorf("error discovering sibling allocatables: %w", err)
+				return false, fmt.Errorf("error discovering sibling allocatables: %w", err)
 			}
 		}
 	}
 	if s.fabricManagerPartitioningEnabled() {
 		if err := s.deactivateFabricPartition(claimUID, &pc, checkpoint); err != nil {
-			return fmt.Errorf("error deactivating fabric partition: %w", err)
+			return false, fmt.Errorf("error deactivating fabric partition: %w", err)
 		}
 	}
 
@@ -581,9 +587,9 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 	// PreparedClaims map.
 	err = s.deleteClaimFromCheckpoint(ctx, claimRef)
 	if err != nil {
-		return fmt.Errorf("error deleting claim from checkpoint: %w", err)
+		return false, fmt.Errorf("error deleting claim from checkpoint: %w", err)
 	}
-	return nil
+	return taintRemoved, nil
 }
 
 // Rollback previously partially prepared claim.
@@ -1124,14 +1130,15 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 	return preparedDevices, nil
 }
 
-func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, devices PreparedDevices, checkpoint *Checkpoint) error {
+func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, devices PreparedDevices, checkpoint *Checkpoint) (bool, error) {
 	klog.V(6).Infof("Unpreparing claim '%s', previously prepared devices from checkpoint: %v", claimUID, devices.GetDeviceNames())
+	var taintRemoved bool
 	for _, group := range devices {
 		// Unconfigure the vfio-pci devices.
 		if featuregates.Enabled(featuregates.PassthroughSupport) {
 			err := s.unprepareVfioDevices(ctx, group.Devices.VfioDevices())
 			if err != nil {
-				return fmt.Errorf("error unpreparing VFIO devices: %w", err)
+				return false, fmt.Errorf("error unpreparing VFIO devices: %w", err)
 			}
 		}
 
@@ -1158,7 +1165,10 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, dev
 					err := s.nvdevlib.deleteMigDevice(mig)
 					if err != nil {
 						klog.Warningf("Error deleting MIG device %s: %s", device.Mig.Device.DeviceName, err)
-						return fmt.Errorf("error deleting MIG device %s: %w", device.Mig.Device.DeviceName, err)
+						return false, fmt.Errorf("error deleting MIG device %s: %w", device.Mig.Device.DeviceName, err)
+					}
+					if s.clearDynamicMIGXIDTaint(device.Mig.Device.DeviceName) {
+						taintRemoved = true
 					}
 				} else {
 					klog.V(4).Infof("Unprepare: static MIG: noop (MIG %s)", device.Mig.Concrete.MigUUID)
@@ -1170,7 +1180,7 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, dev
 		if featuregates.Enabled(featuregates.MPSSupport) {
 			mpsControlDaemon := s.mpsManager.NewMpsControlDaemon(claimUID, group)
 			if err := mpsControlDaemon.Stop(ctx); err != nil {
-				return fmt.Errorf("error stopping MPS control daemon: %w", err)
+				return false, fmt.Errorf("error stopping MPS control daemon: %w", err)
 			}
 		}
 		// Reset when time-slicing was applied at prepare (true), or when the
@@ -1192,14 +1202,14 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, dev
 					if err == nvml.ERROR_NOT_SUPPORTED {
 						klog.Warningf("Unprepare: skip resetting time-slice policy for devices: %v", err)
 					} else {
-						return fmt.Errorf("error setting timeslice for devices: %w", err)
+						return false, fmt.Errorf("error setting timeslice for devices: %w", err)
 					}
 				}
 			}
 		}
 
 	}
-	return nil
+	return taintRemoved, nil
 }
 
 // unprepareVfioDevices rebinds each passthrough GPU from vfio-pci back to the
@@ -1984,6 +1994,26 @@ func isAdminAccess(results []resourceapi.DeviceRequestAllocationResult) bool {
 		if r.AdminAccess != nil && *r.AdminAccess {
 			return true
 		}
+	}
+	return false
+}
+
+// clearDynamicMIGXIDTaint clears health state that belongs to a concrete
+// Dynamic MIG incarnation after that device no longer exists. Parent-scoped
+// taints, such as GPU lost or an unavailable health monitor, remain intact.
+//
+// NOTE: An XID event already queued before deletion could re-add the taint.
+// This cleanup intentionally does not track concrete MIG
+// incarnations; that race can be addressed separately if observed.
+func (s *DeviceState) clearDynamicMIGXIDTaint(name DeviceName) bool {
+	device := s.perGPUAllocatable.GetAllocatableDevice(name)
+	if device == nil || device.Type() != MigDynamicDeviceType {
+		return false
+	}
+	if taint, removed := device.RemoveTaint(TaintKeyXID); removed {
+		klog.V(4).Infof("Cleared health taint for destroyed Dynamic MIG device %s: key=%q, value=%q, effect=%s",
+			name, taint.Key, taint.Value, taint.Effect)
+		return true
 	}
 	return false
 }

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -128,6 +128,24 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		useSplitResourceSlices: useSplitSlices,
 	}
 
+	// Register NVML events before kubeletplugin.Start exposes Prepare/Unprepare.
+	// On plugin restart, previously prepared devices and their workloads can remain
+	// live and emit an XID before the kubelet service is available. NVML does not
+	// retain events that occur before registration.
+	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
+		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
+		}
+		driver.deviceHealthMonitor = deviceHealthMonitor
+
+		// Events recorded after registration remain queued until Start begins
+		// waiting after the kubelet helper is available.
+		if err := deviceHealthMonitor.RegisterEvents(); err != nil {
+			return nil, fmt.Errorf("failed to register NVML device events: %w", err)
+		}
+	}
+
 	opts := []kubeletplugin.Option{
 		kubeletplugin.KubeClient(driver.client),
 		kubeletplugin.NodeName(config.flags.nodeName),
@@ -154,23 +172,6 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	}
 	driver.healthcheck = healthcheck
 
-	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
-		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
-		}
-		if err := deviceHealthMonitor.Start(ctx); err != nil {
-			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
-		}
-		driver.deviceHealthMonitor = deviceHealthMonitor
-
-		driver.wg.Add(1)
-		go func() {
-			defer driver.wg.Done()
-			driver.deviceHealthEvents(ctx, config.flags.nodeName)
-		}()
-	}
-
 	// Pass `nodeUnprepareResource` function to the cleanup manager.
 	if err := state.checkpointCleanupManager.Start(ctx, driver.nodeUnprepareResource); err != nil {
 		return nil, fmt.Errorf("error starting CheckpointCleanupManager: %w", err)
@@ -178,6 +179,25 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 
 	if err := driver.publishResources(ctx, config); err != nil {
 		return nil, err
+	}
+
+	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
+		// RegisterEvents can queue unmonitored events before this consumer
+		// starts. Publish the initial ResourceSlices first, so subsequent health
+		// updates republish tainted resources without an initial snapshot
+		// overwriting them.
+		// TODO: NVML does not replay XIDs emitted before registration. Because
+		// health taints are not persisted, a restart can advertise a device as
+		// healthy unless the fault emits another event. Persist health state or
+		// validate recovery before clearing taints during startup.
+		driver.wg.Add(1)
+		go func() {
+			defer driver.wg.Done()
+			driver.deviceHealthEvents(ctx, config.flags.nodeName)
+		}()
+		if err := driver.deviceHealthMonitor.Start(ctx); err != nil {
+			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
+		}
 	}
 
 	klog.V(4).Infof("Current kubelet plugin registration status: %s", helper.RegistrationStatus())

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -130,6 +130,24 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		useSplitResourceSlices: useSplitSlices,
 	}
 
+	// Register NVML events before kubeletplugin.Start exposes Prepare/Unprepare.
+	// On plugin restart, previously prepared devices and their workloads can remain
+	// live and emit an XID before the kubelet service is available. NVML does not
+	// retain events that occur before registration.
+	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
+		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
+		}
+		driver.deviceHealthMonitor = deviceHealthMonitor
+
+		// Events recorded after registration remain queued until Start begins
+		// waiting after the kubelet helper is available.
+		if err := deviceHealthMonitor.RegisterEvents(); err != nil {
+			return nil, fmt.Errorf("failed to register NVML device events: %w", err)
+		}
+	}
+
 	opts := []kubeletplugin.Option{
 		kubeletplugin.KubeClient(driver.client),
 		kubeletplugin.NodeName(config.flags.nodeName),
@@ -158,23 +176,6 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	}
 	driver.healthcheck = healthcheck
 
-	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
-		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
-		}
-		if err := deviceHealthMonitor.Start(ctx); err != nil {
-			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
-		}
-		driver.deviceHealthMonitor = deviceHealthMonitor
-
-		driver.wg.Add(1)
-		go func() {
-			defer driver.wg.Done()
-			driver.deviceHealthEvents(ctx, config.flags.nodeName)
-		}()
-	}
-
 	// Pass `nodeUnprepareResource` function to the cleanup manager.
 	if err := state.checkpointCleanupManager.Start(ctx, driver.nodeUnprepareResource); err != nil {
 		return nil, fmt.Errorf("error starting CheckpointCleanupManager: %w", err)
@@ -182,6 +183,25 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 
 	if err := driver.publishResources(ctx, config); err != nil {
 		return nil, err
+	}
+
+	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
+		// RegisterEvents can queue unmonitored events before this consumer
+		// starts. Publish the initial ResourceSlices first, so subsequent health
+		// updates republish tainted resources without an initial snapshot
+		// overwriting them.
+		// TODO: NVML does not replay XIDs emitted before registration. Because
+		// health taints are not persisted, a restart can advertise a device as
+		// healthy unless the fault emits another event. Persist health state or
+		// validate recovery before clearing taints during startup.
+		driver.wg.Add(1)
+		go func() {
+			defer driver.wg.Done()
+			driver.deviceHealthEvents(ctx, config.flags.nodeName)
+		}()
+		if err := driver.deviceHealthMonitor.Start(ctx); err != nil {
+			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
+		}
 	}
 
 	klog.V(4).Infof("Current kubelet plugin registration status: %s", helper.RegistrationStatus())

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -197,7 +197,7 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		driver.wg.Add(1)
 		go func() {
 			defer driver.wg.Done()
-			driver.deviceHealthEvents(ctx, config.flags.nodeName)
+			driver.deviceHealthEvents(ctx)
 		}()
 		if err := driver.deviceHealthMonitor.Start(ctx); err != nil {
 			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
@@ -467,7 +467,7 @@ func (d *driver) nodeUnprepareResource(ctx context.Context, claimRef kubeletplug
 
 	cs := claimRef.String()
 	tunprep0 := time.Now()
-	err = d.state.Unprepare(ctx, claimRef)
+	taintRemovedRepublish, err := d.state.Unprepare(ctx, claimRef)
 	klog.V(6).Infof("t_unprep %.3f s (claim %s)", time.Since(tunprep0).Seconds(), cs)
 
 	if err != nil {
@@ -475,8 +475,12 @@ func (d *driver) nodeUnprepareResource(ctx context.Context, claimRef kubeletplug
 		return fmt.Errorf("error unpreparing devices for claim %v: %w", claimRef.String(), err)
 	}
 
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
-		// Re-advertise updated resourceslice after unpreparing devices.
+	if featuregates.Enabled(featuregates.PassthroughSupport) ||
+		(featuregates.Enabled(featuregates.DynamicMIG) &&
+			featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) &&
+			taintRemovedRepublish) {
+		// Re-advertise updated resourceslice after unpreparing devices
+		// or removed a Dynamic MIG XID taint.
 		if err = d.publishResources(ctx, d.state.config); err != nil {
 			drametrics.IncNodeUnprepareError(DriverName, "publish_resources")
 			return fmt.Errorf("error publishing resources: %w", err)
@@ -528,7 +532,7 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 
 }
 
-func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
+func (d *driver) deviceHealthEvents(ctx context.Context) {
 	klog.V(4).Info("Starting to watch for device health notifications")
 	for {
 		select {
@@ -545,26 +549,13 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
 			taint := healthEventToTaint(d.deviceHealthMonitor, event)
 			modified := false
 			for _, dev := range event.Devices {
-				klog.Warningf("Received %s health event for device %s", event.EventType, dev.UUID())
+				klog.Warningf("Received %s health event for device %s", event.EventType, dev.CanonicalName())
 				if d.state.AddDeviceTaint(dev, taint) {
 					modified = true
 				}
 			}
 			if !modified {
 				continue
-			}
-
-			var resourceSlice resourceslice.Slice
-			for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
-				for _, dev := range devices {
-					d := dev.GetDevice(d.state.config)
-
-					taints := dev.Taints()
-					if len(taints) > 0 {
-						d.Taints = taints
-					}
-					resourceSlice.Devices = append(resourceSlice.Devices, d)
-				}
 			}
 
 			// NOTE: We only log an error on publish failure and do not retry.
@@ -581,12 +572,6 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
 			klog.V(4).Infof("Republishing ResourceSlice: %d device(s) tainted with %s=%q (effect=%s)",
 				len(event.Devices), taint.Key, taint.Value, taint.Effect)
 
-			resources := resourceslice.DriverResources{
-				Pools: map[string]resourceslice.Pool{
-					nodeName: {Slices: []resourceslice.Slice{resourceSlice}},
-				},
-			}
-
 			// NOTE: GPU_LOST and unmonitored events are already batched at the
 			// sender (all affected devices arrive in a single DeviceHealthEvent).
 			// XID events are still per-device and may cause repeated publishes.
@@ -594,8 +579,8 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
 			// Evaluate two strategies:
 			// 1. Channel drain: non-blocking pull of all pending events (Pro: zero latency; Con: susceptible to NVML lag).
 			// 2. Timer debounce: e.g., 50ms window (Pro: standard K8s API protection; Con: slight delay).
-			// This also needs to be handle properly in the recovery path.
-			if err := d.pluginhelper.PublishResources(ctx, resources); err != nil {
+			// This also needs to be handled properly in the recovery path.
+			if err := d.publishResources(ctx, d.state.config); err != nil {
 				klog.Errorf("Failed to publish resources after taint update: %v", err)
 			}
 		}

--- a/cmd/gpu-kubelet-plugin/partitions.go
+++ b/cmd/gpu-kubelet-plugin/partitions.go
@@ -215,22 +215,23 @@ func (i MigSpec) PartConsumesCounters() []resourceapi.DeviceCounterConsumption {
 
 // A variant of the legacy `GetDevice()`, for the Partitionable Devices paradigm.
 func (d *AllocatableDevice) PartGetDevice(config *Config) resourceapi.Device {
+	var dev resourceapi.Device
 	switch d.Type() {
 	case GpuDeviceType:
-		dev := d.Gpu.PartGetDevice()
+		dev = d.Gpu.PartGetDevice()
 		applyConsumableShares(&dev, config)
-		return dev
 	case MigStaticDeviceType:
 		panic("PartGetDevice() called for MigStaticDeviceType")
 	case MigDynamicDeviceType:
-		dev := d.MigDynamic.PartGetDevice()
+		dev = d.MigDynamic.PartGetDevice()
 		applyConsumableShares(&dev, config)
-		return dev
 	case VfioDeviceType:
 		panic("not yet implemented")
 	default:
 		panic("unexpected type for AllocatableDevice")
 	}
+	dev.Taints = d.Taints()
+	return dev
 }
 
 // Insert one counter for each memory slice consumed, as given by the `start`

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -259,10 +259,6 @@ func ValidateFeatureGates() error {
 		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", DynamicMIG, PassthroughSupport)
 	}
 
-	if Enabled(DynamicMIG) && Enabled(NVMLDeviceHealthCheck) {
-		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", DynamicMIG, NVMLDeviceHealthCheck)
-	}
-
 	if Enabled(DynamicMIG) && Enabled(MPSSupport) {
 		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", DynamicMIG, MPSSupport)
 	}

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -471,11 +471,10 @@ func TestValidateFeatureGates(t *testing.T) {
 			description:  "should fail when both DynamicMIG and PassthroughSupport are enabled",
 		},
 		{
-			name:         "DynamicMIG enabled with NVMLDeviceHealthCheck",
-			fgMap:        map[featuregate.Feature]bool{DynamicMIG: true, NVMLDeviceHealthCheck: true},
-			expectError:  true,
-			errorMessage: "feature gate DynamicMIG is currently mutually exclusive with NVMLDeviceHealthCheck",
-			description:  "should fail when both DynamicMIG and NVMLDeviceHealthCheck are enabled",
+			name:        "DynamicMIG enabled with NVMLDeviceHealthCheck",
+			fgMap:       map[featuregate.Feature]bool{DynamicMIG: true, NVMLDeviceHealthCheck: true},
+			expectError: false,
+			description: "should allow DynamicMIG health monitoring",
 		},
 		{
 			name:         "DynamicMIG enabled with MPSSupport",

--- a/site/content/docs/reference/feature-gates.md
+++ b/site/content/docs/reference/feature-gates.md
@@ -53,7 +53,6 @@ The following feature gate combinations are mutually exclusive and cannot be ena
 | Combination | Reason |
 | --- | --- |
 | `DynamicMIG` + `PassthroughSupport` | Mutually exclusive |
-| `DynamicMIG` + `NVMLDeviceHealthCheck` | Mutually exclusive |
 | `DynamicMIG` + `MPSSupport` | Mutually exclusive |
 | `PassthroughSupport` + `NVMLDeviceHealthCheck` | Mutually exclusive |
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature
-->

#### What this PR does / why we need it:
- Refractors NVML health routing to use existing GPU inventory for both Full GPUs and Static MIG devices 
- Enables healthchecking of dynamically created devices

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1164
Follow-up of https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1253

#### Special notes for your reviewer:

- This enables DynamicMIG and NVMLDeviceHealthCheck to be used together.
- NVML events are registered once on each physical parent GPU before the kubelet plugin starts accepting Prepare requests. MIG XIDs continue to use the same exact (parent UUID, GI, CI) attribution as static MIG.

Cursor assisted with the PR.

#### Does this PR introduce a user-facing change?
Yes. DynamicMIG and NVMLDeviceHealthCheck can now be enabled together.
```release-note
Added NVML health monitoring support for Dynamic MIG devices, including DRA device taint propagation.
```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally

- [x] Tests added or updated for the change
