### PR TITLE
Extend FabricManagerPartitioning featuregate to full GPU devices

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -227,7 +227,7 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	state.checkpointCleanupManager = NewCheckpointCleanupManager(state, config.clientsets.Resource)
 
 	// Attach Fabric Manager partition mappings to every discovered GPU. The
-	// gpuModuleId was resolved from NVML during GPU discovery; the FM Manager
+	// gpuModuleID was resolved from NVML during GPU discovery; the FM Manager
 	// (owned by DeviceState) turns it into the size->partitionId mapping that
 	// VFIO devices publish via their parent GpuInfo.
 	if state.fabricManagerPartitioningEnabled() {
@@ -519,14 +519,12 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 
 	// TODO: Remove this once partitionable device support is introduced for vfio devices.
 	if featuregates.Enabled(featuregates.PassthroughSupport) {
-		var vfioInfos []*VfioDeviceInfo
 		for _, device := range pc.PreparedDevices.GetDevices() {
 			allocatableDevice := s.perGPUAllocatable.GetAllocatableDevice(device.DeviceName)
 			if allocatableDevice == nil {
 				klog.Warningf("allocatable not found for device: %v", device.DeviceName)
 				continue
 			}
-			isVfio := allocatableDevice.Type() == VfioDeviceType
 			// Rediscover all sibling devices on the parent GPU of the unprepared device.
 			// When vfio type is unprepared, gpu type should be advertised and vice versa.
 			// For a VFIO device this also repopulates its parent GpuInfo (now
@@ -535,18 +533,11 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 			if err != nil {
 				return fmt.Errorf("error discovering sibling allocatables: %w", err)
 			}
-			if isVfio {
-				vfioInfos = append(vfioInfos, allocatableDevice.Vfio)
-			}
 		}
-
-		// The passthrough GPUs are back on the nvidia driver and their parent
-		// GpuInfo carries a fresh gpuModuleId; only now can we resolve and
-		// deactivate the Fabric Manager partition they formed.
-		if s.fabricManagerPartitioningEnabled() && len(vfioInfos) > 0 {
-			if err := s.deactivateFabricPartition(vfioInfos); err != nil {
-				return fmt.Errorf("error deactivating fabric partition: %w", err)
-			}
+	}
+	if s.fabricManagerPartitioningEnabled() {
+		if err := s.deactivateFabricPartition(&pc); err != nil {
+			return fmt.Errorf("error deactivating fabric partition: %w", err)
 		}
 	}
 
@@ -611,12 +602,10 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 // other entity that currently legitimately owns the device represented in `pc`.
 func (s *DeviceState) unpreparePartiallyPrepairedClaim(ctx context.Context, cuid string, pc PreparedClaim, checkpoint *Checkpoint) error {
 	// Roll back VFIO passthrough side effects. A previous Prepare() attempt may
-	// have already bound one or more GPUs to vfio-pci and activated the
-	// corresponding Fabric Manager partition. Unlike the completed path that
-	// operates on checkpointed PreparedDevices, a partially prepared claim has
-	// no PreparedDevices checkpointed yet, so we resolve the affected VFIO
-	// devices from the allocation results and mirror the completed-path
-	// teardown.
+	// have already bound one or more GPUs to vfio-pci. Unlike the completed
+	// path that operates on checkpointed PreparedDevices, a partially prepared
+	// claim has no PreparedDevices checkpointed yet, so we resolve the affected
+	// VFIO devices from the allocation results and mirror the completed-path
 	if featuregates.Enabled(featuregates.PassthroughSupport) && pc.Status.Allocation != nil {
 		var vfioDevices []*AllocatableDevice
 		for _, r := range pc.Status.Allocation.Devices.Results {
@@ -643,10 +632,8 @@ func (s *DeviceState) unpreparePartiallyPrepairedClaim(ctx context.Context, cuid
 			// GPU back to the nvidia driver, then rediscover so each VFIO
 			// device's parent GpuInfo is repopulated with fresh Fabric Manager
 			// info, and only then deactivate the FM partition.
-			infos := make([]*VfioDeviceInfo, 0, len(vfioDevices))
 			for _, device := range vfioDevices {
 				info := device.Vfio
-				infos = append(infos, info)
 				if err := s.vfioPciManager.Unconfigure(ctx, info); err != nil {
 					return fmt.Errorf("error unconfiguring vfio device %q: %w", info.CanonicalName(), err)
 				}
@@ -657,10 +644,12 @@ func (s *DeviceState) unpreparePartiallyPrepairedClaim(ctx context.Context, cuid
 					return fmt.Errorf("error discovering sibling allocatables for vfio device %q: %w", device.Vfio.CanonicalName(), err)
 				}
 			}
+		}
+	}
 
-			if err := s.deactivateFabricPartition(infos); err != nil {
-				return fmt.Errorf("error deactivating fabric partition: %w", err)
-			}
+	if s.fabricManagerPartitioningEnabled() {
+		if err := s.deactivateFabricPartition(&pc); err != nil {
+			return fmt.Errorf("error deactivating fabric partition: %w", err)
 		}
 	}
 
@@ -905,6 +894,12 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 		}
 	}
 
+	if s.fabricManagerPartitioningEnabled() {
+		if err := s.activateFabricPartition(claim); err != nil {
+			return nil, err
+		}
+	}
+
 	// Normalize, validate, and apply all configs associated with devices that
 	// need to be prepared. Track device group configs generated from applying the
 	// config to the set of device allocation results.
@@ -1104,7 +1099,7 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, dev
 // nvidia driver. It intentionally does NOT deactivate the Fabric Manager
 // partition: deactivation is deferred to the caller until after the parent
 // GpuInfo has been repopulated (via discoverSiblingAllocatables) with a fresh
-// gpuModuleId resolved from NVML now that the GPU is visible again.
+// gpuModuleID resolved from NVML now that the GPU is visible again.
 func (s *DeviceState) unprepareVfioDevices(ctx context.Context, devices PreparedDeviceList) error {
 	for _, device := range devices {
 		vfioAllocatable := s.perGPUAllocatable.GetAllocatableDevice(device.Vfio.Device.DeviceName)
@@ -1151,7 +1146,7 @@ func (s *DeviceState) discoverSiblingAllocatables(device *AllocatableDevice) err
 		device.Vfio.parent = gpu.Gpu
 
 		// The GPU is back on the nvidia driver: its freshly discovered parent
-		// GpuInfo already carries the gpuModuleId (resolved from NVML in
+		// GpuInfo already carries the gpuModuleID (resolved from NVML in
 		// getGpuInfo). Attach the FM partition mapping.
 		if err := s.attachFabricManagerPartitions(gpu.Gpu); err != nil {
 			return fmt.Errorf("error attaching fabric manager partitions for gpu %q: %w", gpu.Gpu.CanonicalName(), err)
@@ -1279,14 +1274,6 @@ func (s *DeviceState) applyVfioDeviceConfig(ctx context.Context, config *configa
 		infos = append(infos, device.Vfio)
 	}
 
-	// Program the NVSwitch fabric for this set of passthrough GPUs via Fabric
-	// Manager *before* binding them to vfio-pci
-	if s.fabricManagerPartitioningEnabled() {
-		if err := s.activateFabricPartition(infos); err != nil {
-			return nil, err
-		}
-	}
-
 	for i, r := range results {
 		if err := s.vfioPciManager.Configure(ctx, infos[i]); err != nil {
 			return nil, fmt.Errorf("error configuring vfio device %q: %w", r.Device, err)
@@ -1296,21 +1283,20 @@ func (s *DeviceState) applyVfioDeviceConfig(ctx context.Context, config *configa
 	return &configState, nil
 }
 
-// resolveFabricPartitionForVfioDevices resolves the FM partition formed by the
-// given set of VFIO GPU devices, using each device's parent GpuInfo gpuModuleId
-// (resolved from NVML at discovery). The caller must ensure s.fmManager is
-// non-nil.
-func (s *DeviceState) resolveFabricPartitionForVfioDevices(infos []*VfioDeviceInfo) (int, error) {
-	moduleIDs := make([]int, 0, len(infos))
-	for _, info := range infos {
-		if info == nil || info.parent == nil || info.parent.gpuModuleID == 0 {
+// resolveFabricPartition resolves the FM partition formed by the given
+// set of physical GPUs, using each GPU's gpuModuleID (resolved from NVML at
+// discovery).
+func (s *DeviceState) resolveFabricPartition(gpus []*GpuInfo) (int, error) {
+	moduleIDs := make([]int, 0, len(gpus))
+	for _, gpu := range gpus {
+		if gpu == nil || gpu.gpuModuleID == 0 {
 			pci := ""
-			if info != nil {
-				pci = info.PciBusID
+			if gpu != nil {
+				pci = gpu.pciBusID
 			}
-			return 0, fmt.Errorf("fabric manager: no gpuModuleId for VFIO GPU at PCI %q", pci)
+			return 0, fmt.Errorf("fabric manager: no gpuModuleID for GPU at PCI %q", pci)
 		}
-		moduleIDs = append(moduleIDs, info.parent.gpuModuleID)
+		moduleIDs = append(moduleIDs, gpu.gpuModuleID)
 	}
 	partitionID, ok := s.fmManager.FindPartitionByModuleIDs(moduleIDs)
 	if !ok {
@@ -1319,8 +1305,60 @@ func (s *DeviceState) resolveFabricPartitionForVfioDevices(infos []*VfioDeviceIn
 	return partitionID, nil
 }
 
+// gpuInfosFromPreparedClaim maps a claim's device allocation results to the set of
+// backing physical GPUs for full GPUs and VFIO devices.
+func (s *DeviceState) gpuInfosFromPreparedClaim(results []resourceapi.DeviceRequestAllocationResult) []*GpuInfo {
+	var gpus []*GpuInfo
+	for _, r := range results {
+		if r.Driver != DriverName {
+			continue
+		}
+		device := s.perGPUAllocatable.GetAllocatableDevice(r.Device)
+		if device == nil {
+			klog.V(6).Infof("allocatable not found for device %q", r.Device)
+			continue
+		}
+		switch device.Type() {
+		case GpuDeviceType:
+			gpus = append(gpus, device.Gpu)
+		case VfioDeviceType:
+			gpus = append(gpus, device.Vfio.parent)
+		default:
+			klog.V(6).Infof("device %q has unsupported type %q; skipping for fabric partition", r.Device, device.Type())
+		}
+	}
+	return gpus
+}
+
+// deactivateFabricPartition releases the FM partition formed by the physical
+// GPUs backing the claim's allocation results. It is a no-op when Fabric
+// Manager partitioning is disabled or when the claim has no allocation.
+// Callers that include VFIO devices must first rebind those GPUs to the nvidia
+// driver and rediscover so each VFIO device's parent is repopulated.
+func (s *DeviceState) deactivateFabricPartition(pc *PreparedClaim) error {
+	if !s.fabricManagerPartitioningEnabled() || pc.Status.Allocation == nil {
+		return nil
+	}
+	gpus := s.gpuInfosFromPreparedClaim(pc.Status.Allocation.Devices.Results)
+	if len(gpus) == 0 {
+		return nil
+	}
+	partitionID, err := s.resolveFabricPartition(gpus)
+	if err != nil {
+		klog.Warningf("%v; skipping partition deactivation", err)
+		return nil
+	}
+	// DeactivatePartition is idempotent: an already-inactive partition is a
+	// no-op.
+	klog.V(2).Infof("Fabric Manager: deactivating partition %d for %d-GPU claim %s/%s", partitionID, len(gpus), pc.Namespace, pc.Name)
+	if err := s.fmManager.DeactivatePartition(partitionID); err != nil {
+		return fmt.Errorf("deactivating fabric partition %d: %w", partitionID, err)
+	}
+	return nil
+}
+
 // attachFabricManagerPartitions populates the given GPU's size->partitionId
-// mapping from its gpuModuleId using the FM Manager. It is a no-op when Fabric
+// mapping from its gpuModuleID using the FM Manager. It is a no-op when Fabric
 // Manager partitioning is disabled. It gracefully skips GPUs whose module ID
 // could not be resolved from NVML (e.g. a GPU that was already bound to
 // vfio-pci at discovery time).
@@ -1329,69 +1367,41 @@ func (s *DeviceState) attachFabricManagerPartitions(gpu *GpuInfo) error {
 		return nil
 	}
 	if gpu.gpuModuleID == 0 {
-		klog.Warningf("GPU %s has no gpuModuleId; skipping Fabric Manager partition attributes. "+
+		klog.Warningf("GPU %s has no gpuModuleID; skipping Fabric Manager partition attributes. "+
 			"This happens when the GPU was bound to vfio-pci before discovery (e.g. an active passthrough claim across a plugin restart).",
 			gpu.CanonicalName())
 		return nil
 	}
 	bySize, err := s.fmManager.GetPartitionsBySizeByModuleID(gpu.gpuModuleID)
 	if err != nil {
-		return fmt.Errorf("getting partition-by-size mapping for moduleId %d: %w", gpu.gpuModuleID, err)
+		return fmt.Errorf("getting partition-by-size mapping for moduleID %d: %w", gpu.gpuModuleID, err)
 	}
 	gpu.partitionsBySize = bySize
 	return nil
-}
-
-// fabricPartitionForVfioDevices resolves the FM partition formed by the given
-// set of VFIO GPU devices. It is lenient: lookup failures are logged and
-// reported as (0, false) so unprepare can proceed best-effort.
-func (s *DeviceState) fabricPartitionForVfioDevices(infos []*VfioDeviceInfo) (int, bool) {
-	partitionID, err := s.resolveFabricPartitionForVfioDevices(infos)
-	if err != nil {
-		klog.Warningf("%v; skipping partition (de)activation", err)
-		return 0, false
-	}
-	return partitionID, true
 }
 
 func (s *DeviceState) fabricManagerPartitioningEnabled() bool {
 	return featuregates.Enabled(featuregates.FabricManagerPartitioning) && s.fmManager != nil
 }
 
-// activateFabricPartition activates the FM partition formed by the given VFIO GPUs.
-func (s *DeviceState) activateFabricPartition(infos []*VfioDeviceInfo) error {
-	if !s.fabricManagerPartitioningEnabled() {
+// activateFabricPartition activates the FM partition formed by the physical
+// GPUs backing the claim's allocation results. The caller must ensure
+// fabricManagerPartitioningEnabled() is true and that the claim is allocated.
+func (s *DeviceState) activateFabricPartition(claim *resourceapi.ResourceClaim) error {
+	gpus := s.gpuInfosFromPreparedClaim(claim.Status.Allocation.Devices.Results)
+	if len(gpus) == 0 {
 		return nil
 	}
-	partitionID, err := s.resolveFabricPartitionForVfioDevices(infos)
+	partitionID, err := s.resolveFabricPartition(gpus)
 	if err != nil {
 		return fmt.Errorf("%v; refusing partition activation", err)
 	}
 	// ActivatePartition is idempotent: a retried Prepare (e.g. after a later
 	// step failed) that hits an already-active partition is a no-op rather than
 	// an FM in-use error.
-	klog.V(2).Infof("Fabric Manager: activating partition %d for %d-GPU passthrough claim", partitionID, len(infos))
+	klog.V(2).Infof("Fabric Manager: activating partition %d for %d-GPU claim %s", partitionID, len(gpus), ResourceClaimToString(claim))
 	if err := s.fmManager.ActivatePartition(partitionID); err != nil {
 		return fmt.Errorf("activating fabric partition %d: %w", partitionID, err)
-	}
-	return nil
-}
-
-// deactivateFabricPartition releases the FM partition formed by the given VFIO
-// GPUs.
-func (s *DeviceState) deactivateFabricPartition(infos []*VfioDeviceInfo) error {
-	if !s.fabricManagerPartitioningEnabled() {
-		return nil
-	}
-	partitionID, ok := s.fabricPartitionForVfioDevices(infos)
-	if !ok {
-		return nil
-	}
-	// DeactivatePartition is idempotent: an already-inactive partition is a
-	// no-op.
-	klog.V(2).Infof("Fabric Manager: deactivating partition %d for %d-GPU passthrough claim", partitionID, len(infos))
-	if err := s.fmManager.DeactivatePartition(partitionID); err != nil {
-		return fmt.Errorf("deactivating fabric partition %d: %w", partitionID, err)
 	}
 	return nil
 }

--- a/cmd/gpu-kubelet-plugin/deviceinfo.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo.go
@@ -210,7 +210,40 @@ func (d *GpuInfo) Attributes() map[resourceapi.QualifiedName]resourceapi.DeviceA
 		}
 	}
 
+	if featuregates.Enabled(featuregates.FabricManagerPartitioning) {
+		d.addFabricManagerAttributes(attrs)
+	}
+
 	return attrs
+}
+
+// addFabricManagerAttributes publishes the Fabric Manager-derived attributes
+// (`gpuModuleID` and `partitionN`) for this physical GPU. The values are
+// resolved from NVML / FM at discovery time (see attachFabricManagerPartitions).
+func (d *GpuInfo) addFabricManagerAttributes(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute) {
+	if d == nil {
+		return
+	}
+
+	if d.gpuModuleID == 0 && len(d.partitionsBySize) == 0 {
+		klog.V(4).Infof("No Fabric Manager attributes for %s", d.CanonicalName())
+		return
+	}
+
+	klog.V(4).Infof("Adding Fabric Manager attributes for %s: gpuModuleID=%d partitionsBySize=%v",
+		d.CanonicalName(), d.gpuModuleID, d.partitionsBySize)
+	if d.gpuModuleID != 0 {
+		attrs["gpuModuleID"] = resourceapi.DeviceAttribute{
+			IntValue: ptr.To(int64(d.gpuModuleID)),
+		}
+	}
+
+	for size, partitionID := range d.partitionsBySize {
+		key := resourceapi.QualifiedName(fmt.Sprintf("partition%d", size))
+		attrs[key] = resourceapi.DeviceAttribute{
+			IntValue: ptr.To(int64(partitionID)),
+		}
+	}
 }
 
 func (d *GpuInfo) GetDevice() resourceapi.Device {
@@ -286,44 +319,15 @@ func (d *VfioDeviceInfo) GetDevice() resourceapi.Device {
 	}
 
 	if featuregates.Enabled(featuregates.FabricManagerPartitioning) {
-		d.addFabricManagerAttributes(device.Attributes)
+		if d.parent == nil {
+			klog.V(4).Infof("No parent GPU for %s; skipping Fabric Manager attributes", d.CanonicalName())
+		} else {
+			d.parent.addFabricManagerAttributes(device.Attributes)
+		}
 	}
 	addNumaNodeAttribute(device.Attributes, &d.numaNode)
 
 	return device
-}
-
-// addFabricManagerAttributes publishes the Fabric Manager-derived attributes.
-// The gpuModuleId / partitionN values are owned by the parent GpuInfo (the FM
-// info always tracks the physical GPU, which is why it is resolved fresh on
-// the parent whenever the GPU is (re)discovered on the nvidia driver).
-func (d *VfioDeviceInfo) addFabricManagerAttributes(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute) {
-	if d.parent == nil {
-		klog.V(4).Infof("No parent GPU for %s; skipping Fabric Manager attributes", d.CanonicalName())
-		return
-	}
-
-	gpuModuleID := d.parent.gpuModuleID
-	partitionsBySize := d.parent.partitionsBySize
-	if gpuModuleID == 0 && len(partitionsBySize) == 0 {
-		klog.V(4).Infof("No Fabric Manager attributes for %s", d.CanonicalName())
-		return
-	}
-
-	klog.V(4).Infof("Adding Fabric Manager attributes for %s: gpuModuleId=%d partitionsBySize=%v",
-		d.CanonicalName(), gpuModuleID, partitionsBySize)
-	if gpuModuleID != 0 {
-		attrs["gpuModuleId"] = resourceapi.DeviceAttribute{
-			IntValue: ptr.To(int64(gpuModuleID)),
-		}
-	}
-
-	for size, partitionID := range partitionsBySize {
-		key := resourceapi.QualifiedName(fmt.Sprintf("partition%d", size))
-		attrs[key] = resourceapi.DeviceAttribute{
-			IntValue: ptr.To(int64(partitionID)),
-		}
-	}
 }
 
 func addNumaNodeAttribute(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, numaNode *int) {

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -634,7 +634,7 @@ func (l deviceLib) getGpuInfo(index int, device nvdev.Device) (*GpuInfo, error) 
 		if moduleID, ret := device.GetModuleId(); ret == nvml.SUCCESS {
 			gpuInfo.gpuModuleID = moduleID
 		} else {
-			klog.V(4).Infof("GPU %s: could not resolve gpuModuleId from NVML: %v", gpuInfo.CanonicalName(), ret)
+			klog.V(4).Infof("GPU %s: could not resolve gpuModuleID from NVML: %v", gpuInfo.CanonicalName(), ret)
 		}
 	}
 

--- a/pkg/fabricmanager/manager.go
+++ b/pkg/fabricmanager/manager.go
@@ -129,7 +129,7 @@ func (m *Manager) recordsPartitions(parts []Partition) error {
 		seen := make(map[int]struct{}, len(p.GPUs))
 		for _, g := range p.GPUs {
 			if _, dup := seen[g.PhysicalID]; dup {
-				return fmt.Errorf("fabricmanager: partition %d references gpuModuleId %d twice",
+				return fmt.Errorf("fabricmanager: partition %d references gpuModuleID %d twice",
 					p.ID, g.PhysicalID)
 			}
 			seen[g.PhysicalID] = struct{}{}
@@ -149,9 +149,9 @@ func (m *Manager) GetPartition(partitionID int) (Partition, bool) {
 
 // GetPartitionsBySizeByModuleID returns a map keyed by partition size (number
 // of GPUs in the partition) to the partitionId of the partition of that size
-// that includes the given gpuModuleId. e.g.:
+// that includes the given gpuModuleID. e.g.:
 //
-//	gpuModuleId: 1
+//	gpuModuleID: 1
 //	partition1:  8
 //	partition2:  4
 //	partition4:  2
@@ -167,7 +167,7 @@ func (m *Manager) GetPartitionsBySizeByModuleID(moduleID int) (map[int]int, erro
 			if g.PhysicalID == moduleID {
 				if existing, dup := out[size]; dup {
 					return nil, fmt.Errorf(
-						"fabricmanager: gpuModuleId %d appears in two partitions of size %d (%d and %d)",
+						"fabricmanager: gpuModuleID %d appears in two partitions of size %d (%d and %d)",
 						moduleID, size, existing, p.ID)
 				}
 				out[size] = p.ID
@@ -179,7 +179,7 @@ func (m *Manager) GetPartitionsBySizeByModuleID(moduleID int) (map[int]int, erro
 }
 
 // FindPartitionByModuleIDs returns the partitionId of the FM partition whose
-// GPU member set is exactly equal to the given set of gpuModuleIds, or
+// GPU member set is exactly equal to the given set of gpuModuleIDs, or
 // (0, false) if no partition matches.
 func (m *Manager) FindPartitionByModuleIDs(moduleIDs []int) (int, bool) {
 	if len(moduleIDs) == 0 {

--- a/pkg/fabricmanager/manager_test.go
+++ b/pkg/fabricmanager/manager_test.go
@@ -186,9 +186,9 @@ func TestFindPartitionByModuleIDs(t *testing.T) {
 }
 
 // TestDiscoverFMPartitionWithArbitraryModuleIDs covers FM reporting partitions
-// whose member gpuModuleIds the driver has not (yet) resolved to any local GPU
+// whose member gpuModuleIDs the driver has not (yet) resolved to any local GPU
 // (e.g. a GPU bound to vfio-pci before nv-fabricmanager started). The Manager
-// no longer owns a PCI<->gpuModuleId map, so it simply records the partitions
+// no longer owns a PCI<->gpuModuleID map, so it simply records the partitions
 // as reported; resolution happens on the VFIO device side.
 func TestDiscoverFMPartitionWithArbitraryModuleIDs(t *testing.T) {
 	client := &fakeClient{partitions: []Partition{
@@ -233,7 +233,7 @@ func TestDiscoverFMDuplicateGPUMember(t *testing.T) {
 		{ID: 1, GPUs: gpus(1, 2, 1)},
 	}}
 	if _, err := Open(client); err == nil {
-		t.Errorf("expected error for duplicate gpuModuleId member, got nil")
+		t.Errorf("expected error for duplicate gpuModuleID member, got nil")
 	}
 }
 

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -76,7 +76,14 @@ const (
 	DeviceMetadata featuregate.Feature = "DeviceMetadata"
 
 	// FabricManagerPartitioning enables Fabric Manager (NVSwitch) partition
-	// management for Passthrough VFIO devices.
+	// management for full-GPU (gpu.nvidia.com) devices and Passthrough VFIO
+	// devices. When enabled, Prepare activates the FM partition whose member
+	// set exactly matches the claim's allocated physical GPUs; a non-matching
+	// set fails Prepare. ResourceClaims should constrain allocation with
+	// matchAttribute on gpu.nvidia.com/partitionN. Requires Fabric Manager
+	// running with FABRIC_MODE=1. Independent of PassthroughSupport: with both
+	// gates on, full-GPU and VFIO claims are partitioned; with only this gate
+	// on, only full-GPU claims are.
 	FabricManagerPartitioning featuregate.Feature = "FabricManagerPartitioning"
 
 	// HostManagedIMEXDaemon gates whether the imex deployment mode
@@ -252,10 +259,6 @@ func ValidateFeatureGates() error {
 
 	if Enabled(DeviceMetadata) && !Enabled(PassthroughSupport) {
 		return fmt.Errorf("feature gate %s requires %s to also be enabled", DeviceMetadata, PassthroughSupport)
-	}
-
-	if Enabled(FabricManagerPartitioning) && !Enabled(PassthroughSupport) {
-		return fmt.Errorf("feature gate %s requires %s to also be enabled", FabricManagerPartitioning, PassthroughSupport)
 	}
 
 	return nil

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -517,13 +517,6 @@ func TestValidateFeatureGates(t *testing.T) {
 			description: "should be valid when both DeviceMetadata and PassthroughSupport are enabled",
 		},
 		{
-			name:         "FabricManagerPartitioning enabled without PassthroughSupport",
-			fgMap:        map[featuregate.Feature]bool{FabricManagerPartitioning: true, PassthroughSupport: false},
-			expectError:  true,
-			errorMessage: "feature gate FabricManagerPartitioning requires PassthroughSupport to also be enabled",
-			description:  "should fail when FabricManagerPartitioning is enabled but PassthroughSupport is not",
-		},
-		{
 			name:        "FabricManagerPartitioning enabled with PassthroughSupport",
 			fgMap:       map[featuregate.Feature]bool{FabricManagerPartitioning: true, PassthroughSupport: true},
 			expectError: false,

--- a/site/content/docs/reference/feature-gates.md
+++ b/site/content/docs/reference/feature-gates.md
@@ -39,7 +39,7 @@ helm install dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/chart
 | `ComputeDomainCliques` | Beta | `true` | Uses `ComputeDomainClique` CRD objects to track IMEX daemon membership. Requires `IMEXDaemonsWithDNSNames`. |
 | `CrashOnNVLinkFabricErrors` | Beta | `true` | Causes the kubelet plugin to crash rather than fall back to non-fabric mode when NVLink fabric errors are detected. |
 | `DeviceMetadata` | Alpha | `false` | Enables IOMMU API device exposure (`/dev/iommu` or `/dev/vfio/vfio`) for VFIO workloads via `VfioDeviceConfig`. Requires `PassthroughSupport`. |
-| `FabricManagerPartitioning` | Alpha | `false` | Enables Fabric Manager (NVSwitch) partition management in single-node NVL systems for Passthrough VFIO devices. Requires `PassthroughSupport`. |
+| `FabricManagerPartitioning` | Alpha | `false` | Enables Fabric Manager (NVSwitch) partition management in single-node NVL systems for full-GPU (`gpu.nvidia.com`) devices and Passthrough VFIO devices. Requires Fabric Manager running with `FABRIC_MODE=1`. When combined with `PassthroughSupport`, both device types are partitioned; otherwise only full-GPU devices. **Prepare requires the allocated physical-GPU set to match an FM partition exactly**; non-matching claims (including ordinary multi-GPU full-GPU workloads without a `matchAttribute` on `gpu.nvidia.com/partitionN`) fail Prepare. Do not enable on nodes that still run unconstrained full-GPU claims. |
 
 ## Constraints
 
@@ -59,5 +59,4 @@ The feature gates below have the following dependencies:
 |---|---|
 | `ComputeDomainCliques` | `IMEXDaemonsWithDNSNames` |
 | `DeviceMetadata` | `PassthroughSupport` |
-| `FabricManagerPartitioning` | `PassthroughSupport` |
 | `DynamicMIG` (Kubernetes 1.34–1.35) | `DRAPartitionableDevices` Kubernetes feature gate enabled on kube-apiserver and kube-scheduler |


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Fabric Manager Partition activation was introduced for VFIO devices by https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1190. This extends the feature gate with full GPU devices (DeviceClass gpu.nvidia.com)

#### Which issue(s) this PR is related to:
Fixes #1070 

#### Special notes for your reviewer:
- When `FabricManagerPartitioning` feature gate is enabled Prepare activates the FM partition whose member set exactly matches the claim's allocated physical GPUs; a non-matching
set fails Prepare. 

- ResourceClaims should constrain allocation with `matchAttribute` on `gpu.nvidia.com/partitionN`. 
- Requires Fabric Manager running with FABRIC_MODE=1.
-  Independent of PassthroughSupport: with both gates on, full-GPU and VFIO claims are partitioned; with only this gate on, only full-GPU claims activate FM partitions

#### Does this PR introduce a user-facing change?
```release-note
Support FabricManager partition activate for full GPU devices.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
