### PR TITLE
demo/kind: resolve image tag from VERSION file, not versions.mk

### DIFF
--- a/demo/clusters/kind/scripts/common.sh
+++ b/demo/clusters/kind/scripts/common.sh
@@ -26,7 +26,9 @@ function from_versions_mk() {
 }
 DRIVER_NAME=$(from_versions_mk "DRIVER_NAME")
 DRIVER_IMAGE_REGISTRY=$(from_versions_mk "REGISTRY")
-DRIVER_IMAGE_VERSION=$(from_versions_mk "VERSION")
+# VERSION in versions.mk is a `$(shell ...)` expression, not a literal;
+# read the VERSION file directly, as the Makefile does.
+DRIVER_IMAGE_VERSION=$(tr -d '[:space:]' < "${PROJECT_DIR}/VERSION")
 
 : ${DRIVER_IMAGE_NAME:=${DRIVER_NAME}}
 # TODO: update to the latest tag once we remove the ubi tag suffix


### PR DESCRIPTION
**What**: `demo/kind` resolves `DRIVER_IMAGE_VERSION` by reading the `VERSION` file directly instead of grepping the unexpanded `$(shell …)` value of `VERSION` out of `versions.mk`.

**Why**: `VERSION` in `versions.mk` is `$(shell tr -d '[:space:]' < $(CURDIR)/VERSION)`, not a literal, so `from_versions_mk "VERSION"` returns that make expression verbatim. The derived reference becomes `…/dra-driver-nvidia-gpu:$(shell tr -d '[:space:]' < $(CURDIR)/VERSION)`, which is not a valid image reference. This breaks image detection and loading in `./demo/clusters/kind`:
- `create-cluster.sh` looks up an existing image with `docker images --filter "reference=${DRIVER_IMAGE}" -q`, which silently returns empty for the malformed reference, so an already-built image is not detected;
- `load-driver-image-into-kind.sh` passes the malformed reference to `kind load docker-image`, preventing the intended image from being loaded.

`DRIVER_NAME` and `REGISTRY` are plain literals in `versions.mk` and keep using `from_versions_mk`.

**Testing** (CPU-only, no GPU/cluster):
- Sourcing `demo/clusters/kind/scripts/common.sh` at `main` yields `DRIVER_IMAGE=…:$(shell tr -d '[:space:]' < $(CURDIR)/VERSION)`; with the fix it yields `…:v0.5.0-dev`.
- Consumer-level: with a matching image present locally, `docker images --filter "reference=${DRIVER_IMAGE}" -q` returns empty at baseline vs. the image id after the fix.
- Env-var override (`DRIVER_IMAGE_TAG=…`) still honored; `bash -n` clean.
