### PR TITLE
Docs for 0.5.0

### DIFF
--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -21,7 +21,8 @@ The [Kubernetes device plugin framework](https://kubernetes.io/docs/concepts/ext
 
 DRA is a replacement for the device plugin architecture itself, not just a different driver for the same interface. It brings hardware resource management closer to the Persistent Volume model: a workload declares what it needs in a `ResourceClaim`, and the driver fulfills it. This separation of declaration from consumption enables capabilities that are fundamentally out of scope for the device plugin framework:
 
-- Share a single GPU across multiple containers or pods (time-slicing or MPS)
+- Share a GPU allocation across containers with time-slicing or MPS
+- Share a single GPU across independent claims using Kubernetes DRA consumable capacity
 - Request GPUs by capability — memory size, compute capacity, architecture — rather than just count
 - Attach per-workload configuration (sharing strategy, MIG profile, MPS thread limits) directly to the claim
 - Allocate MIG devices dynamically without pre-configuring profiles on the node
@@ -31,7 +32,8 @@ DRA is a replacement for the device plugin architecture itself, not just a diffe
 
 ### GPU allocation
 
-Request GPUs, MIG slices, or VFIO passthrough devices in a ResourceClaim, with an optional sharing strategy such as time-slicing or MPS (Multi-Process Service).
+Request GPUs, MIG slices, or VFIO passthrough devices in a `ResourceClaim`.
+Use [consumable capacity](guides/gpu-allocation/consumable-capacity.md) to share a full GPU or MIG device across independent claims, or configure time-slicing or MPS (Multi-Process Service) for containers that share an allocation.
 Refer to [Architecture](concepts/architecture.md) for how requests are fulfilled.
 
 ### Multi-node NVLink with ComputeDomains

--- a/site/content/docs/concepts/architecture.md
+++ b/site/content/docs/concepts/architecture.md
@@ -65,9 +65,9 @@ sequenceDiagram
     Runtime-->>User: Container running with GPU
 ```
 
-## ComputeDomain flow
+## Driver-managed ComputeDomain flow
 
-User creates a `ComputeDomain` → controller creates a per-CD DaemonSet → each daemon pod runs `nvidia-imex` → daemons publish their IP and clique through `ComputeDomainClique` CRs → workload pods claim a channel from the `compute-domain-default-channel.nvidia.com` DeviceClass → the CD kubelet plugin asserts readiness and injects `/dev/nvidia-caps-imex-channels/chan*` plus `/imexd` into the container.
+User creates a `ComputeDomain` → controller creates a per-CD DaemonSet → each daemon pod runs `nvidia-imex` → daemons publish their IP and clique through `ComputeDomainClique` CRs → workload pods claim a channel from the `compute-domain-default-channel.nvidia.com` DeviceClass → the CD kubelet plugin asserts readiness and injects one or more selected `/dev/nvidia-caps-imex-channels/channelN` devices into the container.
 
 ```mermaid
 sequenceDiagram
@@ -86,7 +86,7 @@ sequenceDiagram
     User->>API: Create Pod claiming channel
     API->>Plugin: Prepare(channel ResourceClaim)
     Plugin-->>API: Assert readiness
-    Plugin->>Runtime: Inject /dev/nvidia-caps-imex-channels + /imexd
+    Plugin->>Runtime: Inject selected IMEX channel devices
     Runtime-->>User: Container running with NVLink fabric
 ```
 

--- a/site/content/docs/concepts/compute-domains.md
+++ b/site/content/docs/concepts/compute-domains.md
@@ -9,23 +9,51 @@ A `ComputeDomain` is a custom resource that sets up a group of nodes to run a mu
 
 ---
 
-## How it works
+## IMEX lifecycle modes
 
-Creating a `ComputeDomain` triggers the following sequence:
+The `resources.computeDomains.imex.mode` Helm value determines who manages the `nvidia-imex` daemon lifecycle.
+
+| Mode | Lifecycle |
+|---|---|
+| `driverManaged` | By default, the DRA Driver creates one `nvidia-imex` DaemonSet for each `ComputeDomain` and tracks daemon readiness through `ComputeDomainClique` resources. |
+| `hostManaged` | You run `nvidia-imex` as a host service with a ready command socket, and the DRA Driver does not create daemon DaemonSets or daemon claims; this mode requires the `HostManagedIMEXDaemon` feature gate. |
+
+## How driver-managed mode works
+
+Creating a `ComputeDomain` in the default `driverManaged` mode triggers the following sequence:
 
 1. The `compute-domain-controller` watches for new `ComputeDomain` resources and creates a per-domain DaemonSet.
 2. Each daemon pod in that DaemonSet runs `nvidia-imex`, which manages the NVLink fabric connection on its node.
 3. Each daemon publishes its IP address, clique membership, and readiness via a `ComputeDomainClique` CR in the driver namespace.
 4. The `compute-domain-controller` also creates a `ResourceClaimTemplate` per channel, making IMEX channels available for workload pods to claim.
-5. When a workload pod claims a channel, the `compute-domain-kubelet-plugin` injects the IMEX channel device (`/dev/nvidia-caps-imex-channels/chan*`) and the IMEX socket mount (`/imexd`) into the container.
+5. When a workload pod claims a channel, the `compute-domain-kubelet-plugin` injects one or more selected IMEX channel devices (`/dev/nvidia-caps-imex-channels/channelN`) into the container.
 
-For the full sequence diagram, see [Architecture › ComputeDomain flow](architecture.md#computedomain-flow).
+For the full sequence diagram, see [Architecture › Driver-managed ComputeDomain flow](architecture.md#driver-managed-computedomain-flow).
+
+## How host-managed mode works
+
+Creating a `ComputeDomain` in `hostManaged` mode uses an existing host `nvidia-imex` service:
+
+1. You run `nvidia-imex` on each participating GPU node and expose its command socket.
+2. The `compute-domain-controller` creates the workload `ResourceClaimTemplate`.
+3. When a workload pod claims a channel, the `compute-domain-kubelet-plugin` queries the host daemon through the daemon's command socket and requires a `READY` response. If the daemon is unavailable or not ready, claim preparation fails and is retried.
+4. After the readiness check succeeds, the plugin injects channel 0 (`/dev/nvidia-caps-imex-channels/channel0`) into the workload container.
+5. Deleting the `ComputeDomain` removes the workload claim template, but it does not stop or reconfigure the host service.
+
+Host-managed mode currently supports domain isolation only. All ComputeDomains
+that use the same host IMEX domain share channel 0. Because this mode has no
+per-ComputeDomain daemon pods, the controller disables its
+`IMEXDaemonsWithDNSNames` and `ComputeDomainCliques` behaviors and does not create
+`ComputeDomainClique` objects. A `Ready` ComputeDomain therefore does not report
+the health of the host service.
+
+For service and socket configuration, see [Host-managed IMEX](../prerequisites.md#host-managed-imex).
 
 ---
 
 ## Prerequisites
 
-See [Prerequisites](../prerequisites.md) for hardware and software requirements, including the ComputeDomain-specific requirements for Multi-Node NVLink hardware, GPU Feature Discovery, and `nvidia-imex` service configuration.
+See [Prerequisites](../prerequisites.md) for hardware and software requirements, including the ComputeDomain-specific requirements for Multi-Node NVLink hardware, `nvidia.com/gpu.clique` label ownership, and `nvidia-imex` service configuration.
 
 ---
 

--- a/site/content/docs/concepts/gpu-allocation.md
+++ b/site/content/docs/concepts/gpu-allocation.md
@@ -21,8 +21,10 @@ The DRA Driver for NVIDIA GPUs exposes three types of GPU resources, each suited
 
 A full GPU gives a container exclusive access to a single physical GPU. This is the default allocation mode and requires no additional configuration.
 
-Full GPUs support two optional sharing strategies for cases where you want to divide the GPU across multiple containers:
+Full GPUs support optional sharing for cases where you want to divide the GPU across multiple workloads:
 
+- **Consumable capacity:** independent `ResourceClaim` objects can share a multi-allocatable device while Kubernetes tracks the capacity consumed by each claim.
+  The NVIDIA driver requires its `ConsumableShares` feature gate and a `consumableShares` mode.
 - **Time-slicing:** containers take turns on the GPU using CUDA preemption. Requires the `TimeSlicingSettings` feature gate.
 - **MPS (Multi-Process Service):** containers run concurrently with configurable thread percentage and memory limits. Requires the `MPSSupport` feature gate.
 
@@ -101,7 +103,8 @@ It works in three phases:
 A request can be satisfied even when no matching partition was pre-configured —
 the driver creates one to match.
 
-MIG slices support both time-slicing and MPS sharing, using the same strategies as full GPUs. Time-slicing on MIG slices does not support interval configuration.
+MIG slices support consumable capacity, time-slicing, and MPS sharing, using the same approaches as full GPUs.
+Time-slicing on MIG slices does not support interval configuration.
 
 Target DeviceClass: `mig.nvidia.com`
 
@@ -128,10 +131,31 @@ Requires the `PassthroughSupport` feature gate (Alpha, default: false). See [Fea
 | | Full GPU | MIG slice | VFIO passthrough |
 |---|---|---|---|
 | Hardware isolation | No | Yes | Full device |
-| Sharing supported | Yes (time-slicing or MPS) | Yes (time-slicing or MPS) | No |
+| Sharing supported | Yes (consumable capacity, time-slicing, or MPS) | Yes (consumable capacity, time-slicing, or MPS) | No |
 | Supported hardware | All NVIDIA GPUs | MIG-capable data center GPUs (A100, A30, H100, and newer) | All NVIDIA GPUs |
 | Feature gate required | No (sharing gates optional) | No | `PassthroughSupport` (Alpha) |
 | Typical use case | ML training, general workloads | Multi-tenant inference, strict isolation | VM passthrough, specialized environments |
+
+### Add optional allocation features
+
+Choose a resource type first, and then add only the features that apply to that
+resource:
+
+- **Sharing across claims:** Kubernetes DRA consumable capacity lets independent claims share a full GPU or MIG device by memory capacity, without a capacity limit, or by a fixed share count.
+  Refer to [Consumable capacity](../guides/gpu-allocation/consumable-capacity.md).
+- **Sharing within a claim:** time-slicing or MPS can share supported full-GPU or MIG allocations among containers that reference the claim.
+  A device configuration uses one sharing strategy.
+- **Fabric topology:** Fabric Manager partitioning constrains a claim to one
+  complete NVSwitch partition.
+  The partitioning applies to full GPUs and VFIO devices, not MIG slices.
+  `PassthroughSupport` is required if you want to use VFIO devices.
+- **Operational features:** health checking and device metadata modify
+  supported workflows without creating another resource type.
+
+Refer to [Feature gate constraints](../reference/feature-gates.md#constraints)
+for the combinations enforced at driver startup.
+For the topology workflow, refer to
+[Fabric Manager partitioning](../guides/gpu-allocation/fabric-manager-partitioning.md).
 
 ---
 
@@ -199,4 +223,5 @@ For more details on using these with the DRA, refer to the how-to guides:
 - [View available GPU resources](../guides/gpu-allocation/view-resources.md)
 - [MIG](../guides/gpu-allocation/mig.md)
 - [Time-slicing](../guides/gpu-allocation/time-slicing.md)
+- [Fabric Manager partitioning](../guides/gpu-allocation/fabric-manager-partitioning.md)
 - [VFIO GPU passthrough](../guides/gpu-allocation/kubevirt-vfio-gpu-passthrough.md)

--- a/site/content/docs/guides/compute-domain-workloads.md
+++ b/site/content/docs/guides/compute-domain-workloads.md
@@ -10,7 +10,7 @@ For background on what a `ComputeDomain` is and how it fits together, see
 
 ## Prerequisites
 
-Refer to [Prerequisites](../prerequisites.md) for hardware and software requirements, including the ComputeDomain-specific requirements for Multi-Node NVLink hardware, GPU Feature Discovery, and `nvidia-imex` service configuration.
+Refer to [Prerequisites](../prerequisites.md) for hardware and software requirements, including the ComputeDomain-specific requirements for Multi-Node NVLink hardware, `nvidia.com/gpu.clique` label ownership, and `nvidia-imex` service configuration.
 
 ## Create a ComputeDomain
 
@@ -33,7 +33,13 @@ spec:
 After applying this resource, the controller creates:
 
 - A per-domain `DaemonSet` of `compute-domain-daemon` pods, one per GPU node.
-- A `ResourceClaimTemplate` named `imex-channel-0` (or whatever name you gave it), which workload pods use to request a channel.
+- A `ResourceClaimTemplate` named `imex-channel-0`, which workload pods use to request a channel.
+
+These objects describe the default `driverManaged` mode.
+In `hostManaged` mode, the controller creates the workload `ResourceClaimTemplate` but does not create the per-domain daemon DaemonSet.
+The host service must be ready through its configured command socket before a workload claim can prepare.
+Host-managed mode currently provides domain isolation and channel 0 only, even if the `ComputeDomain` requests `allocationMode: All`.
+See [Host-managed IMEX](../prerequisites.md#host-managed-imex) before you select this mode.
 
 ## Use the channel in a workload
 
@@ -45,11 +51,24 @@ kind: Pod
 metadata:
   name: my-workload
 spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nvidia.com/gpu.clique
+            operator: Exists
   containers:
   - name: app
-    image: my-image
+    image: ubuntu:22.04
     command: ["bash", "-c"]
-    args: ["ls -la /dev/nvidia-caps-imex-channels; sleep 9999"]
+    args:
+    - |
+      set -eu
+      test -c /dev/nvidia-caps-imex-channels/channel0
+      echo "IMEX channel0 is available"
+      ls -la /dev/nvidia-caps-imex-channels
+      sleep 9999
     resources:
       claims:
       - name: imex-channel-0
@@ -58,18 +77,36 @@ spec:
     resourceClaimTemplateName: imex-channel-0
 ```
 
-The pod will not start until the local IMEX daemon is ready.
+The required node affinity prevents the workload from being used as a false-positive
+test on a node that is not part of an NVLink clique.
+The pod will not start until the local IMEX daemon is ready, and its startup command
+fails unless `channel0` is a character device.
+After the pod starts, verify the device explicitly; `Running` by itself is not a
+successful IMEX validation:
+
+```bash
+kubectl exec my-workload -- test -c /dev/nvidia-caps-imex-channels/channel0
+kubectl logs my-workload
+```
+
+The first command must exit successfully, and the logs must include
+`IMEX channel0 is available`.
 
 ### Channel allocation modes
 
-The `spec.channel.allocationMode` field controls how many IMEX channels are injected:
+In `driverManaged` mode, the `spec.channel.allocationMode` field controls how many
+IMEX channels are injected:
 
 | Mode | Value | Description |
 |---|---|---|
 | Single | `Single` (default) | Injects a single IMEX channel into the workload container |
 | All | `All` | Injects all available IMEX channels (up to the hardware maximum) |
 
-Use `All` for workloads that need access to every channel in the IMEX domain.
+Use `All` only in `driverManaged` mode for workloads that need access to every
+channel in the IMEX domain.
+In `hostManaged` mode, domain isolation shares channel 0 among workloads.
+The controller forces the generated workload claim to `Single`, so a requested
+`All` is equivalent to `Single` when using host-managed mode and does not expose additional channels.
 
 ## Check status
 
@@ -77,22 +114,138 @@ Use `All` for workloads that need access to every channel in the IMEX domain.
 kubectl get computedomain my-compute-domain -o yaml
 ```
 
-The `status.status` field reports `Ready` when all expected IMEX daemons have joined. The `status.nodes` list shows each node's IP, clique ID, and individual daemon status.
+Interpret `status.status` according to the configured lifecycle mode:
 
-To see the `ComputeDomainClique` objects created for this domain:
+- In `driverManaged` mode, `Ready` reflects the readiness of the per-ComputeDomain
+  daemons managed by the driver. When `ComputeDomainCliques` is enabled, inspect
+  the `ComputeDomainClique` objects for daemon membership:
 
-```bash
-kubectl get computedomainclique -n dra-driver-nvidia-gpu
-```
+  ```bash
+  kubectl get computedomainclique -n dra-driver-nvidia-gpu
+  ```
+
+- In `hostManaged` mode, `Ready` means only that the controller admitted the
+  `ComputeDomain` and created its workload `ResourceClaimTemplate`. It does not
+  report the health of the administrator-managed `nvidia-imex` service.
+  Host daemon health is checked later, on each node, when the kubelet plugin
+  prepares a workload channel claim. Host-managed mode does not create
+  `ComputeDomainClique` objects.
+
+## Validate host-managed IMEX
+
+Use this validation after installing the driver with both
+`featureGates.HostManagedIMEXDaemon=true` and
+`resources.computeDomains.imex.mode=hostManaged`.
+Complete the [host-managed prerequisites](../prerequisites.md#host-managed-imex)
+first, including configuring the same command socket path in the host service and
+the Helm value.
+
+1. On every node that can run the workload, verify the administrator-managed
+   service and command socket:
+
+   ```bash
+   sudo systemctl is-active nvidia-imex.service
+   sudo /usr/bin/nvidia-imex-ctl -q --u=/etc/nvidia-imex/imex_ctrl.sock
+   ```
+
+   The first command must report `active` and the second must report `READY`.
+   Substitute the configured `resources.computeDomains.imex.hostSocketPath` when
+   it is not the default.
+
+2. Create the `ComputeDomain` shown above, then verify that the controller created
+   only its workload claim template:
+
+   ```bash
+   CD_UID="$(kubectl get computedomain my-compute-domain -o jsonpath='{.metadata.uid}')"
+
+   kubectl get resourceclaimtemplate imex-channel-0
+   kubectl get daemonset --all-namespaces \
+       -l "resource.nvidia.com/computeDomain=${CD_UID}"
+   kubectl get resourceclaimtemplate --all-namespaces \
+       -l "resource.nvidia.com/computeDomain=${CD_UID},resource.nvidia.com/computeDomainTarget=Daemon"
+   ```
+
+   The first command must return `imex-channel-0`. The two label queries must
+   return no resources: host-managed mode creates neither a per-domain daemon
+   DaemonSet nor a daemon `ResourceClaimTemplate`.
+
+3. Save the clique-affined workload above as `my-workload.yaml`, apply it, and
+   verify `channel0` with both `test -c` and the workload log commands shown
+   after the manifest.
+   A `Running` pod without that device check is not sufficient.
+
+4. In a maintenance window on a test node, exercise readiness failure and
+   recovery. Record the node used in step 3, then delete that pod:
+
+   ```bash
+   TEST_NODE="$(kubectl get pod my-workload -o jsonpath='{.spec.nodeName}')"
+   echo "${TEST_NODE}"
+   kubectl delete -f my-workload.yaml
+   ```
+
+   In `my-workload.yaml`, add this expression alongside the existing
+   `nvidia.com/gpu.clique` expression, replacing `<test-node-name>` with the
+   value printed above:
+
+   ```yaml
+   - key: kubernetes.io/hostname
+     operator: In
+     values:
+     - <test-node-name>
+   ```
+
+   On that node, stop `nvidia-imex.service`:
+
+   ```bash
+   sudo systemctl stop nvidia-imex.service
+   ```
+
+   Reapply the same pod manifest from your administration host:
+
+   ```bash
+   kubectl apply -f my-workload.yaml
+   kubectl describe pod my-workload
+   kubectl get events --field-selector reason=FailedPrepareDynamicResources \
+       --sort-by=.lastTimestamp
+   ```
+
+   The pod must not start while the command socket is unavailable: claim
+   preparation fails and the kubelet retries. On the same node, restart the
+   service and wait for the command socket to report `READY`. The same pending
+   pod and claim then proceed without being recreated:
+
+   ```bash
+   sudo systemctl start nvidia-imex.service
+   sudo /usr/bin/nvidia-imex-ctl -q --u=/etc/nvidia-imex/imex_ctrl.sock
+   ```
+
+   From your administration host, verify recovery and channel injection:
+
+   ```bash
+   kubectl wait --for=condition=Ready pod/my-workload --timeout=5m
+   kubectl exec my-workload -- test -c /dev/nvidia-caps-imex-channels/channel0
+   ```
+
+5. Delete the workload and `ComputeDomain`. The controller removes the workload
+   claim template, but it does not stop or reconfigure the host service:
+
+   ```bash
+   kubectl delete pod my-workload
+   kubectl delete computedomain my-compute-domain
+   ```
+
+   Keep `nvidia-imex.service` running and manage its lifecycle outside the DRA
+   Driver.
 
 ## Feature gates
 
-Both feature gates that affect ComputeDomains are Beta and enabled by default. You do not need to set them for standard operation.
+The default driver-managed mode uses two Beta feature gates that are enabled by default.
 
-| Feature gate | Stage | Default | Effect |
+| Feature gate | Stage | Default | Description |
 |---|---|---|---|
-| `IMEXDaemonsWithDNSNames` | Beta | `true` | Daemons communicate using DNS names instead of raw IP addresses. This is the recommended mode and required by `ComputeDomainCliques`. |
-| `ComputeDomainCliques` | Beta | `true` | Uses `ComputeDomainClique` CRD objects to track daemon membership per clique instead of storing that information in `ComputeDomain.status.nodes`. Requires `IMEXDaemonsWithDNSNames`. |
+| `IMEXDaemonsWithDNSNames` | Beta | `true` | Makes daemons communicate using DNS names instead of raw IP addresses and is required by `ComputeDomainCliques`. |
+| `ComputeDomainCliques` | Beta | `true` | Uses `ComputeDomainClique` CRD objects to track daemon membership per clique instead of storing that information in `ComputeDomain.status.nodes` and requires `IMEXDaemonsWithDNSNames`. |
+| `HostManagedIMEXDaemon` | Alpha | `false` | Allows you to select `resources.computeDomains.imex.mode=hostManaged` without changing the lifecycle mode by itself. |
 
 To disable a Beta gate (for example, to test a downgrade path):
 

--- a/site/content/docs/guides/gpu-allocation/_index.md
+++ b/site/content/docs/guides/gpu-allocation/_index.md
@@ -5,7 +5,20 @@ weight: 10
 description: Task-oriented walkthroughs for running GPU workloads.
 ---
 
-These guides walk through how to run GPU workloads with the driver: requesting
-full GPUs, sharing them, and using MIG and VFIO passthrough. For example manifests, refer to
+Start with [GPU allocation](../../concepts/gpu-allocation.md) to choose a base
+resource type: full GPU, MIG, or VFIO passthrough. Then use the corresponding
+guide to request that resource.
+
+Kubernetes DRA consumable capacity enables independent `ResourceClaim` objects to share a full GPU or MIG device with scheduler-managed capacity accounting.
+Refer to [Consumable capacity](consumable-capacity.md) to configure memory-based, unlimited, or fixed-count shares.
+
+Time-slicing and Multi-Process Service are optional in-claim sharing strategies.
+Fabric Manager partitioning is an optional topology layer for full-GPU and
+VFIO devices.
+Refer to
+[Fabric Manager partitioning](fabric-manager-partitioning.md) to select and
+activate one complete NVSwitch partition.
+
+For example manifests, refer to
 [`demo/`](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/tree/{{< param driver_release_tag >}}/demo)
 in the repository.

--- a/site/content/docs/guides/gpu-allocation/allocating-gpus.md
+++ b/site/content/docs/guides/gpu-allocation/allocating-gpus.md
@@ -196,6 +196,16 @@ selectors.
 
 This example requires at least two allocatable GPUs in your cluster.
 
+{{% alert color="warning" title="Fabric Manager partitions require one claim" %}}
+The example below creates two independent single-GPU claims. It does not request
+one two-GPU Fabric Manager partition. On a node with
+`FabricManagerPartitioning` enabled, use one claim with `count: 2` and
+`matchAttribute: gpu.nvidia.com/partition2` when both GPUs must form one
+Fabric Manager partition. Each independent single-GPU claim must instead match a
+reported single-GPU partition. See
+[Fabric Manager partitioning](fabric-manager-partitioning.md#request-a-full-gpu-partition).
+{{% /alert %}}
+
 To give each container its own GPU, create separate device requests. This
 example reuses the `single-gpu` `ResourceClaimTemplate` from [Request any GPU](#request-any-gpu).
 
@@ -617,3 +627,4 @@ kubectl delete resourceclaimtemplate -n gpu-example single-gpu a100-gpu large-gp
 
 - [Time-slicing](time-slicing.md) — share a single GPU across multiple containers using CUDA time-slicing.
 - [MIG](mig.md) — partition a GPU into isolated hardware slices for multi-tenant workloads.
+- [Fabric Manager partitioning](fabric-manager-partitioning.md) — constrain a full-GPU or VFIO claim to one complete NVSwitch partition.

--- a/site/content/docs/guides/gpu-allocation/consumable-capacity.md
+++ b/site/content/docs/guides/gpu-allocation/consumable-capacity.md
@@ -1,0 +1,152 @@
+---
+title: Share GPUs with consumable capacity
+linkTitle: Consumable capacity
+weight: 42
+description: Share full GPUs and MIG devices across independent ResourceClaims with consumable capacity.
+---
+
+Kubernetes DRA consumable capacity lets multiple independent `ResourceClaim` objects allocate the same physical GPU or MIG device.
+The NVIDIA driver exposes this capability through its `ConsumableShares` feature gate and `consumableShares` Helm value.
+It marks supported devices as multi-allocatable and publishes a capacity policy; the Kubernetes scheduler then tracks how much capacity each claim consumes.
+
+Use consumable capacity when separate pods need independent claims but can safely co-locate on one device.
+This differs from time-slicing and MPS, where multiple containers reference an allocation with a driver-specific sharing configuration.
+
+## Feature status
+
+`ConsumableShares` is the NVIDIA driver's Alpha feature gate and is disabled by default.
+It must be enabled together with a non-disabled `consumableShares` mode.
+The corresponding upstream Kubernetes feature is DRA consumable capacity, controlled by the `DRAConsumableCapacity` feature gate.
+
+| Feature gate | Stage | Default |
+|---|---|---|
+| `ConsumableShares` | Alpha | `false` |
+
+Refer to the [feature gates reference](../../reference/feature-gates.md) for all available gates.
+
+## Prerequisites
+
+- Install the DRA Driver for NVIDIA GPUs.
+  Refer to [Installation](../../install.md).
+- Use Kubernetes v1.34 or later.
+  On Kubernetes v1.34 and v1.35, enable the upstream `DRAConsumableCapacity` feature gate on the kube-apiserver, kube-controller-manager, kube-scheduler, and kubelet.
+  Kubernetes v1.36 and later enables that gate by default.
+  Refer to [Kubernetes consumable capacity](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#consumable-capacity).
+- Use the `gpu.nvidia.com` or `mig.nvidia.com` DeviceClass.
+  The driver's consumable-capacity implementation does not support VFIO passthrough devices.
+- Do not use an MPS configuration on claims that use a shared device.
+
+## Enable consumable capacity
+
+Enable the driver's consumable-capacity implementation and choose one driver-specific accounting mode for all GPU kubelet plugins in the Helm release.
+This example selects memory-based accounting:
+
+```bash
+helm upgrade dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
+  --namespace dra-driver-nvidia-gpu \
+  --set featureGates.ConsumableShares=true \
+  --set consumableShares=memory \
+  --set gpuResourcesEnabledOverride=true
+```
+
+The Helm upgrade rolls the GPU kubelet plugin pods so they republish their `ResourceSlice` objects with `allowMultipleAllocations: true` and the selected capacity request policy.
+
+To disable the feature, set `consumableShares=disabled` or clear the value.
+You can then disable the `ConsumableShares` feature gate.
+
+## Choose a capacity accounting mode
+
+| `consumableShares` value | Behavior when a claim omits a capacity request |
+|---|---|
+| `memory` | Consumes the device's full advertised memory capacity unless a claim requests a smaller amount in 1 MiB increments. |
+| `unlimited` | Consumes zero memory capacity by default, so the scheduler does not limit the number of claims that omit a memory request, although a claim can still request an explicit amount of memory. |
+| Positive integer, such as `4` | Publishes that many `shares`, with each claim consuming one share by default unless it requests more, while memory consumption defaults to zero. |
+| `disabled` or empty | Does not publish multi-allocation or consumable-capacity policies and is the default. |
+
+The mode is a cluster-administrator setting applied to supported devices on every node managed by the Helm release.
+Workload authors express their needs in the `capacity.requests` map of a `ResourceClaim` or `ResourceClaimTemplate`.
+
+### Memory mode
+
+With `consumableShares=memory`, request the amount of GPU memory that the scheduler should reserve for each claim:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-4gi
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          capacity:
+            requests:
+              memory: 4Gi
+```
+
+Each pod that references this template gets its own claim.
+Kubernetes can allocate multiple claims to one GPU while their combined requested memory fits within the device's advertised memory capacity.
+If `capacity.requests.memory` is omitted in memory mode, the claim consumes the full memory capacity and no other memory-consuming claim can be allocated to that device.
+
+### Unlimited mode
+
+With `consumableShares=unlimited`, omit `capacity` from the device request:
+
+```yaml
+devices:
+  requests:
+  - name: gpu
+    exactly:
+      deviceClassName: gpu.nvidia.com
+```
+
+The claim consumes zero capacity by default.
+The scheduler can therefore place an unbounded number of these claims on the same device, subject to its other scheduling constraints.
+
+### Fixed share count
+
+Set `consumableShares` to a positive integer to publish a fixed number of shares.
+For example, `consumableShares=4` lets four claims that use the default of one share co-allocate on a device.
+To consume more than the default, add a `shares` request:
+
+```yaml
+capacity:
+  requests:
+    shares: 2
+```
+
+## Verify shared allocations
+
+Inspect the published device policy:
+
+```bash
+kubectl get resourceslices -o yaml
+```
+
+For supported devices, verify that `allowMultipleAllocations` is `true` and that the `memory` or `shares` capacity contains the expected `requestPolicy`.
+
+After creating workloads, inspect their claims:
+
+```bash
+kubectl get resourceclaims -A -o yaml
+```
+
+For a shared allocation, the allocation result records a `shareID` and its `consumedCapacity`.
+Example manifests for all three modes are available under [`demo/specs/consumable-shares/`](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/tree/{{< param driver_release_tag >}}/demo/specs/consumable-shares).
+
+## Limitations and considerations
+
+- **Capacity is scheduling accounting, not runtime isolation.**
+  A memory value reserves scheduler-visible capacity but does not limit a process's CUDA memory use.
+  Workloads sharing a device can affect each other's memory use and performance.
+- **MPS is not supported while the driver's consumable-capacity mode is active.**
+  The driver rejects an MPS-configured claim in this configuration.
+- **VFIO passthrough is not supported.**
+  The driver implements consumable capacity only for full GPUs and static or dynamic MIG devices.
+- **Claims must use matching device configurations.**
+  If a device is already prepared for another shared claim, a new claim with a conflicting `GpuConfig` or `MigDeviceConfig` fails to prepare.
+- **Unlimited means unbounded scheduler placement.**
+  Because a claim without a memory request consumes zero capacity in `unlimited` mode, use this mode only when the workloads can tolerate unrestricted contention.

--- a/site/content/docs/guides/gpu-allocation/fabric-manager-partitioning.md
+++ b/site/content/docs/guides/gpu-allocation/fabric-manager-partitioning.md
@@ -1,0 +1,334 @@
+---
+title: Fabric Manager partitioning
+linkTitle: Fabric Manager partitioning
+weight: 48
+description: Constrain full-GPU and VFIO claims to partitions managed by NVIDIA Fabric Manager.
+---
+
+Fabric Manager partitioning enables the DRA Driver for NVIDIA GPUs to activate
+and deactivate NVSwitch fabric partitions for workloads on supported HGX and
+single-node NVL systems.
+It is an optional topology layer for full-GPU and VFIO allocations, not a
+separate GPU resource type.
+
+## Feature status
+
+Choose a base resource type first:
+
+| Base resource | Fabric Manager partitioning | Required feature gates |
+|---|---|---|
+| Full GPU (`gpu.nvidia.com`) | Supported | `FabricManagerPartitioning` |
+| VFIO passthrough (`vfio.gpu.nvidia.com`) | Supported | `FabricManagerPartitioning`, `PassthroughSupport` |
+| MIG slice (`mig.nvidia.com`) | Not supported | — |
+
+`FabricManagerPartitioning` does not require `PassthroughSupport`.
+Enable `PassthroughSupport` only when you also need VFIO devices.
+For all other feature-gate dependencies and incompatibilities, refer to
+[Feature gate constraints](../../reference/feature-gates.md#constraints).
+
+## How partition matching works
+
+Fabric Manager reports the valid groups of physical GPUs that it can manage as
+partitions.
+For example, it might report these two-GPU partitions:
+
+| Partition | Physical GPUs |
+|---|---|
+| 4 | GPU modules 1 and 2 |
+| 5 | GPU modules 3 and 4 |
+
+The driver publishes the partition membership as device attributes.
+Both GPUs in partition 4 receive `partition2: 4`, and both GPUs in partition 5
+receive `partition2: 5`.
+
+When kubelet prepares a claim, the driver collects all full-GPU and VFIO
+physical GPUs allocated to that claim.
+Their complete set must exactly match one partition reported by Fabric Manager.
+A subset of a partition, a set that crosses partition boundaries, or a set that
+combines multiple partitions fails Prepare and prevents the pod from starting.
+
+For the example topology, the following allocations succeed or fail as shown:
+
+| Allocated GPU modules | Result |
+|---|---|
+| 1 and 2 | Succeeds: exactly matches partition 4 |
+| 3 and 4 | Succeeds: exactly matches partition 5 |
+| 1 and 3 | Fails: crosses partition boundaries |
+| 1 only | Succeeds only if Fabric Manager also reports a one-GPU partition containing GPU module 1 |
+
+Use one `ResourceClaim` for one Fabric Manager partition.
+Separate claims cannot use a `matchAttribute` constraint to ensure that their
+combined GPUs form one partition.
+
+## Prerequisites
+
+Before enabling the feature:
+
+- Meet the general driver [prerequisites](../../prerequisites.md).
+- Use a supported HGX or single-node NVL system with an NVSwitch-managed
+  fabric and a supported partition topology.
+- Run NVIDIA Fabric Manager on each participating node with `FABRIC_MODE=1`,
+  `FM_CMD_UNIX_SOCKET_PATH=/run/nvidia-fabricmanager/socket`, and
+  `FABRIC_MODE_RESTART=1`.
+- Ensure the target GPUs are visible to NVML when the GPU kubelet plugin
+  starts, so that the driver can resolve their `gpuModuleID` values.
+
+The driver verifies that it can find the Fabric Manager client library,
+connect to Fabric Manager, and read the reported topology.
+The driver cannot verify that the platform is in the supported-product list or
+identify how Fabric Manager was started.
+Verify the platform support and the environment variables configuration before enabling
+the feature.
+
+Migrate claims before enabling this feature.
+On a participating Fabric Manager node, the gate affects every full-GPU claim
+and, when `PassthroughSupport` is enabled, every VFIO claim.
+Audit existing claim templates first.
+A request for `count: N` without a matching `gpu.nvidia.com/partitionN`
+constraint can receive an invalid GPU combination and then fail Prepare.
+
+If unconstrained claims must continue to run, schedule them on other nodes
+until their claim templates are partition-aware.
+
+### Special Considerations: GPU Operator deployments
+
+If you deploy GPU Operator to manage your nodes, then use the `GPUCluster`
+custom resource to deploy the DRA driver.
+
+Using the GPU Operator `ClusterPolicy` resource, the default, with `FABRIC_MODE=1` is
+unsupported. Installing the DRA driver separately with Helm does not make this
+configuration supported.
+
+
+## Enable Fabric Manager partitioning
+
+Enable the gate on the existing Helm release:
+
+```bash
+helm upgrade -i dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
+    --version {{< param "driver_version" >}} \
+    --namespace dra-driver-nvidia-gpu \
+    --reuse-values \
+    --set featureGates.FabricManagerPartitioning=true
+```
+
+For VFIO allocations, also enable `PassthroughSupport` and follow the
+[KubeVirt VFIO GPU passthrough guide](kubevirt-vfio-gpu-passthrough.md) for
+the remaining VFIO prerequisites:
+
+```bash
+helm upgrade -i dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
+    --version {{< param "driver_version" >}} \
+    --namespace dra-driver-nvidia-gpu \
+    --reuse-values \
+    --set featureGates.FabricManagerPartitioning=true \
+    --set featureGates.PassthroughSupport=true
+```
+
+On nodes where the driver does not detect an NVSwitch or an NVLink 5
+switch-managed fabric, it skips Fabric Manager initialization.
+
+## Inspect the published partitions
+
+Inspect the GPU ResourceSlices before creating a claim:
+
+```bash
+kubectl get resourceslice -o yaml
+```
+
+When the gate is active and Fabric Manager reports the topology, full-GPU and
+VFIO devices include attributes similar to:
+
+```yaml
+attributes:
+  gpuModuleID:
+    int: 1
+  partition1:
+    int: 8
+  partition2:
+    int: 4
+  partition4:
+    int: 2
+  partition8:
+    int: 1
+  type:
+    string: gpu
+```
+
+`gpuModuleID` is the physical module identifier used by Fabric Manager.
+`partitionN` is the ID of the reported N-GPU partition containing that device.
+The driver publishes a `partitionN` attribute only when Fabric Manager reports
+a partition of that size containing the GPU.
+Do not assume that a particular size is available; inspect the ResourceSlice
+first.
+
+Partition and module IDs are local topology details.
+Prefer `matchAttribute: gpu.nvidia.com/partitionN` over selecting a hardcoded
+partition ID.
+Refer to
+[ResourceSlice device attributes](../../reference/resourceslice-attributes.md#fabric-manager-partition-attributes)
+for the attribute reference.
+
+## Request a full-GPU partition
+
+This example requests one complete two-GPU partition:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: fm-full-gpu-partition-2
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpus
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: 2
+      constraints:
+      - requests:
+        - gpus
+        matchAttribute: gpu.nvidia.com/partition2
+```
+
+`matchAttribute` requires the selected GPUs to have the same size-two
+partition ID.
+Combined with `count: 2`, this selects all GPUs in that reported two-GPU
+partition.
+A count alone does not guarantee a valid partition.
+
+Reference the two-GPU partition claim for the workload:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fm-partition-pod
+spec:
+  containers:
+  - name: ctr
+    image: nvidia/cuda:12.0.0-base-ubuntu22.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; sleep infinity"]
+    resources:
+      claims:
+      - name: gpus
+  resourceClaims:
+  - name: gpus
+    resourceClaimTemplateName: fm-full-gpu-partition-2
+```
+
+## Request a VFIO partition
+
+For VFIO, use the same count and constraint with the `vfio.gpu.nvidia.com`
+DeviceClass.
+Keep all selected VFIO devices in one request and apply one `VfioDeviceConfig`
+group to that request:
+
+```yaml
+devices:
+  config:
+  - requests:
+    - gpus
+    opaque:
+      driver: gpu.nvidia.com
+      parameters:
+        apiVersion: resource.nvidia.com/v1beta1
+        kind: VfioDeviceConfig
+        iommu:
+          backendPolicy: LegacyOnly
+          enableAPIDevice: true
+  requests:
+  - name: gpus
+    exactly:
+      deviceClassName: vfio.gpu.nvidia.com
+      allocationMode: ExactCount
+      count: 2
+  constraints:
+  - requests:
+    - gpus
+    matchAttribute: gpu.nvidia.com/partition2
+```
+
+KubeVirt also requires `DeviceMetadata` and additional host configuration.
+Refer to [KubeVirt VFIO GPU passthrough](kubevirt-vfio-gpu-passthrough.md).
+
+## Verify the allocation
+
+After creating the workload, confirm that its generated claim contains exactly
+the expected number of devices:
+
+```bash
+kubectl get resourceclaim
+kubectl get resourceclaim <claim-name> -o yaml
+```
+
+Review `status.allocation.devices.results` and compare the selected device
+names with the node's ResourceSlice.
+They must all share the requested `partitionN` value.
+
+Confirm that the pod reaches `Running`:
+
+```bash
+kubectl get pod fm-partition-pod
+kubectl exec fm-partition-pod -- nvidia-smi -L
+```
+
+For a two-GPU full-GPU claim, `nvidia-smi -L` should list two GPUs.
+
+## Troubleshooting
+
+### View GPU kubelet-plugin logs
+
+Check the GPU kubelet-plugin logs for startup and Prepare errors:
+
+```bash
+kubectl logs -n dra-driver-nvidia-gpu \
+    -l dra-driver-nvidia-gpu-component=kubelet-plugin \
+    -c gpus
+```
+
+| Error or symptom | Action |
+|---|---|
+| `fabric manager library not found` | Verify that `libnvfm.so` is installed under `nvidiaDriverRoot` in a standard library directory. |
+| `Fabric Manager could not be opened` | Verify that Fabric Manager is running with `FABRIC_MODE=1` and that its socket or configured address is reachable from the plugin. |
+| `GPU module set [...] does not match any FM partition` | Compare the allocated devices with their `partitionN` attributes. Use one claim with the correct `count: N` and `matchAttribute`. |
+| `no gpuModuleID` or missing FM attributes | Verify NVML visibility and the reported FM topology. A GPU already bound to `vfio-pci` when the plugin starts might not have a resolvable module ID. |
+| No FM attributes on the node | Confirm that the gate is enabled and that the driver detects an NVSwitch or NVLink 5 switch-managed fabric on the node. |
+
+If a VFIO workload remains in `ContainerCreating` after its partition is
+selected, continue with the VFIO-specific
+[troubleshooting steps](kubevirt-vfio-gpu-passthrough.md#troubleshooting).
+
+### View Fabric Manager partition status
+
+On the host, list all partitions and their status:
+
+```bash
+/run/nvidia/fmpm \
+  --unix-domain-socket /run/nvidia-fabricmanager/socket \
+  -l
+```
+
+If a partition is activated, the response includes `isActive: 1`, as in this
+example:
+
+```json
+{
+  "gpuInfo": [
+    {
+      "maxNumNvLinks": 0,
+      "numNvLinksAvailable": 0,
+      "nvlinkLineRateMBps": 26562,
+      "pciBusId": "00000000:00:00.0",
+      "physicalId": 7,
+      "uuid": ""
+    }
+  ],
+  "isActive": 1,
+  "numGpus": 1,
+  "partitionId": 13
+}
+```

--- a/site/content/docs/guides/gpu-allocation/kubevirt-vfio-gpu-passthrough.md
+++ b/site/content/docs/guides/gpu-allocation/kubevirt-vfio-gpu-passthrough.md
@@ -13,12 +13,13 @@ For KubeVirt feature gates, VM fields, and VM examples, refer to the [KubeVirt u
 
 ## Feature status
 
-This guide uses two Alpha feature gates, both disabled by default:
+This guide uses Alpha feature gates that are disabled by default:
 
-| Feature gate | Default | Stage |
-|---|---|---|
-| `PassthroughSupport` | `false` | Alpha |
-| `DeviceMetadata` | `false` | Alpha |
+| Feature gate | Stage | Default | Description |
+|---|---|---|---|
+| `PassthroughSupport` | Alpha | `false` | Enables VFIO passthrough allocation. |
+| `DeviceMetadata` | Alpha | `false` | Exposes the VFIO API device required by KubeVirt. |
+| `FabricManagerPartitioning` | Alpha | `false` | Optionally constrains VFIO claims to partitions managed by Fabric Manager. |
 
 Refer to the [feature gates reference](../../reference/feature-gates.md) and [constraints](../../reference/feature-gates.md#constraints) for details.
 
@@ -26,22 +27,79 @@ Refer to the [feature gates reference](../../reference/feature-gates.md) and [co
 
 - Meet the general driver [prerequisites](../../prerequisites.md).
 - **IOMMU enabled** on GPU nodes. VFIO passthrough requires IOMMU; the GPU kubelet plugin fails to start with `PassthroughSupport` enabled if IOMMU is off.
-- Use **DRA Driver for NVIDIA GPUs v0.4.0 or later** with the **`PassthroughSupport`** and **`DeviceMetadata`** feature gates enabled.
+- Enable the `PassthroughSupport` and `DeviceMetadata` feature gates in the DRA Driver.
 - Use **KubeVirt v1.8.0 or later** with the **`GPUsWithDRA`** feature gate enabled. This gate is enabled by default from KubeVirt v1.9.0, so it only needs to be set explicitly on v1.8.x.
+
+### NVIDIA Grace VFIO module selection
+
+The GPU kubelet plugin automatically selects the most specific VFIO module variant that matches each GPU PCI modalias.
+For example, on NVIDIA Grace systems, the kubelet plugin automatically selects the `nvgrace_gpu_vfio_pci` driver.
 
 ## Limitations and considerations
 
-For a GPU to switch between the `nvidia` and `vfio-pci` drivers, nothing on the host may hold an open handle on that GPU's `/dev/nvidia*` device nodes.
+- For a GPU to switch between the `nvidia` and `vfio-pci` drivers, no process on the host can have an open handle on that GPU's `/dev/nvidia*` device nodes.
 
-Make sure each of the following is either not using the GPU being prepared, or is configured to release it:
+  Make sure each of the following is either not using the GPU being prepared, or is configured to release it:
 
-| Component | Notes |
-|---|---|
-| **display-manager (Xorg)** | **Must be disabled.** |
-| **nvidia-device-plugin** | **Must be disabled.** Not supported on the same node as the DRA Driver, which already handles both container and passthrough allocation. Exclude it from these nodes with a node selector or taint. |
-| **nvidia-persistenced** | On DRA Driver v0.4.0 or later, the DRA Driver automatically disables persistence mode on the target GPU before rebinding it to `vfio-pci` and restores it afterward, so the service can keep running. Older versions don't have this handling and require stopping the service manually. |
-| **dcgm** | Recommended to disable this service. **Note:** DCGM v4.5.0+ can automatically release GPUs when switching between the `nvidia` and `vfio-pci` drivers. |
-| **dcgm-exporter** | Recommended to disable this service. **Note:** dcgm-exporter v4.5.0+ has an experimental feature, `DCGM_EXPORTER_ENABLE_GPU_BIND_UNBIND_WATCH=true` (plus a poll frequency `DCGM_EXPORTER_GPU_BIND_UNBIND_POLL_INTERVAL=1s`), to automatically release GPUs when switching between the `nvidia` and `vfio-pci` drivers. Use with caution. |
+  | Component | Notes |
+  |---|---|
+  | **display-manager (Xorg)** | **Must be disabled.** |
+  | **nvidia-device-plugin** | **Must be disabled.** Not supported on the same node as the DRA Driver, which already handles both container and passthrough allocation. Exclude it from these nodes with a node selector or taint. |
+  | **nvidia-persistenced** | On DRA Driver v0.4.0 or later, the DRA Driver automatically disables persistence mode on the target GPU before rebinding it to `vfio-pci` and restores it afterward, so the service can keep running. Older versions don't have this handling and require stopping the service manually. |
+  | **dcgm** | Recommended to disable this service. **Note:** DCGM v4.5.0+ can automatically release GPUs when switching between the `nvidia` and `vfio-pci` drivers. |
+  | **dcgm-exporter** | Recommended to disable this service. **Note:** dcgm-exporter v4.5.0+ has an experimental feature, `DCGM_EXPORTER_ENABLE_GPU_BIND_UNBIND_WATCH=true` (plus a poll frequency `DCGM_EXPORTER_GPU_BIND_UNBIND_POLL_INTERVAL=1s`), to automatically release GPUs when switching between the `nvidia` and `vfio-pci` drivers. Use with caution. |
+
+- With `PassthroughSupport` enabled, the driver initially advertises both a GPU device and a VFIO device for each eligible physical GPU.
+  These are two representations of the same hardware and cannot be used simultaneously.
+
+  A race exists between claim allocation and device preparation.
+  If a container GPU claim and a VFIO passthrough claim are allocated for the same physical GPU before either device is prepared, the scheduler can allocate both.
+  Whichever device is prepared first succeeds.
+  Preparation of the other fails with `allocatable not found for device "<device-name>"`.
+
+  After device preparation succeeds, the driver removes the alternate device type from the node's `ResourceSlice` and prevents further conflicting allocations.
+
+  One way to avoid conflicting allocations is to submit the workloads serially and waiting for the first workload's device preparation to complete before submitting the next.
+  Another way to prevent conflicting allocations is to dedicate separate nodes to container GPU and VFIO workloads.
+  Label the nodes by workload type, and add the matching `nodeSelector` to every GPU pod and KubeVirt VM.
+  For stronger isolation, you can taint the VFIO nodes with `NoSchedule` and add the corresponding toleration only to VFIO workloads.
+
+  For example, label the container and VFIO nodes and taint the VFIO nodes:
+
+  ```bash
+  kubectl label node <container-node> demo/gpu-workload=container
+  kubectl label node <vfio-node> demo/gpu-workload=vfio
+  kubectl taint node <vfio-node> demo/gpu-workload=vfio:NoSchedule
+  ```
+
+  Add the following node selector to container GPU pods:
+
+  ```yaml
+  spec:
+    nodeSelector:
+      demo/gpu-workload: container
+  ```
+
+  Add the matching node selector and toleration to the KubeVirt VM template:
+
+  ```yaml
+  spec:
+    template:
+      spec:
+        nodeSelector:
+          demo/gpu-workload: vfio
+        tolerations:
+        - key: demo/gpu-workload
+          operator: Equal
+          value: vfio
+          effect: NoSchedule
+  ```
+
+  A toleration permits scheduling on the tainted nodes but does not require it, so use it together with the node selector.
+  Ensure that the DRA kubelet plugin and other required DaemonSets also tolerate the taint.
+
+  If a conflict occurs, delete and recreate the failed pod and its resource claim after the other workload completes device preparation.
+  When the claim is generated from a `ResourceClaimTemplate`, deleting the pod also deletes the generated claim.
 
 ## Install the DRA Driver
 
@@ -65,6 +123,39 @@ Set `nvidiaDriverRoot` based on how the NVIDIA driver is installed on your nodes
 - `/` for a host-installed driver.
 - `/run/nvidia/driver` for a GPU Operator-managed driver.
 - `/home/kubernetes/bin/nvidia` for a GKE-managed driver.
+
+### Optional: Fabric Manager partitioning
+
+On supported HGX and single-node NVL systems, Fabric Manager partitioning provides
+additional isolation at the NVLink fabric level for passthrough workloads using
+claims with `vfio.gpu.nvidia.com` device classes.
+The partitioning also supports full-GPU claims and does not depend on `PassthroughSupport`.
+This guide already enables `PassthroughSupport` because the base resource is
+VFIO.
+
+Before enabling the gate, configure Fabric Manager with `FABRIC_MODE=1` and
+update every applicable VFIO claim to select one complete published partition.
+Refer to [Fabric Manager partitioning](fabric-manager-partitioning.md) for
+platform prerequisites, claim migration, topology inspection, and
+troubleshooting.
+
+Enable the optional gate on the existing Helm release:
+
+```bash
+helm upgrade -i dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
+    --version {{< param "driver_version" >}} \
+    --namespace dra-driver-nvidia-gpu \
+    --reuse-values \
+    --set featureGates.FabricManagerPartitioning=true
+```
+
+With the gate enabled, VFIO ResourceSlice devices publish `gpuModuleID` and
+the `partitionN` attributes reported for each physical GPU.
+The GPU kubelet plugin activates the exact partition before binding the
+selected GPUs to VFIO and deactivates it after the GPUs return to the NVIDIA
+driver.
+For the attribute definitions, refer to
+[ResourceSlice device attributes](../../reference/resourceslice-attributes.md#fabric-manager-partition-attributes).
 
 Verify that the driver registered the expected `DeviceClass` and advertised node resources:
 
@@ -154,6 +245,32 @@ The opaque `VfioDeviceConfig` block tells the DRA Driver which VFIO device nodes
 - **`backendPolicy: LegacyOnly`** — Selects the legacy IOMMU VFIO backend (`/dev/vfio/<iommu-group>`). The alternative, `PreferIommuFD`, uses the IOMMUFD backend (`/dev/vfio/devices/vfio*`) when available on the host.
 
 Keep `backendPolicy: LegacyOnly` for KubeVirt, which does not support the IOMMUFD backend yet.
+
+### Select a Fabric Manager partition
+
+For a two-GPU VM on a Fabric Manager node, change the request count to `2` and
+require both GPUs to share a size-two partition:
+
+```yaml
+devices:
+  requests:
+  - name: dra-gpu
+    exactly:
+      allocationMode: ExactCount
+      count: 2
+      deviceClassName: vfio.gpu.nvidia.com
+  constraints:
+  - requests:
+    - dra-gpu
+    matchAttribute: gpu.nvidia.com/partition2
+```
+
+The scheduler selects two VFIO GPUs with the same `partition2` value.
+Claim preparation fails if the selected GPU set does not exactly match a
+partition reported by Fabric Manager.
+Keep a single `VfioDeviceConfig` block for all VFIO requests in the claim.
+For why the count and constraint must be used together, refer to
+[Request a VFIO partition](fabric-manager-partitioning.md#request-a-vfio-partition).
 
 ## Troubleshooting
 

--- a/site/content/docs/guides/mps.md
+++ b/site/content/docs/guides/mps.md
@@ -1,6 +1,6 @@
 ---
-title: MPS
-linkTitle: MPS
+title: GPU sharing with Multi-Process Service
+linkTitle: Multi-Process Service
 weight: 45
 description: Share a single GPU between multiple containers using NVIDIA Multi-Process Service (MPS).
 ---
@@ -14,7 +14,7 @@ pinned-memory limit.
 Use MPS when you want several cooperating workloads to make forward progress on
 the same GPU at once and you want coarse-grained control over how they share
 compute and memory. If you instead need workloads to take turns on an idle GPU
-with no configuration, see [Time-slicing](time-slicing.md).
+with no configuration, refer to [Time-slicing](./gpu-allocation/time-slicing.md).
 
 ## Feature status
 
@@ -32,8 +32,8 @@ available gates and their constraints.
 
 - The DRA Driver for NVIDIA GPUs must be installed. See [Installation](../install.md).
 - The `MPSSupport` feature gate must be enabled. See [Enabling the feature](#enabling-the-feature).
-- `MPSSupport` cannot be enabled at the same time as `DynamicMIG` or
-  `NVMLDeviceHealthCheck`. These combinations are mutually exclusive.
+- `MPSSupport` cannot be enabled at the same time as `DynamicMIG`.
+  These combinations are mutually exclusive.
 - To use multi-user mode (`multiUser: true`), the GPUs must be Volta
   architecture or newer.
 
@@ -255,8 +255,8 @@ GPU.
   hard throughput guarantees.
 - MPS requires the
   `EXCLUSIVE_PROCESS` compute mode; time-slicing requires `DEFAULT`.
-- `MPSSupport` cannot be enabled together
-  with `DynamicMIG` or `NVMLDeviceHealthCheck`.
+- `MPSSupport` cannot be enabled together with `DynamicMIG`.
+- MPS claims cannot be prepared when `ConsumableShares` is enabled with a non-disabled `consumableShares` mode.
 - Setting `multiUser: true`
   requires GPUs of Volta architecture or newer; otherwise the claim fails to
   prepare.

--- a/site/content/docs/install.md
+++ b/site/content/docs/install.md
@@ -335,7 +335,9 @@ Deploy a sample workload that provisions an IMEX channel across NVLink-connected
 This section requires Multi-Node NVLink (MNNVL) hardware.
 {{% /alert %}}
 
-1. Validate clique node labels. GPU Feature Discovery labels each MNNVL-capable node with `nvidia.com/gpu.clique`. Confirm all expected nodes have this label:
+1. Validate clique node labels.
+   GPU Feature Discovery or the ComputeDomain kubelet plugin can own the `nvidia.com/gpu.clique` label on each MNNVL-capable node.
+   Confirm all expected nodes have this label:
 
 ```bash
 (echo -e "NODE\tLABEL\tCLIQUE"; kubectl get nodes -o json | \
@@ -351,7 +353,10 @@ gpu-node-001   nvidia.com/gpu.clique    a1b2c3d4-e5f6-7890-abcd-ef1234567890.0
 gpu-node-002   nvidia.com/gpu.clique    a1b2c3d4-e5f6-7890-abcd-ef1234567890.0
 ```
 
-Each value should have the shape `<CLUSTER_UUID>.<CLIQUE_ID>`. If any nodes are missing the label, confirm that GPU Feature Discovery is deployed and running on the affected nodes.
+Each value should have the shape `<CLUSTER_UUID>.<CLIQUE_ID>`.
+If any nodes are missing the label, confirm that GPU Feature Discovery is deployed and running on the affected nodes, or set `kubeletPlugin.containers.computeDomains.gpuCliqueLabelEnabled=true` and restart the kubelet plugin so the DRA Driver can manage the label instead.
+Do not configure both components to own the label.
+Refer to [Prerequisites](prerequisites.md#computedomains-additional-prerequisites) for details.
 
 2. Create a `ComputeDomain`. This groups nodes connected via NVLink fabric and provisions the IMEX channels needed for cross-node GPU communication. The `channel.resourceClaimTemplate` field names a `ResourceClaimTemplate` that the controller creates automatically, which pods then use to claim a channel:
 

--- a/site/content/docs/prerequisites.md
+++ b/site/content/docs/prerequisites.md
@@ -57,8 +57,14 @@ If you plan to use ComputeDomains, you also need:
 
 - NVIDIA Driver v570.158.01 or later. The `IMEXDaemonsWithDNSNames` feature gate is enabled by default and requires this driver version. The ComputeDomain plugin will fail to start on older drivers unless `IMEXDaemonsWithDNSNames` is explicitly disabled.
 - Multi-Node NVLink (MNNVL) hardware. Nodes must be connected via NVLink fabric, such as GB200 NVL72 and similar systems.
-- GPU Feature Discovery (GFD) deployed via the [GPU Operator](#install-prerequisites-with-nvidia-gpu-operator). GFD generates the `nvidia.com/gpu.clique` node labels required by ComputeDomains.
-- On all GPU nodes where the `nvidia-imex-*` packages are installed, the `nvidia-imex.service` systemd unit must be disabled:
+- A component that manages the `nvidia.com/gpu.clique` node label.
+  Use GPU Feature Discovery (GFD), or set `kubeletPlugin.containers.computeDomains.gpuCliqueLabelEnabled=true` so the ComputeDomain kubelet plugin manages the label.
+
+
+### Driver-managed IMEX
+
+The default `resources.computeDomains.imex.mode=driverManaged` setting makes the DRA Driver create one `nvidia-imex` DaemonSet for each `ComputeDomain`.
+On all GPU nodes where the `nvidia-imex-*` packages are installed, disable the host `nvidia-imex.service` systemd unit:
 
 ```bash
 systemctl disable --now nvidia-imex.service && systemctl mask nvidia-imex.service
@@ -68,6 +74,11 @@ systemctl disable --now nvidia-imex.service && systemctl mask nvidia-imex.servic
 
 By default the driver owns the `nvidia-imex` daemon lifecycle, per the requirement above. For clusters where the operator already runs `nvidia-imex` as a host service (for example through systemd), set `resources.computeDomains.imex.mode=hostManaged` to stop the driver from creating per-ComputeDomain `nvidia-imex` DaemonSets. This **inverts** the requirement above: `nvidia-imex.service` must be installed, configured, and left **running** on every participating GPU node. Also, the `nvidia-imex` service should be configured with
 `IMEX_CMD_ENABLED=1` and `IMEX_CMD_UNIX_DOMAIN_PATH=/etc/nvidia-imex/imex_ctrl.sock` (configurable via Helm).
+
+{{% alert color="warning" title="Warning" %}}
+Some `nvidia-imex.service` units use `ProtectSystem=full`, which prevents the service from creating the default socket under `/etc`.
+For these units, set `IMEX_CMD_UNIX_DOMAIN_PATH` and `resources.computeDomains.imex.hostSocketPath` to the same writable runtime path, such as `/var/run/nvidia-imex-ctrl.sock`.
+{{% /alert %}}
 
 Host-managed mode requires two Helm values together:
 
@@ -100,6 +111,9 @@ To enable it:
 2. `nvidia-imex-ctl` must be present under the driver root alongside `nvidia-smi` (it ships with the `nvidia-imex` package).
 3. If a non-default socket path is used, set `resources.computeDomains.imex.hostSocketPath` (Helm value, plumbed to the kubelet plugin as `IMEX_HOST_SOCKET_PATH`) to match. It defaults to `/etc/nvidia-imex/imex_ctrl.sock`.
 
+After installation, follow [Validate host-managed IMEX](guides/compute-domain-workloads.md#validate-host-managed-imex)
+to verify the created objects, channel injection, and Prepare retry behavior.
+
 ## Install prerequisites with NVIDIA GPU Operator
 
 The [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html) is a Kubernetes operator that automates the deployment and lifecycle management of all NVIDIA software components needed to provision and monitor GPUs in a cluster.
@@ -109,6 +123,6 @@ It can manage the following DRA Driver for NVIDIA GPUs prerequisites for you:
 - NVIDIA Driver (v565+ for GPU allocation, v570.158.01+ for ComputeDomains). The GPU Operator installs a [default driver](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html#gpu-operator-component-matrix) that meets the DRA Driver's prerequisites. To use a specific version, see [Common chart customization options](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#common-chart-customization-options) in the GPU Operator documentation.
 - CDI enabled through the NVIDIA Container Toolkit.
 - Node Feature Discovery (NFD).
-- GPU Feature Discovery (GFD), required for ComputeDomains.
+- GPU Feature Discovery (GFD), which can own the ComputeDomain `nvidia.com/gpu.clique` label when you do not enable driver ownership.
 
 If you choose to install the GPU Operator, follow the [DRA Driver for NVIDIA GPUs install guide](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/dra-intro-install.html) in the GPU Operator documentation. It covers installing the GPU Operator with the NVIDIA Kubernetes Device Plugin disabled and installing the DRA Driver for NVIDIA GPUs.

--- a/site/content/docs/reference/api.md
+++ b/site/content/docs/reference/api.md
@@ -37,6 +37,7 @@ sharing:
   mpsConfig:
     defaultActiveThreadPercentage: 50             # optional, integer
     defaultPinnedDeviceMemoryLimit: "4Gi"         # optional, quantity
+    multiUser: true                               # optional, default false
     defaultPerDevicePinnedMemoryLimit:            # optional, map
       "0": "2Gi"
 ```
@@ -51,6 +52,7 @@ sharing:
 | `sharing.mpsConfig.defaultActiveThreadPercentage` | integer | Thread percentage limit applied to all processes sharing the GPU. Requires the [`MPSSupport`](feature-gates.md) feature gate. |
 | `sharing.mpsConfig.defaultPinnedDeviceMemoryLimit` | quantity | Pinned memory limit applied to all devices. |
 | `sharing.mpsConfig.defaultPerDevicePinnedMemoryLimit` | map | Per-device override of `defaultPinnedDeviceMemoryLimit`. Keys are device index (integer) or UUID string. |
+| `sharing.mpsConfig.multiUser` | bool | Starts the MPS control daemon in multi-user mode so processes with different user IDs can share the device, defaults to `false` when omitted, and requires a Volta or newer GPU. |
 
 
 ### MigDeviceConfig
@@ -75,6 +77,7 @@ sharing:
   strategy: MPS
   mpsConfig:
     defaultActiveThreadPercentage: 50
+    multiUser: true
 ```
 
 #### Fields
@@ -83,7 +86,7 @@ sharing:
 |---|---|---|
 | `sharing` | object | Optional. Supports `TimeSlicing` and `MPS` strategies. |
 | `sharing.strategy` | string | `TimeSlicing` or `MPS`. |
-| `sharing.mpsConfig` | object | MPS configuration. Same fields as `GpuConfig.sharing.mpsConfig`. Requires [`MPSSupport`](feature-gates.md). |
+| `sharing.mpsConfig` | object | Supports the same MPS fields, defaults, and Volta-or-newer `multiUser` requirement as `GpuConfig.sharing.mpsConfig` and requires [`MPSSupport`](feature-gates.md). |
 
 {{% alert title="Note" %}}
 `timeSlicingConfig` is not available for MIG devices. Time-slicing on MIG slices does not support interval configuration.

--- a/site/content/docs/reference/feature-gates.md
+++ b/site/content/docs/reference/feature-gates.md
@@ -28,35 +28,38 @@ helm install dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/chart
 
 ## Available feature gates
 
-| Feature gate | Stage | Default | Description |
-|---|---|---|---|
-| `TimeSlicingSettings` | Alpha | `false` | Enables customization of CUDA time-slicing settings in `GpuConfig`. |
-| `MPSSupport` | Alpha | `false` | Enables Multi-Process Service (MPS) sharing strategy in `GpuConfig` and `MigDeviceConfig`. |
-| `IMEXDaemonsWithDNSNames` | Beta | `true` | IMEX daemons use DNS names instead of raw IP addresses for peer communication. Required by `ComputeDomainCliques`. |
-| `PassthroughSupport` | Alpha | `false` | Enables VFIO passthrough device allocation using `VfioDeviceConfig`. |
-| `DynamicMIG` | Alpha | `false` | Enables dynamic MIG device allocation and reconfiguration. See [MIG](../guides/gpu-allocation/mig.md). Kubernetes v1.34–v1.35 requires `DRAPartitionableDevices` enabled on the kube-apiserver and kube-scheduler (enabled by default on Kubernetes v1.36 and later) (see [Kubernetes feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#DRAPartitionableDevices)). |
-| `NVMLDeviceHealthCheck` | Alpha | `false` | Enables GPU health checking using NVML. |
-| `ComputeDomainCliques` | Beta | `true` | Uses `ComputeDomainClique` CRD objects to track IMEX daemon membership. Requires `IMEXDaemonsWithDNSNames`. |
-| `CrashOnNVLinkFabricErrors` | Beta | `true` | Causes the kubelet plugin to crash rather than fall back to non-fabric mode when NVLink fabric errors are detected. |
-| `DeviceMetadata` | Alpha | `false` | Enables IOMMU API device exposure (`/dev/iommu` or `/dev/vfio/vfio`) for VFIO workloads via `VfioDeviceConfig`. Requires `PassthroughSupport`. |
-| `FabricManagerPartitioning` | Alpha | `false` | Enables Fabric Manager (NVSwitch) partition management in single-node NVL systems for full-GPU (`gpu.nvidia.com`) devices and Passthrough VFIO devices. Requires Fabric Manager running with `FABRIC_MODE=1`. When combined with `PassthroughSupport`, both device types are partitioned; otherwise only full-GPU devices. **Prepare requires the allocated physical-GPU set to match an FM partition exactly**; non-matching claims (including ordinary multi-GPU full-GPU workloads without a `matchAttribute` on `gpu.nvidia.com/partitionN`) fail Prepare. Do not enable on nodes that still run unconstrained full-GPU claims. |
+The Kubernetes column identifies additional Kubernetes version or Kubernetes feature gate requirements beyond the baseline versions in [Prerequisites](../prerequisites.md).
+
+| Feature gate | Stage | Default | Kubernetes | Description |
+| --- | --- | --- | --- | --- |
+| `TimeSlicingSettings` | Alpha | `false` | No requirements. | Enables customization of CUDA time-slicing settings in `GpuConfig`. |
+| `MPSSupport` | Alpha | `false` | No requirements. | Enables Multi-Process Service (MPS) sharing strategy in `GpuConfig` and `MigDeviceConfig`. |
+| `IMEXDaemonsWithDNSNames` | Beta | `true` | No requirements. | IMEX daemons use DNS names instead of raw IP addresses for peer communication. Required by `ComputeDomainCliques`. |
+| `PassthroughSupport` | Alpha | `false` | No requirements. | Enables VFIO passthrough device allocation using `VfioDeviceConfig`. |
+| `DynamicMIG` | Alpha | `false` | v1.34 through v1.35 requires `DRAPartitionableDevices=true` on the kube-apiserver and kube-scheduler.  v1.36 and later enables `DRAPartitionableDevices` by default. See [Kubernetes feature gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#DRAPartitionableDevices). | Enables dynamic MIG device allocation and reconfiguration. See [MIG](../guides/gpu-allocation/mig.md). |
+| `NVMLDeviceHealthCheck` | Alpha | `false` | No requirements. | Enables GPU health checking using NVML. |
+| `ComputeDomainCliques` | Beta | `true` | No requirements. | Uses `ComputeDomainClique` CRD objects to track IMEX daemon membership. Requires `IMEXDaemonsWithDNSNames`. |
+| `CrashOnNVLinkFabricErrors` | Beta | `true` | No requirements. | Causes the kubelet plugin to crash rather than fall back to non-fabric mode when NVLink fabric errors are detected. |
+| `DeviceMetadata` | Alpha | `false` | No requirements. | Enables IOMMU API device exposure, such as `/dev/iommu` or `/dev/vfio/vfio`, for VFIO workloads with `VfioDeviceConfig`. Requires `PassthroughSupport`. |
+| `FabricManagerPartitioning` | Alpha | `false` | No requirements. | Enables Fabric Manager partition discovery and lifecycle management for full GPUs and VFIO devices on supported HGX and single-node NVL systems. VFIO devices require `PassthroughSupport`. Requires Fabric Manager with `FABRIC_MODE=1`. Each full-GPU or VFIO claim on a participating node must exactly match one published partition. See [Fabric Manager partitioning](../guides/gpu-allocation/fabric-manager-partitioning.md). |
+| `HostManagedIMEXDaemon` | Alpha | `false` | No requirements. | Allows `resources.computeDomains.imex.mode=hostManaged`, where you manage the host `nvidia-imex` service instead of the DRA Driver creating per-ComputeDomain daemon DaemonSets. This gate only unlocks the mode. Driver-managed DNS daemon naming and `ComputeDomainClique` tracking are not used in this mode. See [Validate host-managed IMEX](../guides/compute-domain-workloads.md#validate-host-managed-imex). |
+| `DRAListTypeAttributes` | Alpha | `false` | v1.36 or later with `DRAListTypeAttributes=true` on the kube-apiserver and kube-scheduler. | Publishes list-valued DRA device attributes, including `resource.kubernetes.io/numaNode` as a one-element list. See [NUMA locality](resourceslice-attributes.md#numa-locality). |
+| `ConsumableShares` | Alpha | `false` | v1.34 through v1.35 requires `DRAConsumableCapacity=true` on the kube-apiserver, kube-controller-manager, kube-scheduler, and kubelet; v1.36 and later enables `DRAConsumableCapacity` by default; see [Kubernetes consumable capacity](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#consumable-capacity). | Implements Kubernetes DRA consumable capacity for full GPUs and MIG devices by publishing them as multi-allocatable and defining their capacity request policies; also set the [`consumableShares`](helm-values.md#feature-gates) Helm value to select an accounting mode; see [Consumable capacity](../guides/gpu-allocation/consumable-capacity.md). |
 
 ## Constraints
 
 The following feature gate combinations are mutually exclusive and cannot be enabled together.
 
 | Combination | Reason |
-|---|---|
+| --- | --- |
 | `DynamicMIG` + `PassthroughSupport` | Mutually exclusive |
 | `DynamicMIG` + `NVMLDeviceHealthCheck` | Mutually exclusive |
 | `DynamicMIG` + `MPSSupport` | Mutually exclusive |
 | `PassthroughSupport` + `NVMLDeviceHealthCheck` | Mutually exclusive |
-| `MPSSupport` + `NVMLDeviceHealthCheck` | Mutually exclusive |
 
 The feature gates below have the following dependencies:
 
 | Feature gate | Requires |
-|---|---|
+| --- | --- |
 | `ComputeDomainCliques` | `IMEXDaemonsWithDNSNames` |
 | `DeviceMetadata` | `PassthroughSupport` |
-| `DynamicMIG` (Kubernetes 1.34–1.35) | `DRAPartitionableDevices` Kubernetes feature gate enabled on kube-apiserver and kube-scheduler |

--- a/site/content/docs/reference/helm-values.md
+++ b/site/content/docs/reference/helm-values.md
@@ -44,6 +44,17 @@ Disable a plugin you do not need with no impact on the other:
 
 When GPU allocation is enabled, the chart also creates DeviceClass resources for full GPUs, MIG slices, and VFIO passthrough. Individual device types still require the appropriate hardware and [feature gates](feature-gates/).
 
+## ComputeDomain IMEX
+
+| Value | Default | Description |
+|---|---|---|
+| `resources.computeDomains.imex.mode` | `driverManaged` | Selects who manages the `nvidia-imex` daemon lifecycle: `driverManaged` creates a per-ComputeDomain daemon DaemonSet, while `hostManaged` uses a host service that you manage and requires the [`HostManagedIMEXDaemon`](feature-gates.md) feature gate. |
+| `resources.computeDomains.imex.isolation` | `domain` | Selects IMEX isolation, where `domain` shares channel 0 among workloads in the same IMEX domain and `channel` is reserved but unsupported. |
+| `resources.computeDomains.imex.hostSocketPath` | `/etc/nvidia-imex/imex_ctrl.sock` | Sets the path under `nvidiaDriverRoot` to the host IMEX command socket that the ComputeDomain kubelet plugin queries for a `READY` response during claim preparation in `hostManaged` mode. |
+
+Drain ComputeDomain workload pods and delete existing `ComputeDomain` resources before you change `resources.computeDomains.imex.mode` or `resources.computeDomains.imex.isolation`.
+
+
 ## Kubernetes API version
 
 | Value | Default | Description |
@@ -66,14 +77,15 @@ When GPU allocation is enabled, the chart also creates DeviceClass resources for
 |---|---|---|
 | `image.repository` | `registry.k8s.io/dra-driver-nvidia/dra-driver-nvidia-gpu` | Container image repository for all driver components. |
 | `image.tag` | `""` | Image tag. When empty, defaults to the chart `appVersion` with a `v` prefix (for example, `v{{< param driver_version >}}`). |
-| `image.pullPolicy` | `IfNotPresent` | Image pull policy for all containers. |
-| `imagePullSecrets` | `[]` | Secrets for pulling images from private registries. |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy for all driver containers and per-claim MPS daemon containers. |
+| `imagePullSecrets` | `[]` | Secrets for pulling images for driver pods and per-claim MPS daemon pods from private registries. |
 
 ## Feature gates
 
 | Value | Default | Description |
 |---|---|---|
 | `featureGates` | `{}` | Key-value map of feature gate names to `true` or `false`. Passed to all driver components. Includes both driver-specific gates and upstream Kubernetes logging gates. |
+| `consumableShares` | `""` | Selects the NVIDIA driver's capacity-accounting policy for Kubernetes DRA consumable capacity on full GPUs and MIG devices; set it to `memory`, `unlimited`, or a positive integer, while an empty value leaves sharing disabled; requires `featureGates.ConsumableShares=true`; see [Consumable capacity](../guides/gpu-allocation/consumable-capacity.md). |
 
 See [Feature gates](feature-gates/) for available gates, defaults, and mutual-exclusion rules.
 
@@ -138,6 +150,7 @@ Deployed as a DaemonSet on GPU nodes when either resource plugin is enabled.
 | `kubeletPlugin.metrics.computeDomainHttpEndpoint` | `:8081` | Metrics endpoint for the ComputeDomain plugin container. |
 | `kubeletPlugin.containers.gpus.healthcheckPort` | `51516` | gRPC health check port for the GPU container. Set to a negative value to disable. |
 | `kubeletPlugin.containers.computeDomains.healthcheckPort` | `51515` | gRPC health check port for the ComputeDomain container. Set to a negative value to disable. |
+| `kubeletPlugin.containers.computeDomains.gpuCliqueLabelEnabled` | `false` | Lets the ComputeDomain kubelet plugin set the `nvidia.com/gpu.clique` node label when GPU Feature Discovery does not own it. |
 | `kubeletPlugin.networkPolicy.enabled` | `false` | Create a NetworkPolicy for kubelet plugin pods. |
 
 The DaemonSet tolerates `nvidia.com/gpu` taints (`NoSchedule`) and requires nodes to match one of several GPU presence labels (NVIDIA GPU Operator or Node Feature Discovery). GPU and ComputeDomain plugin containers run as privileged by default. An init container prepares plugin directories before the main containers start. Additional `kubeletPlugin.*` values set per-container environment variables, resource limits, and scheduling constraints.

--- a/site/content/docs/reference/resourceslice-attributes.md
+++ b/site/content/docs/reference/resourceslice-attributes.md
@@ -39,6 +39,8 @@ are illustrative — confirm them on your own cluster.
 
 ## Full GPU (type: gpu)
 
+<!-- gpuModuleID with ID, cmd/gpu-kubelet-plugin/deviceinfo.go:236 -->
+
 ```yaml
 - attributes:
     addressingMode:
@@ -53,12 +55,18 @@ are illustrative — confirm them on your own cluster.
       version: 13.0.0              # CUDA driver version
     driverVersion:
       version: 580.126.20          # NVIDIA driver version
+    gpuModuleID:
+      int: 1                        # Fabric Manager GPU module ID, when enabled
+    partition2:
+      int: 4                        # ID of a reported size-2 FM partition
     productName:
       string: NVIDIA A100-PCIE-40GB # product name reported by NVML
     resource.kubernetes.io/pciBusID:
       string: 0000:65:00.0          # PCI bus address in BDF notation, when available
     resource.kubernetes.io/pcieRoot:
       string: pci0000:64            # PCIe root complex identifier, when available
+    resource.kubernetes.io/numaNode:
+      int: 0                         # NUMA node, when available
     type:
       string: gpu                   # device kind: gpu, mig, or vfio
     uuid:
@@ -98,6 +106,8 @@ are illustrative — confirm them on your own cluster.
       string: 0000:65:00.0
     resource.kubernetes.io/pcieRoot:
       string: pci0000:64
+    resource.kubernetes.io/numaNode:
+      int: 0                         # inherited from the parent GPU, when available
     type:
       string: mig                   # device kind
     uuid:
@@ -126,12 +136,22 @@ are illustrative — confirm them on your own cluster.
 - attributes:
     deviceID:
       string: "0x20b0"              # PCI device ID
+    gpuModuleID:
+      int: 1                         # Fabric Manager GPU module ID, when enabled
     iommuFDEnabled:
       bool: true                    # whether the IOMMUFD backend is enabled
-    numa:
-      int: 0                        # NUMA node
+    partition1:
+      int: 8                         # ID of the size-1 Fabric Manager partition
+    partition2:
+      int: 4                         # ID of the size-2 Fabric Manager partition
+    partition4:
+      int: 2                         # ID of the size-4 Fabric Manager partition
+    partition8:
+      int: 1                         # ID of the size-8 Fabric Manager partition
     productName:
       string: NVIDIA A100-PCIE-40GB # product name reported by NVML
+    resource.kubernetes.io/numaNode:
+      int: 0                         # NUMA node, when available
     resource.kubernetes.io/pciBusID:
       string: 0000:65:00.0          # PCI bus address in BDF notation, when available
     resource.kubernetes.io/pcieRoot:
@@ -145,8 +165,145 @@ are illustrative — confirm them on your own cluster.
   capacity:
     addressableMemory:
       value: 40Gi                   # addressable device memory
-  name: gpu-0
+  name: gpu-vfio-0
 ```
+
+## NUMA locality
+
+The GPU kubelet plugin publishes the standard
+`resource.kubernetes.io/numaNode` attribute for full GPUs, MIG devices, and
+VFIO devices when the PCI NUMA node is available and non-negative.
+
+By default, the attribute uses the scalar `int` form shown in the examples.
+When you enable both the driver and Kubernetes `DRAListTypeAttributes` feature
+gates, the ResourceSlice serialization changes to a one-element `ints` list:
+
+```yaml
+resource.kubernetes.io/numaNode:
+  ints:
+  - 0
+```
+
+This representation change matters when inspecting or parsing ResourceSlices,
+but it does not change the attribute name that you specify in ResourceClaims,
+like the following example:
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: same-numa-gpus
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpus
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: 2
+      constraints:
+      - requests:
+        - gpus
+        matchAttribute: resource.kubernetes.io/numaNode
+```
+
+This constraint requires all devices selected for `gpus` to have the same
+published NUMA value. It uses the same
+`resource.kubernetes.io/numaNode` spelling for both the scalar `int` and
+one-element `ints` representations.
+
+### Troubleshooting: verify the NUMA value
+
+List each GPU device with its node, PCI bus ID, and published NUMA value:
+
+```bash
+kubectl get resourceslices -o json | jq -r '
+  (
+    ["NODE", "DEVICE", "PCI_BUS_ID", "PUBLISHED_NUMA"],
+    (
+      .items[]
+      | select(.spec.driver == "gpu.nvidia.com")
+      | .spec.nodeName as $node
+      | .spec.devices[]
+      | .basic.attributes as $attrs
+      | select($attrs["resource.kubernetes.io/pciBusID"] != null)
+      | ($attrs["resource.kubernetes.io/numaNode"] // {}) as $numa
+      | [
+          $node,
+          .name,
+          $attrs["resource.kubernetes.io/pciBusID"].string,
+          (
+            if $numa.int != null then ($numa.int | tostring)
+            elif $numa.ints != null then ($numa.ints | join(","))
+            else "omitted"
+            end
+          )
+        ]
+    )
+  )
+  | @tsv'
+```
+
+For one row, use its `NODE` and `PCI_BUS_ID` values to read the host PCI
+device's NUMA node:
+
+```bash
+NODE=<node-from-output>
+BDF=<pci-bus-id-from-output>
+
+kubectl debug "node/${NODE}" -it --image=ubuntu -- chroot /host \
+  cat "/sys/bus/pci/devices/${BDF}/numa_node"
+```
+
+A non-negative host value must match `PUBLISHED_NUMA`. MIG devices report the
+locality of their parent GPU and therefore use the parent's PCI bus ID. If the
+host reports `-1`, the PCI device has no NUMA locality, or discovery is
+otherwise unavailable, the GPU kubelet plugin omits
+`resource.kubernetes.io/numaNode`; it does not publish `-1`.
+
+## Fabric Manager partition attributes
+
+When you enable `FabricManagerPartitioning`, the GPU kubelet plugin publishes
+Fabric Manager attributes on full-GPU and VFIO devices when Fabric Manager
+reports the corresponding data.
+MIG devices do not receive these attributes.
+
+| Attribute | Meaning |
+|---|---|
+| `gpuModuleID` | Physical GPU module identifier reported by NVML and used by Fabric Manager. |
+| `partitionN` | Fabric Manager partition ID for the N-GPU partition that contains this GPU; for example, `partition2` identifies a reported two-GPU partition. |
+
+The GPU kubelet plugin emits each `partitionN` attribute only when Fabric
+Manager reports a partition of that size containing the GPU.
+The attribute name uses the exact spelling `gpuModuleID`, including the
+uppercase `ID`.
+
+To request two full GPUs or VFIO GPUs from the same two-GPU Fabric Manager
+partition, set the request count to `2` and add this constraint to the same
+claim:
+
+```yaml
+constraints:
+- requests:
+  - gpus
+  matchAttribute: gpu.nvidia.com/partition2
+```
+
+You can also use a CEL selector for a known node-local module identifier:
+
+```text
+device.attributes['gpu.nvidia.com'].gpuModuleID == 1
+```
+
+Partition IDs and module IDs describe the local Fabric Manager topology, so use
+a `matchAttribute` constraint when you need portable co-placement instead of
+selecting a hardcoded partition ID.
+The allocated physical-GPU set must exactly match the reported partition when
+the driver prepares the claim.
+Refer to
+[Fabric Manager partitioning](../guides/gpu-allocation/fabric-manager-partitioning.md)
+for prerequisites and complete full-GPU and VFIO examples.
 
 ## Attribute naming: bare keys vs CEL domain
 
@@ -155,7 +312,8 @@ driver attributes appear as **bare keys** (`type`, `productName`, and so on)
 because their domain is implied by the driver name. In a **CEL selector**, you
 address them through that domain, `device.attributes['gpu.nvidia.com'].type`. The
 standardized PCI attributes are the exception: they are stored fully qualified as
-`resource.kubernetes.io/pciBusID` and `resource.kubernetes.io/pcieRoot`.
+`resource.kubernetes.io/pciBusID`, `resource.kubernetes.io/pcieRoot`, and
+`resource.kubernetes.io/numaNode`.
 
 In selectors, attributes are read with
 `device.attributes['gpu.nvidia.com'].<name>` and capacity with

--- a/site/content/docs/upgrade.md
+++ b/site/content/docs/upgrade.md
@@ -9,6 +9,43 @@ This page covers upgrading the DRA Driver for NVIDIA GPUs between releases.
 
 ---
 
+## Upgrade from v0.4.1 to v0.5.0
+
+For the full release summary, see the [{{< param driver_release_tag >}} release notes](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/releases/tag/{{< param driver_release_tag >}}).
+
+Upgrade the Helm release and reuse the values from the existing installation:
+
+```bash
+helm upgrade -i nvidia-dra-driver-gpu oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu \
+    --version {{< param "driver_version" >}} \
+    --namespace nvidia-dra-driver-gpu \
+    --reuse-values
+```
+
+Add any value changes that you want to make to the command.
+If you manage values in a file, pass that file with `--values` instead of using `--reuse-values`.
+The default configuration in {{< param driver_release_tag >}} does not require a data or API migration.
+If you already used `nameOverride` or upgraded the release to v0.4.0 or later, you do not need to add `nameOverride` for this upgrade.
+The per-claim MPS daemon inherits the existing `image.pullPolicy` and `imagePullSecrets` values, so existing MPS installations do not require an image configuration change.
+
+{{% alert color="warning" title="Warning" %}}
+If you change `resources.computeDomains.imex.mode` or `.isolation` as part of this upgrade, first drain ComputeDomain workloads and delete existing ComputeDomain resources.
+The DRA Driver does not enforce a safe transition while ComputeDomain workloads are active.
+{{% /alert %}}
+
+After the upgrade, verify the Helm release, driver pods, DeviceClasses, and node ResourceSlices:
+
+```bash
+helm status nvidia-dra-driver-gpu -n nvidia-dra-driver-gpu
+kubectl get pods -n nvidia-dra-driver-gpu
+kubectl get deviceclasses
+kubectl get resourceslices
+```
+
+Confirm that every driver pod reports `Running` and `Ready`, and that the expected DeviceClasses and node ResourceSlices remain available.
+
+---
+
 ## Upgrade from v0.4.0 to v0.4.1
 
 For the full release summary, see the [v0.4.1 release notes](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/releases/tag/v0.4.1).

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -55,8 +55,8 @@ enableGitInfo = true
 # Site-wide parameters
 [params]
   # Latest published release. Update both when cutting a new release.
-  driver_version = "0.4.1"       # Helm chart version (no "v" prefix; used with --version)
-  driver_release_tag = "v0.4.1"  # GitHub release tag (used for source links)
+  driver_version = "0.5.0"       # Helm chart version (no "v" prefix; used with --version)
+  driver_release_tag = "v0.5.0"  # GitHub release tag (used for source links)
   github_repo = "https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu"
   github_branch = "main"
   github_subdir = "site"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Continues the docs effort for 0.5.0.

- Unrelated, I think, but I added back the [MPS page](https://deploy-preview-1281--dra-driver-nvidia-gpu.netlify.app/docs/guides/mps/) from upstream/main.
- [Fabric Manager partitioning](https://deploy-preview-1281--dra-driver-nvidia-gpu.netlify.app/docs/guides/gpu-allocation/fabric-manager-partitioning/) is added to the TOC and touched up a bit.
- Smallish updates to the resource slice attrs for [NUMA locality](https://deploy-preview-1281--dra-driver-nvidia-gpu.netlify.app/docs/reference/resourceslice-attributes/#numa-locality).
- Updates for host-managed IMEX daemon to the [compute domain concepts](https://deploy-preview-1281--dra-driver-nvidia-gpu.netlify.app/docs/concepts/compute-domains/#imex-lifecycle-modes) and using [compute domain workloads](https://deploy-preview-1281--dra-driver-nvidia-gpu.netlify.app/docs/guides/compute-domain-workloads/).

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
