### PR TITLE
Add support for configuring go proxy for image build

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -32,6 +32,10 @@ ARG GOMODCACHE
 ARG GOPROXY="https://proxy.golang.org,direct"
 ENV GOPROXY=$GOPROXY
 
+# Go module mode for builds: "vendor" (offline, default) or "mod" (download via GOPROXY).
+# Override at build time: --build-arg GO_MOD=mod when using deployments/container/Makefile
+ARG GO_MOD=vendor
+
 # BUILDARCH, TARGETARCH (and others) are defined in the global scope by
 # BuiltKit. BUILDARCH is the architecture of the build platform. TARGETARCH is
 # set via the --platform arg provided to the `docker buildx build ...` command.
@@ -66,7 +70,7 @@ COPY --parents pkg api internal vendor ./
 RUN --mount=type=cache,target=/mc/go/build-cache,id=gocache \
     --mount=type=cache,target=/mc/go/pkg/mod,id=gomodcache \
     case "$TARGETARCH" in "$BUILDARCH") cc=gcc;; arm64) cc=aarch64-linux-gnu-gcc;; amd64) cc=x86_64-linux-gnu-gcc;; esac && \
-    CC=${cc} CGO_ENABLED=1 GOARCH=${TARGETARCH} time go build -mod=vendor ./...
+    CC=${cc} CGO_ENABLED=1 GOARCH=${TARGETARCH} time go build -mod=${GO_MOD} ./...
 
 # Copy everything else (and only) what is required for the Go build ('Explicit
 # include' philosophy). Goal: invalidate layer only when absolutely required.
@@ -87,7 +91,7 @@ RUN mkdir /artifacts
 RUN --mount=type=cache,target=/mc/go/build-cache,id=gocache \
     --mount=type=cache,target=/mc/go/pkg/mod,id=gomodcache \
     case "$TARGETARCH" in "$BUILDARCH") cc=gcc;; arm64) cc=aarch64-linux-gnu-gcc;; amd64) cc=x86_64-linux-gnu-gcc;; esac && \
-    time make CC=${cc} GOARCH=${TARGETARCH} PREFIX=/artifacts cmds
+    time make CC=${cc} GOARCH=${TARGETARCH} GO_MOD=${GO_MOD} PREFIX=/artifacts cmds
 
 # Static bash binary, sourced from the Debian 'bash-static' package on
 # trixie. Replaces a from-source build that was flaky in CI (autoconf

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -29,6 +29,9 @@ ARG GOLANG_VERSION=x.x.x
 ARG GOCACHE
 ARG GOMODCACHE
 
+ARG GOPROXY="https://proxy.golang.org,direct"
+ENV GOPROXY=$GOPROXY
+
 # BUILDARCH, TARGETARCH (and others) are defined in the global scope by
 # BuiltKit. BUILDARCH is the architecture of the build platform. TARGETARCH is
 # set via the --platform arg provided to the `docker buildx build ...` command.

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -85,6 +85,8 @@ ifeq ($(CI), true)
 	GOMODCACHE=/go/pkg/mod
 endif
 
+GOPROXY ?= https://proxy.golang.org,direct
+
 build:
 	mkdir -p $(DIST_DIR)
 	DOCKER_BUILDKIT=1 \
@@ -98,6 +100,7 @@ build:
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
 		--build-arg GOCACHE="$(GOCACHE)" \
 		--build-arg GOMODCACHE="$(GOMODCACHE)" \
+		--build-arg GOPROXY="$(GOPROXY)" \
 		--progress=plain \
 		-f $(DOCKERFILE) \
 		$(CURDIR)

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -86,6 +86,8 @@ ifeq ($(CI), true)
 endif
 
 GOPROXY ?= https://proxy.golang.org,direct
+# Go module mode passed to the Dockerfile as -mod=<value>. vendor (default) or mod.
+GO_MOD ?= vendor
 
 build:
 	mkdir -p $(DIST_DIR)
@@ -101,6 +103,7 @@ build:
 		--build-arg GOCACHE="$(GOCACHE)" \
 		--build-arg GOMODCACHE="$(GOMODCACHE)" \
 		--build-arg GOPROXY="$(GOPROXY)" \
+		--build-arg GO_MOD="$(GO_MOD)" \
 		--progress=plain \
 		-f $(DOCKERFILE) \
 		$(CURDIR)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
Adds supports to set GOPROXY env var for go build
#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note

```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
