### PR TITLE
Don't fail on incomplete fabric registration on non-MNNVL node

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/nvlib.go
+++ b/cmd/compute-domain-kubelet-plugin/nvlib.go
@@ -33,6 +33,7 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"sigs.k8s.io/dra-driver-nvidia-gpu/internal/common"
+	fm "sigs.k8s.io/dra-driver-nvidia-gpu/pkg/fabricmanager"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 )
 
@@ -44,12 +45,13 @@ const (
 
 type deviceLib struct {
 	nvdev.Interface
-	nvmllib               nvml.Interface
-	driverLibraryPath     string
-	devRoot               string
-	nvidiaSMIPath         string
-	maxImexChannelCount   int
-	nvCapImexChanDevInfos []*common.NVcapDeviceInfo
+	nvmllib                  nvml.Interface
+	driverLibraryPath        string
+	devRoot                  string
+	nvidiaSMIPath            string
+	maxImexChannelCount      int
+	nvCapImexChanDevInfos    []*common.NVcapDeviceInfo
+	isSingleNodeNVLinkSystem bool
 }
 
 func newDeviceLib(driverRoot root) (*deviceLib, error) {
@@ -102,6 +104,13 @@ func newDeviceLib(driverRoot root) (*deviceLib, error) {
 		}
 	}
 
+	if featuregates.Enabled(featuregates.FabricManagerPartitioning) {
+		isSingleNodeNVLinkSystem, err := d.checkIsSingleNodeNVLinkSystem()
+		if err != nil {
+			return nil, fmt.Errorf("error checking if node is single-node NVLink system: %w", err)
+		}
+		d.isSingleNodeNVLinkSystem = isSingleNodeNVLinkSystem
+	}
 	return &d, nil
 }
 
@@ -308,6 +317,14 @@ func (l deviceLib) getCliqueIDStrict() (string, error) {
 
 		// NVLink fabric is supported - check if registration completed
 		if info.State != nvml.GPU_FABRIC_STATE_COMPLETED {
+			// Ignore pending NVLink registration on single-node NVLink systems.
+			// In FabricManager multi-tenancy mode, the GPUs may not be registered until a
+			// partition they belong to is activated. We are blanket ignoring this state as
+			// we can't yet differentiate between real NVLink failures and this scenario.
+			if featuregates.Enabled(featuregates.FabricManagerPartitioning) && l.isSingleNodeNVLinkSystem {
+				klog.Infof("no-clique fallback: ignoring incomplete NVLink registration (device=%d/%s, state=%d) on single-node NVLink system", i, duid, info.State)
+				return nil
+			}
 			return fmt.Errorf("NVLink fabric not attached (device %d/%s): state=%d, refusing to start", i, duid, info.State)
 		}
 
@@ -459,4 +476,19 @@ func (l deviceLib) unmountRecursively(root string) error {
 	}
 
 	return helper(root)
+}
+
+// isSingleNodeNVLinkSystem returns true if the node is a single-node NVLink
+// system with one or more NVSwitch (or newer NVLink5 switch) devices.
+func (l deviceLib) checkIsSingleNodeNVLinkSystem() (bool, error) {
+	hasLocalFabric, err := fm.HasFabricManagerFabric(l.devRoot)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if node has local fabric: %w", err)
+	}
+
+	if !hasLocalFabric {
+		return false, nil
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
When running on nodes with a local FabricManager service in the multi-tenancy mode (`FABRIC_MODE=1`), GPU fabric resgistrations will remain in `In Progress` state until fabric partition activation occurs. The compute-domain plugin will not be able to fetch the `cliqueID` at this time and would crash when `CrashOnNVLinkFabricErrors` FG (default: `true`) is enabled.

This change addresses this compute-domain plugin startup failure.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Fixes #1264 

#### Special notes for your reviewer:
Verified on non-fabric and non-MNNVL fabric nodes.

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
