### PR TITLE
normalize vfio driver name for gpu passthrough

### DIFF
--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -37,6 +37,7 @@ const (
 	nvidiaDriver                 = "nvidia"
 	sysModulePath                = "/sys/module"
 	pciDevicesPath               = "/sys/bus/pci/devices"
+	pciDriversPath               = "/sys/bus/pci/drivers"
 	vfioDevicesRoot              = "/dev/vfio"
 	vfioDevicesPath              = "/dev/vfio/devices"
 	iommuDevicePath              = "/dev/iommu"
@@ -136,23 +137,6 @@ func (vm *VfioPciManager) verifyDisabledVFs(pciBusID string) error {
 
 // Configure binds the GPU to the vfio-pci driver.
 func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) error {
-	driver, err := getDriver(pciDevicesPath, info.PciBusID)
-	if err != nil {
-		return fmt.Errorf("error getting driver details for GPU %q: %w", info.PciBusID, err)
-	}
-
-	vfioDriver := getVfioDriverName(info.vfioModule)
-
-	// Skip if the GPU is already bound to the vfio-pci driver.
-	if driver == vfioDriver {
-		return nil
-	}
-
-	// Only support vfio-pci (or variant) or nvidia (if vm.nvidiaEnabled) driver.
-	if !vm.nvidiaEnabled || driver != nvidiaDriver {
-		return fmt.Errorf("GPU %q is bound to %q driver, expected %q or %q", info.PciBusID, driver, vfioDriver, nvidiaDriver)
-	}
-
 	if loaded, err := vm.checkKernelModuleLoaded(info.vfioModule); err == nil {
 		if !loaded {
 			err = vm.loadKernelModule(info.vfioModule)
@@ -162,6 +146,26 @@ func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) e
 		}
 	} else {
 		return fmt.Errorf("error checking if module %q is loaded: %w", info.vfioModule, err)
+	}
+
+	vfioDriver, err := getVfioDriverName(info.vfioModule)
+	if err != nil {
+		return fmt.Errorf("error getting vfio driver for GPU %q: %w", info.PciBusID, err)
+	}
+
+	driver, err := getDriver(pciDevicesPath, info.PciBusID)
+	if err != nil {
+		return fmt.Errorf("error getting driver details for GPU %q: %w", info.PciBusID, err)
+	}
+
+	// Skip if the GPU is already bound to the vfio-pci driver.
+	if driver == vfioDriver {
+		return nil
+	}
+
+	// Only support vfio-pci (or variant) or nvidia (if vm.nvidiaEnabled) driver.
+	if !vm.nvidiaEnabled || driver != nvidiaDriver {
+		return fmt.Errorf("GPU %q is bound to %q driver, expected %q or %q", info.PciBusID, driver, vfioDriver, nvidiaDriver)
 	}
 
 	// Disable GPU Persistence Mode.
@@ -191,12 +195,37 @@ func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) e
 	return nil
 }
 
-// The driver name of vfio_pci module (and its variants) can be derived
-// by substituting all occurrences of underscores `_` with dashes `-`.
-// Eg: Given the module `vfio_pci`, its corresponding driver name under
-// `/sys/bus/pci/drivers/` is `vfio-pci`.
-func getVfioDriverName(vfioModule string) string {
-	return strings.ReplaceAll(vfioModule, "_", "-")
+// Module names in the modules.alias file will only ever contain underscore
+// characters and not dashes -- this aligns with how the linux kernel
+// stores module names internally. This can sometimes differ from the name of the
+// directory in /sys/bus/pci/drivers/ for a given module. For example, this
+// contradiction exists for the standard vfio-pci module:
+//
+// $ file /sys/bus/pci/drivers/vfio-pci
+// sys/bus/pci/drivers/vfio-pci: directory
+//
+// $ modinfo vfio-pci | grep ^name:
+// name:           vfio_pci
+//
+// To account for this difference, we check if the module name exists in
+// /sys/bus/pci/drivers, and if not, we try again but with any underscore
+// characters converted to dashes.
+func getVfioDriverName(vfioModule string) (string, error) {
+	vfioDriver := vfioModule
+	if _, err := os.Stat(filepath.Join(pciDriversPath, vfioDriver)); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("unexpected error checking driver directory for vfio module %q at %q: %w", vfioModule, pciDriversPath, err)
+		}
+		vfioDriverNormalized := strings.ReplaceAll(vfioDriver, "_", "-")
+		if _, err := os.Stat(filepath.Join(pciDriversPath, vfioDriverNormalized)); err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				return "", fmt.Errorf("unexpected error checking driver directory for vfio module %q at %q: %w", vfioModule, pciDriversPath, err)
+			}
+			return "", fmt.Errorf("failed to find driver directory for vfio module %q at %q, is the module loaded?", vfioModule, pciDriversPath)
+		}
+		vfioDriver = vfioDriverNormalized
+	}
+	return vfioDriver, nil
 }
 
 // Unconfigure binds the GPU to the nvidia driver.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
Bug fix for passthrough support on GB200 machines. When preparing the GPU vfio device, the vfio-pci module name is normalized and its presence is validated in `/sys/bus/pci/drivers` before device configuration.


#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Fixes #1268

#### Special notes for your reviewer:
Tested on both A100 (`vfio-pci`) and GB200 (`nvgrace_vfio_pci`) machines and verified appropriate vfio driver is chosen.

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
