### PR TITLE
compute-domain: don't crash on transitional NVLink fabric states

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/nvlib.go
+++ b/cmd/compute-domain-kubelet-plugin/nvlib.go
@@ -274,6 +274,51 @@ func (l deviceLib) getCliqueIDLegacy() (string, error) {
 	return "", fmt.Errorf("unexpected return")
 }
 
+// evaluateGpuFabricInfo decides how a single device's fabric registration
+// info contributes to the node clique: use the device's ClusterUuid/CliqueId,
+// skip the device (no-clique fallback), or fail hard.
+//
+// Transitional registration states (NOT_STARTED, IN_PROGRESS) are not errors
+// and must not be fatal: they occur legitimately when a GPU was re-bound to
+// the driver after Fabric Manager finished its initial registration sweep
+// (e.g. after fell-off-the-bus remediation), and for GPUs that are not part
+// of a currently activated partition when Fabric Manager runs in shared
+// NVSwitch mode. Crashing on them disables compute domain support for the
+// whole node; falling back to "no clique" for the device keeps the plugin
+// alive, and the periodic refresh (periodicGPUCliqueIDRefresh) picks up the
+// final state once registration completes.
+//
+// Only a completed registration that reports an error status is terminal:
+// that is a genuine fabric error, and silently degrading to non-fabric mode
+// could mislabel an MNNVL node.
+func evaluateGpuFabricInfo(i int, duid string, info nvml.GpuFabricInfo) (use bool, err error) {
+	if info.State == nvml.GPU_FABRIC_STATE_NOT_SUPPORTED {
+		klog.Infof("no-clique fallback: NVLink fabric not supported by device (device %d/%s, error: GPU_FABRIC_STATE_NOT_SUPPORTED)", i, duid)
+		return false, nil
+	}
+
+	// NVLink fabric is supported - fall back (do not fail) while registration
+	// has not completed.
+	if info.State != nvml.GPU_FABRIC_STATE_COMPLETED {
+		klog.Warningf("no-clique fallback: NVLink fabric registration not completed (device %d/%s): state=%d", i, duid, info.State)
+		return false, nil
+	}
+
+	// Registration completed - check Status field for errors (only valid when State == COMPLETED)
+	if nvml.Return(info.Status) != nvml.SUCCESS {
+		return false, fmt.Errorf("NVLink fabric registration error (device %d/%s): status=%v, refusing to start", i, duid, nvml.Return(info.Status))
+	}
+
+	// Cluster UUID with zero value: treat as MNNVL not supported. Expected
+	// for systems which are NVLink-capable, but not MNNVL-capable.
+	if info.ClusterUuid == [16]uint8{} {
+		klog.Infof("no-clique fallback: cluster UUID is zero, treat as fabric not attached (device %d/%s)", i, duid)
+		return false, nil
+	}
+
+	return true, nil
+}
+
 // getCliqueIDStrict performs strict validation of NVLink fabric state and crashes on errors.
 func (l deviceLib) getCliqueIDStrict() (string, error) {
 	uniqueClusterUUIDs := make(map[string]struct{})
@@ -301,25 +346,11 @@ func (l deviceLib) getCliqueIDStrict() (string, error) {
 			return fmt.Errorf("failed to get GPU fabric info (device %d/%s): %w", i, duid, ret)
 		}
 
-		if info.State == nvml.GPU_FABRIC_STATE_NOT_SUPPORTED {
-			klog.Infof("no-clique fallback: NVLink fabric not supported by device (device %d/%s, error: GPU_FABRIC_STATE_NOT_SUPPORTED)", i, duid)
-			return nil
+		use, err := evaluateGpuFabricInfo(i, duid, info)
+		if err != nil {
+			return err
 		}
-
-		// NVLink fabric is supported - check if registration completed
-		if info.State != nvml.GPU_FABRIC_STATE_COMPLETED {
-			return fmt.Errorf("NVLink fabric not attached (device %d/%s): state=%d, refusing to start", i, duid, info.State)
-		}
-
-		// Registration completed - check Status field for errors (only valid when State == COMPLETED)
-		if nvml.Return(info.Status) != nvml.SUCCESS {
-			return fmt.Errorf("NVLink fabric registration error (device %d/%s): status=%v, refusing to start", i, duid, nvml.Return(info.Status))
-		}
-
-		// Cluster UUID with zero value: treat as MNNVL not supported. Expected
-		// for systems which are NVLink-capable, but not MNNVL-capable.
-		if info.ClusterUuid == [16]uint8{} {
-			klog.Infof("no-clique fallback: cluster UUID is zero, treat as fabric not attached (device %d/%s)", i, duid)
+		if !use {
 			return nil
 		}
 

--- a/cmd/compute-domain-kubelet-plugin/nvlib_test.go
+++ b/cmd/compute-domain-kubelet-plugin/nvlib_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
 // TestCheckHostIMEXReadyMissingBinary confirms that a driver root without
@@ -36,4 +38,84 @@ func TestCheckHostIMEXReadyMissingBinary(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nvidia-imex-ctl not found")
+}
+
+// TestEvaluateGpuFabricInfo covers the per-device fabric registration
+// decision used by getCliqueIDStrict. Transitional registration states
+// (NOT_STARTED, IN_PROGRESS) must fall back to "no clique" instead of
+// returning an error: a GPU re-bound to the driver after Fabric Manager's
+// initial registration sweep (e.g. post fell-off-the-bus remediation), or a
+// GPU outside any activated partition in shared NVSwitch mode, legitimately
+// reports these states, and an error here crashes the plugin on startup
+// (issue #1264).
+func TestEvaluateGpuFabricInfo(t *testing.T) {
+	nonZeroUUID := [16]uint8{0xde, 0xad, 0xbe, 0xef, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+
+	testCases := []struct {
+		name      string
+		info      nvml.GpuFabricInfo
+		expectUse bool
+		expectErr string
+	}{
+		{
+			name: "fabric not supported by device",
+			info: nvml.GpuFabricInfo{
+				State: nvml.GPU_FABRIC_STATE_NOT_SUPPORTED,
+			},
+			expectUse: false,
+		},
+		{
+			name: "registration not started is transitional, not fatal",
+			info: nvml.GpuFabricInfo{
+				State: nvml.GPU_FABRIC_STATE_NOT_STARTED,
+			},
+			expectUse: false,
+		},
+		{
+			name: "registration in progress is transitional, not fatal",
+			info: nvml.GpuFabricInfo{
+				State: nvml.GPU_FABRIC_STATE_IN_PROGRESS,
+			},
+			expectUse: false,
+		},
+		{
+			name: "completed registration with error status is fatal",
+			info: nvml.GpuFabricInfo{
+				State:  nvml.GPU_FABRIC_STATE_COMPLETED,
+				Status: uint32(nvml.ERROR_UNKNOWN),
+			},
+			expectErr: "NVLink fabric registration error",
+		},
+		{
+			name: "completed with zero cluster UUID falls back (non-MNNVL)",
+			info: nvml.GpuFabricInfo{
+				State:  nvml.GPU_FABRIC_STATE_COMPLETED,
+				Status: uint32(nvml.SUCCESS),
+			},
+			expectUse: false,
+		},
+		{
+			name: "completed with cluster UUID contributes to clique",
+			info: nvml.GpuFabricInfo{
+				State:       nvml.GPU_FABRIC_STATE_COMPLETED,
+				Status:      uint32(nvml.SUCCESS),
+				ClusterUuid: nonZeroUUID,
+			},
+			expectUse: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			use, err := evaluateGpuFabricInfo(0, "GPU-test-uuid", tc.info)
+
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectUse, use)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #1264

## What this does

With `CrashOnNVLinkFabricErrors` enabled (default since v0.3), `getCliqueIDStrict` returns an error whenever any GPU reports a fabric registration state other than `COMPLETED`. That error is fatal at plugin startup (`NewComputeDomainManager` → `NewDeviceState` → `NewDriver` → `main`), so the kubelet plugin enters `CrashLoopBackOff` and compute-domain support is lost for the whole node.

Transitional states are not errors:

- A GPU re-bound to the driver after Fabric Manager's initial registration sweep (e.g. after fell-off-the-bus remediation) reports `IN_PROGRESS` until it is re-registered.
- With Fabric Manager in shared NVSwitch mode, GPUs outside any activated partition legitimately report a transitional state indefinitely — so a startup retry/wait alone cannot fix this.
- A plain node reboot can race kubelet pod startup against FM's initial registration sweep (observed in practice, see below).

The same condition is already non-fatal at runtime: `periodicGPUCliqueIDRefresh` logs the error and retries on the next tick. Only plugin startup treated it as terminal, so whether a node survives a transitional fabric state depends on whether the plugin happened to (re)start during the window.

This PR:

- extracts the per-device decision into `evaluateGpuFabricInfo` (pure function, unit-testable),
- treats `NOT_STARTED`/`IN_PROGRESS` as a no-clique fallback with a warning — the periodic clique refresh picks up the final state once registration completes,
- keeps the hard failure for a completed registration that reports an error status (a genuine fabric error, where silently degrading to non-fabric mode could mislabel an MNNVL node),
- adds table-driven unit tests for the six decision paths.

## Validation

Reproduced and validated on an 8x H100 SXM node (NVSwitch, non-MNNVL, driver 570.133.20, FM bare-metal mode) on Crusoe Cloud managed Kubernetes, chart 0.4.1 config with `resources.gpus.enabled=false` — details in https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1264#issuecomment-5082390726:

1. **Organic repro**: plain node reboot; plugin started while FM was mid-registration → crashed at `05:56:57` with `state=2`, FM finished registering at `05:57:00`, pod recovered on its third restart.
2. **Deterministic A/B on identical state** (nvidia module reloaded with FM stopped → all 8 GPUs persistently `In Progress`):
   - released `v0.4.1` image → `CrashLoopBackOff`: `NVLink fabric not attached (device 0/GPU-0a75...): state=2, refusing to start`
   - image built from this branch → `1/1 Running`, per-device `no-clique fallback: NVLink fabric registration not completed (device .../...): state=2` warnings, ResourceSlices published.
3. Starting FM afterwards: all GPUs reached `Completed/Success` ~10s later; the plugin ran through it with zero restarts.

## Notes for reviewers

- The `GPU_FABRIC_STATE_NOT_SUPPORTED` and zero-ClusterUUID fallbacks are unchanged; only the `State != COMPLETED` branch changes behavior (error → warn + skip).
- If a bounded startup wait for transitional states is preferred before falling back, happy to add it — but note the shared-NVSwitch-partition case above where such a wait never converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

