### PR TITLE
Add search box

### DIFF
--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -7,6 +7,7 @@ type: docs
 cascade:
   type: docs
 ---
+<meta name="algolia-site-verification"  content="80E709C1F52CF68E" />
 
 The DRA Driver for NVIDIA GPUs is a Kubernetes [Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) driver that enables flexible GPU allocation and provisioning of multi-node NVLink fabrics for Kubernetes workloads.
 It requires Kubernetes 1.32 or later. Starting in Kubernetes 1.34, DRA is enabled by default. On Kubernetes 1.32 and 1.33, the `DynamicResourceAllocation` feature gate must be enabled.

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -80,17 +80,17 @@ enableGitInfo = true
     sidebar_menu_foldable = true
     # Search hidden until Algolia DocSearch is approved + configured.
     # Flip to false once [params.search.algolia] is populated below.
-    sidebar_search_disable = true
+    sidebar_search_disable = false
 
     [params.ui.feedback]
       enable = false
 
   # Algolia DocSearch — uncomment and populate after the OSS application
   # is approved. Also flip params.ui.sidebar_search_disable to false above.
-  # [params.search.algolia]
-  #   appId = ""
-  #   apiKey = ""
-  #   indexName = ""
+   [params.search.algolia]
+     appId = "W12287PLRG"
+     apiKey = "2d752a2eb1d1da62d8f0bab90c35f299"
+     indexName = "DRA Driver Site"
 
   [params.links]
     [[params.links.user]]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:

adds in search information with Algolia Search through DocSearch
adds search configuration to hugo.toml
add temp verification data to index page

links
* https://docsearch.algolia.com/docs/what-is-docsearch
* https://www.docsy.dev/docs/content/search/#sign-up-for-algolia-docsearch

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
