### PR TITLE
fix(ci): correct the expected gb200 product name in mock NVML checks

### DIFF
--- a/hack/ci/mock-nvml/common.sh
+++ b/hack/ci/mock-nvml/common.sh
@@ -39,7 +39,7 @@ mock_nvml_expected_name() {
     a100)  echo "NVIDIA A100-SXM4-40GB" ;;
     h100)  echo "NVIDIA H100 80GB HBM3" ;;
     b200)  echo "NVIDIA B200" ;;
-    gb200) echo "NVIDIA GB200 NVL" ;;
+    gb200) echo "NVIDIA GB200" ;;
     l40s)  echo "NVIDIA L40S" ;;
     t4)    echo "NVIDIA T4" ;;
     *)     echo "UNKNOWN" ;;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`hack/ci/mock-nvml/common.sh` hardcodes the GPU product name each mock profile is expected to report, and `verify-mock-gpu.sh` asserts on it at two layers. The `gb200` entry says `NVIDIA GB200 NVL`, but the nvml-mock profile it mirrors was renamed upstream in `NVIDIA/k8s-test-infra` and now reports plain `NVIDIA GB200`.

Nothing is broken today, because `.github/workflows/mock-nvml-e2e.yaml` still pins k8s-test-infra at `1275802b` (v0.2.1), which predates the rename. The breakage lands the moment anyone advances that pin — `gb200` is both the workflow's profile and `common.sh`'s default, so it is the path everyone hits first.

Measured against the published mock, holding the binary constant and varying only the profile config:

| profile config | `nvidia-smi -L` reports |
|---|---|
| v0.2.1 (`1275802b`, the current pin) | `NVIDIA GB200 NVL` |
| v0.3.0 | `NVIDIA GB200` |

Checked all six profiles in the table against the v0.3.0 configs; `gb200` is the only one that drifted. `a100`, `h100`, `b200`, `l40s` and `t4` all still agree.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

**This is safe to merge ahead of any pin bump.** `check_output` in `verify-mock-gpu.sh:60` matches with `grep -qF`, i.e. a substring, so the corrected value passes against *both* profile versions:

| expected value | vs v0.2.1 config (current pin) | vs v0.3.0 config |
|---|---|---|
| `NVIDIA GB200 NVL` (before) | match | **no match** |
| `NVIDIA GB200` (after) | match | match |

I ran both assertions rather than reasoning about them, against the exact config the workflow installs (v0.2.1 profile plus the `driver_version` / `nvml_version` / `num_devices` patches from `setup-mock-gpu.sh`), on `linux/amd64` to match `ubuntu-latest`:

- Layer 2 (`config has correct GPU name`) — passes
- Layer 5 (`nvidia-smi shows correct GPU name`) — passes; `nvidia-smi` reports `NVIDIA GB200 NVL`, 8 GPUs, driver `570.170.01`

Blast radius is two assertions, `verify-mock-gpu.sh:140` and `:183`. The bats suite references `productName` only as a ResourceSlice attribute key, never as a literal value — the sole exception is the deliberate non-match in `tests/bats/specs/gpu-cel-nomatch.yaml`.

One consequence worth naming: because the match is a substring, this change makes the assertion *less* strict in the window before the pin moves — `NVIDIA GB200` matches the old name too, so a green run here does not by itself prove the mock's product name is correct. A follow-up that compares the table against the pinned profile configs directly would restore that, and I am happy to send it separately if you would like it.

On the checklist below: this touches one line of shell in `hack/ci/`, so `make check test` is not the relevant gate and I have not ticked it. The two assertions this line feeds are what I verified, as described above.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

```docs

```

#### Checklist

- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
