### PR TITLE
Reset GPU compute mode to DEFAULT on MPS teardown

### DIFF
--- a/cmd/gpu-kubelet-plugin/sharing.go
+++ b/cmd/gpu-kubelet-plugin/sharing.go
@@ -443,6 +443,13 @@ func (m *MpsControlDaemon) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to delete deployment: %w", err)
 	}
 
+	// Start() sets the compute mode of these GPUs to EXCLUSIVE_PROCESS as
+	// required by MPS. Reset it back to DEFAULT here so the GPUs are not left
+	// stuck in EXCLUSIVE_PROCESS after teardown.
+	if err := m.manager.nvdevlib.setComputeMode(m.devices.GpuUUIDs(), "DEFAULT"); err != nil {
+		return fmt.Errorf("error resetting compute mode to DEFAULT: %w", err)
+	}
+
 	mountExecutable, err := exec.LookPath("mount")
 	if err != nil {
 		return fmt.Errorf("error finding 'mount' executable: %w", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

MPS `Start()` sets GPU compute mode to `EXCLUSIVE_PROCESS`, but `Stop()` did not restore `DEFAULT`. Reset previously happened only via the time-slicing path in `unprepareDevices()`, which does not run for MPS-only claims when `TimeSlicingSettings` is disabled, leaving GPUs stuck in `EXCLUSIVE_PROCESS` after teardown.
This PR resets compute mode to `DEFAULT` in `MpsControlDaemon.Stop()` so MPS teardown always restores the mode.

#### Which issue(s) this PR is related to:

Fixes #1262

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
MPS teardown now resets GPU compute mode to DEFAULT after stopping the MPS control daemon, so MPS-only claims no longer leave GPUs in EXCLUSIVE_PROCESS when time-slicing settings are disabled.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs
NONE
```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
