### PR TITLE
Skip non-regular files in findFile library/binary discovery

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/root.go
+++ b/cmd/compute-domain-kubelet-plugin/root.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"k8s.io/klog/v2"
 )
 
 type root string
@@ -108,12 +110,24 @@ func (r root) getDevRoot() string {
 // findFile searches the root for a specified file.
 // A number of folders can be specified to search in addition to the root itself.
 // If the file represents a symlink, this is resolved and the final path is returned.
+// Candidates that do not resolve to a regular file (e.g. directories) are skipped
+// so that they cannot shadow the actual file in a later search path.
 func (r root) findFile(name string, searchIn ...string) (string, error) {
 
 	for _, d := range append([]string{"/"}, searchIn...) {
 		l := filepath.Join(string(r), d, name)
 		candidate, err := resolveLink(l)
 		if err != nil {
+			klog.V(4).Infof("Skipping candidate %q: %v", l, err)
+			continue
+		}
+		info, err := os.Stat(candidate)
+		if err != nil {
+			klog.V(4).Infof("Skipping candidate %q: %v", candidate, err)
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			klog.V(4).Infof("Skipping candidate %q: not a regular file (mode %s)", candidate, info.Mode())
 			continue
 		}
 		return candidate, nil

--- a/cmd/compute-domain-kubelet-plugin/root_test.go
+++ b/cmd/compute-domain-kubelet-plugin/root_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindFile(t *testing.T) {
+	// Mirrors the search paths used by getDriverLibraryPath.
+	librarySearchPaths := []string{
+		"/usr/lib64",
+		"/usr/lib/x86_64-linux-gnu",
+		"/usr/lib/aarch64-linux-gnu",
+		"/lib64",
+		"/lib/x86_64-linux-gnu",
+		"/lib/aarch64-linux-gnu",
+	}
+	// Mirrors the search paths used by getNvidiaSMIPath and getNvidiaImexCtlPath.
+	binarySearchPaths := []string{
+		"/opt/bin",
+		"/usr/bin",
+		"/usr/sbin",
+		"/bin",
+		"/sbin",
+	}
+
+	tests := map[string]struct {
+		// name is the file findFile searches for.
+		name string
+		// searchIn are the folders searched in addition to the root.
+		searchIn []string
+		// dirs are created (relative to the test root) before searching.
+		dirs []string
+		// files are created (relative to the test root) before searching.
+		files []string
+		// expected is the path (relative to the test root) findFile should
+		// return, or "" if an error is expected.
+		expected string
+	}{
+		"library in first search path": {
+			name:     "libnvidia-ml.so.1",
+			searchIn: librarySearchPaths,
+			files:    []string{"usr/lib64/libnvidia-ml.so.1"},
+			expected: "usr/lib64/libnvidia-ml.so.1",
+		},
+		"directory in earlier search path does not shadow library": {
+			name:     "libnvidia-ml.so.1",
+			searchIn: librarySearchPaths,
+			dirs:     []string{"usr/lib64/libnvidia-ml.so.1"},
+			files:    []string{"usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1"},
+			expected: "usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",
+		},
+		"only directories found": {
+			name:     "libnvidia-ml.so.1",
+			searchIn: librarySearchPaths,
+			dirs:     []string{"usr/lib64/libnvidia-ml.so.1"},
+			expected: "",
+		},
+		"library not found": {
+			name:     "libnvidia-ml.so.1",
+			searchIn: librarySearchPaths,
+			expected: "",
+		},
+		"nvidia-smi in binary search path": {
+			name:     "nvidia-smi",
+			searchIn: binarySearchPaths,
+			files:    []string{"usr/bin/nvidia-smi"},
+			expected: "usr/bin/nvidia-smi",
+		},
+		"directory in earlier search path does not shadow nvidia-smi": {
+			name:     "nvidia-smi",
+			searchIn: binarySearchPaths,
+			dirs:     []string{"opt/bin/nvidia-smi"},
+			files:    []string{"usr/bin/nvidia-smi"},
+			expected: "usr/bin/nvidia-smi",
+		},
+	}
+
+	for description, tc := range tests {
+		t.Run(description, func(t *testing.T) {
+			testRoot := t.TempDir()
+			for _, d := range tc.dirs {
+				require.NoError(t, os.MkdirAll(filepath.Join(testRoot, d), 0o755))
+			}
+			for _, f := range tc.files {
+				path := filepath.Join(testRoot, f)
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, []byte{}, 0o644))
+			}
+
+			found, err := root(testRoot).findFile(tc.name, tc.searchIn...)
+			if tc.expected == "" {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// t.TempDir may itself contain symlinks (e.g. on macOS), so
+			// compare against the resolved expected path.
+			expected, err := filepath.EvalSymlinks(filepath.Join(testRoot, tc.expected))
+			require.NoError(t, err)
+			require.Equal(t, expected, found)
+		})
+	}
+}

--- a/cmd/gpu-kubelet-plugin/root.go
+++ b/cmd/gpu-kubelet-plugin/root.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"k8s.io/klog/v2"
 )
 
 type root string
@@ -93,12 +95,24 @@ func (r root) getDevRoot() string {
 // findFile searches the root for a specified file.
 // A number of folders can be specified to search in addition to the root itself.
 // If the file represents a symlink, this is resolved and the final path is returned.
+// Candidates that do not resolve to a regular file (e.g. directories) are skipped
+// so that they cannot shadow the actual file in a later search path.
 func (r root) findFile(name string, searchIn ...string) (string, error) {
 
 	for _, d := range append([]string{"/"}, searchIn...) {
 		l := filepath.Join(string(r), d, name)
 		candidate, err := resolveLink(l)
 		if err != nil {
+			klog.V(4).Infof("Skipping candidate %q: %v", l, err)
+			continue
+		}
+		info, err := os.Stat(candidate)
+		if err != nil {
+			klog.V(4).Infof("Skipping candidate %q: %v", candidate, err)
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			klog.V(4).Infof("Skipping candidate %q: not a regular file (mode %s)", candidate, info.Mode())
 			continue
 		}
 		return candidate, nil

--- a/cmd/gpu-kubelet-plugin/root_test.go
+++ b/cmd/gpu-kubelet-plugin/root_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindFile(t *testing.T) {
+	// Mirrors the search paths used by getDriverLibraryPath.
+	librarySearchPaths := []string{
+		"/usr/lib64",
+		"/usr/lib/x86_64-linux-gnu",
+		"/usr/lib/aarch64-linux-gnu",
+		"/lib64",
+		"/lib/x86_64-linux-gnu",
+		"/lib/aarch64-linux-gnu",
+	}
+	// Mirrors the search paths used by getNvidiaSMIPath.
+	binarySearchPaths := []string{
+		"/opt/bin",
+		"/usr/bin",
+		"/usr/sbin",
+		"/bin",
+		"/sbin",
+	}
+
+	tests := map[string]struct {
+		// name is the file findFile searches for.
+		name string
+		// searchIn are the folders searched in addition to the root.
+		searchIn []string
+		// dirs are created (relative to the test root) before searching.
+		dirs []string
+		// files are created (relative to the test root) before searching.
+		files []string
+		// expected is the path (relative to the test root) findFile should
+		// return, or "" if an error is expected.
+		expected string
+	}{
+		"library in first search path": {
+			name:     "libnvidia-ml.so.1",
+			searchIn: librarySearchPaths,
+			files:    []string{"usr/lib64/libnvidia-ml.so.1"},
+			expected: "usr/lib64/libnvidia-ml.so.1",
+		},
+		"directory in earlier search path does not shadow library": {
+			name:     "libnvidia-ml.so.1",
+			searchIn: librarySearchPaths,
+			dirs:     []string{"usr/lib64/libnvidia-ml.so.1"},
+			files:    []string{"usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1"},
+			expected: "usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",
+		},
+		"only directories found": {
+			name:     "libnvidia-ml.so.1",
+			searchIn: librarySearchPaths,
+			dirs:     []string{"usr/lib64/libnvidia-ml.so.1"},
+			expected: "",
+		},
+		"library not found": {
+			name:     "libnvidia-ml.so.1",
+			searchIn: librarySearchPaths,
+			expected: "",
+		},
+		"nvidia-smi in binary search path": {
+			name:     "nvidia-smi",
+			searchIn: binarySearchPaths,
+			files:    []string{"usr/bin/nvidia-smi"},
+			expected: "usr/bin/nvidia-smi",
+		},
+		"directory in earlier search path does not shadow nvidia-smi": {
+			name:     "nvidia-smi",
+			searchIn: binarySearchPaths,
+			dirs:     []string{"opt/bin/nvidia-smi"},
+			files:    []string{"usr/bin/nvidia-smi"},
+			expected: "usr/bin/nvidia-smi",
+		},
+	}
+
+	for description, tc := range tests {
+		t.Run(description, func(t *testing.T) {
+			testRoot := t.TempDir()
+			for _, d := range tc.dirs {
+				require.NoError(t, os.MkdirAll(filepath.Join(testRoot, d), 0o755))
+			}
+			for _, f := range tc.files {
+				path := filepath.Join(testRoot, f)
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, []byte{}, 0o644))
+			}
+
+			found, err := root(testRoot).findFile(tc.name, tc.searchIn...)
+			if tc.expected == "" {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// t.TempDir may itself contain symlinks (e.g. on macOS), so
+			// compare against the resolved expected path.
+			expected, err := filepath.EvalSymlinks(filepath.Join(testRoot, tc.expected))
+			require.NoError(t, err)
+			require.Equal(t, expected, found)
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

Both kubelet plugins locate driver files (`libnvidia-ml.so.1`, `nvidia-smi`,
and so on) under the driver root with `findFile`, which validates each
candidate path with `filepath.EvalSymlinks`. `EvalSymlinks` succeeds for any
path that exists, including directories, and `findFile` returns the first
candidate that resolves.

`/usr/lib64` is searched before `/usr/lib/x86_64-linux-gnu`. On Ubuntu, where
the driver installs the library in the latter, a stray directory named
`/usr/lib64/libnvidia-ml.so.1` wins the search and gets handed to dlopen. The
plugin then crash-loops with:

```
error creating driver: ... error initializing NVML: ERROR_LIBRARY_NOT_FOUND
```

even though the real library is present, and recovers only when the directory
is removed.

With this change, `findFile` skips any candidate that does not resolve to a
regular file and keeps searching. The compute-domain kubelet plugin carries an
identical copy of `findFile` with the same bug, so the same guard is applied
there.

Tests cover the reported scenario (a decoy directory in an earlier search path
with the real file in a later one) plus the happy path and the error paths.
The decoy-directory and directories-only cases fail without the fix.

## Which issue(s) this PR fixes

Fixes #1272

## Special notes for your reviewer

The same pattern exists in vendored `github.com/NVIDIA/go-nvlib`
(`pkg/nvlib/info/root.go`, `tryResolveLibrary`). I left the vendored code
alone; the upstream fix is filed as NVIDIA/go-nvlib#107 with the fix in NVIDIA/go-nvlib#108.

## Does this PR introduce a user-facing change?

```release-note
Fixed the kubelet plugins crash-looping with ERROR_LIBRARY_NOT_FOUND when a directory named after a driver library (for example /usr/lib64/libnvidia-ml.so.1) shadows the real library in a later search path.
```