### PR TITLE
Make vfio device preparation robust

### DIFF
--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -52,6 +52,8 @@ type VfioPciManager struct {
 	hostDriverRoot      string
 	nvlib               *deviceLib
 	nvidiaEnabled       bool
+
+	inflightDriverSwitches map[string]struct{}
 }
 
 func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib *deviceLib, nvidiaEnabled bool) (*VfioPciManager, error) {
@@ -64,13 +66,85 @@ func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib 
 	}
 
 	vm := &VfioPciManager{
-		containerDriverRoot: containerDriverRoot,
-		hostDriverRoot:      hostDriverRoot,
-		nvlib:               nvlib,
-		nvidiaEnabled:       nvidiaEnabled,
+		containerDriverRoot:    containerDriverRoot,
+		hostDriverRoot:         hostDriverRoot,
+		nvlib:                  nvlib,
+		nvidiaEnabled:          nvidiaEnabled,
+		inflightDriverSwitches: make(map[string]struct{}),
 	}
 
 	return vm, nil
+}
+
+// Configure binds the GPU to the vfio-pci driver.
+func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) error {
+	if loaded, err := vm.checkKernelModuleLoaded(info.vfioModule); err == nil {
+		if !loaded {
+			err = vm.loadKernelModule(info.vfioModule)
+			if err != nil {
+				return fmt.Errorf("failed to load module %q: %w", info.vfioModule, err)
+			}
+		}
+	} else {
+		return fmt.Errorf("error checking if module %q is loaded: %w", info.vfioModule, err)
+	}
+
+	// If we were already in the middle of changing drivers, then don't proceed.
+	if vm.isDriverSwitchInflight(info.PciBusID) {
+		return fmt.Errorf("a driver switch is inflight for GPU %q, please check the kernel logs for more details", info.PciBusID)
+	}
+
+	vfioDriver, err := getVfioDriverName(info.vfioModule)
+	if err != nil {
+		return fmt.Errorf("error getting vfio driver for GPU %q: %w", info.PciBusID, err)
+	}
+
+	driver, err := getDriver(pciDevicesPath, info.PciBusID)
+	if err != nil {
+		return fmt.Errorf("error getting driver details for GPU %q: %w", info.PciBusID, err)
+	}
+
+	// Skip if the GPU is already bound to the vfio-pci (or variant) driver.
+	if driver == vfioDriver {
+		return nil
+	}
+
+	// Only support vfio-pci (or variant) or nvidia (if vm.nvidiaEnabled) driver.
+	if vm.nvidiaEnabled {
+		// The driver may be empty if a previous driver change operation got aborted
+		// before completion. changeDriver() is idempotent and handles this scenario.
+		if driver != "" && driver != nvidiaDriver {
+			return fmt.Errorf("GPU %q is bound to %q driver, expected %q or %q", info.PciBusID, driver, vfioDriver, nvidiaDriver)
+		}
+	}
+
+	// Verify SRIOV VFs are disabled on the GPU.
+	err = vm.verifyDisabledVFs(info.PciBusID)
+	if err != nil {
+		return fmt.Errorf("error verifying disabled VFs: %w", err)
+	}
+
+	if driver == nvidiaDriver {
+		// Disable GPU Persistence Mode.
+		err = vm.disableGPUPersistenceMode(info.PciBusID)
+		if err != nil {
+			return fmt.Errorf("error disabling persistence mode for GPU %q: %w", info.PciBusID, err)
+		}
+
+		// Wait for other GPU clients to evacuate.
+		err = vm.WaitForGPUFree(ctx, info)
+		if err != nil {
+			return fmt.Errorf("error waiting for GPU %q to be free: %w", info.PciBusID, err)
+		}
+	}
+
+	// Change the GPU driver to vfio-pci (or variant).
+	err = vm.changeDriver(info.PciBusID, vfioDriver)
+	if err != nil {
+		return fmt.Errorf("error changing driver for GPU %q: %w", info.PciBusID, err)
+	}
+
+	return nil
 }
 
 // WaitForGPUFree does a best effort scan of the GPU clients running on the host and
@@ -114,82 +188,23 @@ func (vm *VfioPciManager) WaitForGPUFree(ctx context.Context, info *VfioDeviceIn
 	}
 }
 
-// Verify there are no VFs on the GPU.
-func (vm *VfioPciManager) verifyDisabledVFs(pciBusID string) error {
-	gpu, err := vm.nvlib.nvpci.GetGPUByPciBusID(pciBusID)
-	if err != nil {
-		return err
-	}
-	if gpu == nil {
-		return fmt.Errorf("no GPU found at PCI bus ID %q", pciBusID)
-	}
-	// PhysicalFunction is nil for GPUs that do not support SR-IOV (e.g. T400).
-	// A nil PhysicalFunction means no VFs can exist, so it is safe to proceed.
-	if gpu.SriovInfo.PhysicalFunction == nil {
-		return nil
-	}
-	numVFs := gpu.SriovInfo.PhysicalFunction.NumVFs
-	if numVFs > 0 {
-		return fmt.Errorf("gpu has %d VFs, cannot unbind", numVFs)
-	}
-	return nil
-}
-
-// Configure binds the GPU to the vfio-pci driver.
-func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) error {
-	if loaded, err := vm.checkKernelModuleLoaded(info.vfioModule); err == nil {
-		if !loaded {
-			err = vm.loadKernelModule(info.vfioModule)
-			if err != nil {
-				return fmt.Errorf("failed to load module %q: %w", info.vfioModule, err)
-			}
-		}
-	} else {
-		return fmt.Errorf("error checking if module %q is loaded: %w", info.vfioModule, err)
-	}
-
-	vfioDriver, err := getVfioDriverName(info.vfioModule)
-	if err != nil {
-		return fmt.Errorf("error getting vfio driver for GPU %q: %w", info.PciBusID, err)
-	}
-
-	driver, err := getDriver(pciDevicesPath, info.PciBusID)
-	if err != nil {
-		return fmt.Errorf("error getting driver details for GPU %q: %w", info.PciBusID, err)
-	}
-
-	// Skip if the GPU is already bound to the vfio-pci driver.
-	if driver == vfioDriver {
+// Unconfigure binds the GPU to the nvidia driver.
+func (vm *VfioPciManager) Unconfigure(ctx context.Context, info *VfioDeviceInfo) error {
+	// Do nothing if we dont expect to switch to nvidia driver.
+	if !vm.nvidiaEnabled {
 		return nil
 	}
 
-	// Only support vfio-pci (or variant) or nvidia (if vm.nvidiaEnabled) driver.
-	if !vm.nvidiaEnabled || driver != nvidiaDriver {
-		return fmt.Errorf("GPU %q is bound to %q driver, expected %q or %q", info.PciBusID, driver, vfioDriver, nvidiaDriver)
-	}
-
-	// Disable GPU Persistence Mode.
-	err = vm.disableGPUPersistenceMode(info.PciBusID)
-	if err != nil {
-		return fmt.Errorf("error disabling persistence mode for GPU %q: %w", info.PciBusID, err)
-	}
-
-	// Wait for other GPU clients to evacuate.
-	err = vm.WaitForGPUFree(ctx, info)
-	if err != nil {
-		return fmt.Errorf("error waiting for GPU %q to be free: %w", info.PciBusID, err)
-	}
-
-	// Verify SRIOV VFs are disabled on the GPU.
-	err = vm.verifyDisabledVFs(info.PciBusID)
-	if err != nil {
-		return fmt.Errorf("error verifying disabled VFs: %w", err)
-	}
-
-	// Change the GPU driver to vfio-pci (or variant).
-	err = vm.changeDriver(info.PciBusID, vfioDriver)
+	// Change the GPU driver to nvidia.
+	err := vm.changeDriver(info.PciBusID, nvidiaDriver)
 	if err != nil {
 		return fmt.Errorf("error changing driver for GPU %q: %w", info.PciBusID, err)
+	}
+
+	// Enable GPU Persistence Mode.
+	err = vm.enableGPUPersistenceMode(info.PciBusID)
+	if err != nil {
+		return fmt.Errorf("error enabling persistence mode for GPU %q: %w", info.PciBusID, err)
 	}
 
 	return nil
@@ -228,32 +243,13 @@ func getVfioDriverName(vfioModule string) (string, error) {
 	return vfioDriver, nil
 }
 
-// Unconfigure binds the GPU to the nvidia driver.
-func (vm *VfioPciManager) Unconfigure(ctx context.Context, info *VfioDeviceInfo) error {
-	// Do nothing if we dont expect to switch to nvidia driver.
-	if !vm.nvidiaEnabled {
-		return nil
-	}
-
-	// Change the GPU driver to nvidia.
-	err := vm.changeDriver(info.PciBusID, nvidiaDriver)
-	if err != nil {
-		return fmt.Errorf("error changing driver for GPU %q: %w", info.PciBusID, err)
-	}
-
-	// Enable GPU Persistence Mode.
-	err = vm.enableGPUPersistenceMode(info.PciBusID)
-	if err != nil {
-		return fmt.Errorf("error enabling persistence mode for GPU %q: %w", info.PciBusID, err)
-	}
-
-	return nil
-}
-
 // Get the current driver the GPU is bound to.
 func getDriver(pciDevicesPath, pciAddress string) (string, error) {
 	driverPath, err := os.Readlink(filepath.Join(pciDevicesPath, pciAddress, "driver"))
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
 		return "", err
 	}
 	_, driver := filepath.Split(driverPath)
@@ -261,7 +257,19 @@ func getDriver(pciDevicesPath, pciAddress string) (string, error) {
 }
 
 // Change the driver the GPU is bound to.
+//
+// Here, we keep track of inflight driver switches so that we don't attempt to
+// switch the driver again while a previous driver switch for a GPU is in progress.
+// A previous driver switch if stuck for some reason is expected to be stalled
+// in the kernel and hence we error out early without reattempting it. The
+// goroutine responsible for this stuck operation will also block any attempt to
+// terminate the plugin process. Once the goroutine is freed up, we're safe to
+// reattempt the driver switch.
 func (vm *VfioPciManager) changeDriver(pciAddress, driver string) error {
+	if vm.isDriverSwitchInflight(pciAddress) {
+		return fmt.Errorf("an existing driver switch for GPU %q is inflight, please check the kernel logs for more details", pciAddress)
+	}
+
 	currentDriver, err := getDriver(pciDevicesPath, pciAddress)
 	if err != nil {
 		return fmt.Errorf("error getting driver details for GPU %q: %w", pciAddress, err)
@@ -272,14 +280,68 @@ func (vm *VfioPciManager) changeDriver(pciAddress, driver string) error {
 		return nil
 	}
 
-	err = vm.nvlib.nvpasst.Unbind(pciAddress)
-	if err != nil {
-		return fmt.Errorf("error unbinding GPU %q from driver %q: %w", pciAddress, currentDriver, err)
+	// Mark the driver switch as inflight.
+	vm.markDriverSwitchInflight(pciAddress)
+	defer vm.unmarkDriverSwitchInflight(pciAddress)
+
+	if currentDriver != "" {
+		err := vm.nvlib.nvpasst.Unbind(pciAddress)
+		if err != nil {
+			return fmt.Errorf("error unbinding GPU %q from driver %q: %w", pciAddress, currentDriver, err)
+		}
 	}
 
 	err = vm.nvlib.nvpasst.BindToDriver(pciAddress, driver)
 	if err != nil {
 		return fmt.Errorf("error binding GPU %q to driver %q: %w", pciAddress, driver, err)
+	}
+	return nil
+}
+
+// Check if a driver switch is inflight for the given PCI address.
+func (vm *VfioPciManager) isDriverSwitchInflight(pciAddress string) bool {
+	vm.Lock()
+	defer vm.Unlock()
+	_, exists := vm.inflightDriverSwitches[pciAddress]
+	return exists
+}
+
+// Mark a driver switch as inflight for the given PCI address.
+func (vm *VfioPciManager) markDriverSwitchInflight(pciAddress string) error {
+	vm.Lock()
+	defer vm.Unlock()
+	if _, ok := vm.inflightDriverSwitches[pciAddress]; ok {
+		return fmt.Errorf("an existing driver switch for GPU %q is inflight, please check the kernel logs for more details", pciAddress)
+	}
+
+	vm.inflightDriverSwitches[pciAddress] = struct{}{}
+	return nil
+}
+
+// Unmark inflight driver switch for the given PCI address.
+func (vm *VfioPciManager) unmarkDriverSwitchInflight(pciAddress string) {
+	vm.Lock()
+	defer vm.Unlock()
+	delete(vm.inflightDriverSwitches, pciAddress)
+}
+
+// Verify there are no VFs on the GPU.
+func (vm *VfioPciManager) verifyDisabledVFs(pciBusID string) error {
+	gpu, err := vm.nvlib.nvpci.GetGPUByPciBusID(pciBusID)
+	if err != nil {
+		return err
+	}
+	if gpu == nil {
+		return fmt.Errorf("no GPU found at PCI bus ID %q", pciBusID)
+	}
+	// PhysicalFunction is nil for GPUs that do not support SR-IOV (e.g. T400).
+	// A nil PhysicalFunction means no VFs can exist, so it is safe to proceed.
+	if gpu.SriovInfo.PhysicalFunction == nil {
+		return nil
+	}
+	numVFs := gpu.SriovInfo.PhysicalFunction.NumVFs
+	if numVFs > 0 {
+		return fmt.Errorf("gpu has %d VFs, cannot unbind", numVFs)
 	}
 	return nil
 }

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -82,15 +82,15 @@ func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib 
 
 // Configure binds the GPU to the vfio-pci driver.
 func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) error {
-	if loaded, err := vm.checkKernelModuleLoaded(info.vfioModule); err == nil {
-		if !loaded {
-			err = vm.loadKernelModule(info.vfioModule)
-			if err != nil {
-				return fmt.Errorf("failed to load module %q: %w", info.vfioModule, err)
-			}
-		}
-	} else {
+	loaded, err := vm.checkKernelModuleLoaded(info.vfioModule)
+	if err != nil {
 		return fmt.Errorf("error checking if module %q is loaded: %w", info.vfioModule, err)
+	}
+	if !loaded {
+		err := vm.loadKernelModule(info.vfioModule)
+		if err != nil {
+			return fmt.Errorf("failed to load module %q: %w", info.vfioModule, err)
+		}
 	}
 
 	// If we were already in the middle of changing drivers, then don't proceed.

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -44,6 +44,10 @@ const (
 	nvidiaPersistencedSocketPath = "/run/nvidia-persistenced/socket"
 	gpuFreeCheckInterval         = 1 * time.Second
 	gpuFreeCheckTimeout          = 60 * time.Second
+	// Keep driverChangeTimeout short to avoid blocking the plugin process
+	// for too long from serving other device preparation/unpreparation
+	// requests.
+	driverChangeTimeout = 15 * time.Second
 )
 
 type VfioPciManager struct {
@@ -139,7 +143,14 @@ func (vm *VfioPciManager) Configure(ctx context.Context, info *VfioDeviceInfo) e
 	}
 
 	// Change the GPU driver to vfio-pci (or variant).
-	err = vm.changeDriver(info.PciBusID, vfioDriver)
+	// Run the driver change operation in a separate goroutine because the
+	// underlying kernel operation may get stuck and cannot be cancelled. The
+	// driver change holds the inflight marker until it completes so that a
+	// subsequent Configure/Unconfigure call will not attempt to change the
+	// driver again.
+	err = vm.tryChangeDriverWithTimeout(ctx, driverChangeTimeout, func() error {
+		return vm.changeDriver(info.PciBusID, vfioDriver)
+	})
 	if err != nil {
 		return fmt.Errorf("error changing driver for GPU %q: %w", info.PciBusID, err)
 	}
@@ -256,6 +267,36 @@ func getDriver(pciDevicesPath, pciAddress string) (string, error) {
 	return driver, nil
 }
 
+// Run the driver change operation in a separate goroutine and wait for it to complete.
+//
+// If the driver change times out, its possible that it may be stuck in the kernel
+// and become uncancelable due to another process holding an open handle to the
+// GPU device minor file. Another consequence of this is that the plugin
+// process may not be able to terminate due to the stuck kernel task. This would
+// require either the GPU handle to be released by the culprit process or a node
+// reboot to recover. This is executed with a fixed timeout to avoid holding the
+// `pu.lock` when running in the context of the goroutine serving the
+// NodePrepare/NodeUnprepare API call.
+func (vm *VfioPciManager) tryChangeDriverWithTimeout(ctx context.Context, timeout time.Duration, changeDriverFn func() error) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Create a buffered channel to avoid blocking the goroutine
+	// if this function times out and exits.
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		errCh <- changeDriverFn()
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-timeoutCtx.Done():
+		return timeoutCtx.Err()
+	}
+}
+
 // Change the driver the GPU is bound to.
 //
 // Here, we keep track of inflight driver switches so that we don't attempt to
@@ -266,9 +307,11 @@ func getDriver(pciDevicesPath, pciAddress string) (string, error) {
 // terminate the plugin process. Once the goroutine is freed up, we're safe to
 // reattempt the driver switch.
 func (vm *VfioPciManager) changeDriver(pciAddress, driver string) error {
-	if vm.isDriverSwitchInflight(pciAddress) {
-		return fmt.Errorf("an existing driver switch for GPU %q is inflight, please check the kernel logs for more details", pciAddress)
+	err := vm.markDriverSwitchInflight(pciAddress)
+	if err != nil {
+		return err
 	}
+	defer vm.unmarkDriverSwitchInflight(pciAddress)
 
 	currentDriver, err := getDriver(pciDevicesPath, pciAddress)
 	if err != nil {
@@ -279,10 +322,6 @@ func (vm *VfioPciManager) changeDriver(pciAddress, driver string) error {
 	if currentDriver == driver {
 		return nil
 	}
-
-	// Mark the driver switch as inflight.
-	vm.markDriverSwitchInflight(pciAddress)
-	defer vm.unmarkDriverSwitchInflight(pciAddress)
 
 	if currentDriver != "" {
 		err := vm.nvlib.nvpasst.Unbind(pciAddress)
@@ -310,7 +349,7 @@ func (vm *VfioPciManager) isDriverSwitchInflight(pciAddress string) bool {
 func (vm *VfioPciManager) markDriverSwitchInflight(pciAddress string) error {
 	vm.Lock()
 	defer vm.Unlock()
-	if _, ok := vm.inflightDriverSwitches[pciAddress]; ok {
+	if _, exists := vm.inflightDriverSwitches[pciAddress]; exists {
 		return fmt.Errorf("an existing driver switch for GPU %q is inflight, please check the kernel logs for more details", pciAddress)
 	}
 

--- a/cmd/gpu-kubelet-plugin/vfio-device_test.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -48,4 +51,84 @@ func TestGetDriver(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "nvidia", driver)
 	})
+}
+
+func TestTryChangeDriverWithTimeout(t *testing.T) {
+	vm := &VfioPciManager{
+		nvidiaEnabled: true,
+	}
+
+	t.Run("returns success", func(t *testing.T) {
+		err := vm.tryChangeDriverWithTimeout(context.Background(), time.Second, func() error {
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("returns error", func(t *testing.T) {
+		expected := errors.New("work function failed")
+		err := vm.tryChangeDriverWithTimeout(context.Background(), time.Second, func() error {
+			return expected
+		})
+		require.ErrorIs(t, err, expected)
+	})
+
+	t.Run("returns on timeout", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		finished := make(chan struct{})
+
+		err := vm.tryChangeDriverWithTimeout(context.Background(), 10*time.Millisecond, func() error {
+			close(started)
+			defer close(finished)
+			<-release
+			return nil
+		})
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		requireClosed(t, started)
+
+		close(release)
+		requireEventuallyClosed(t, finished)
+	})
+
+	t.Run("returns on caller cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		started := make(chan struct{})
+		release := make(chan struct{})
+		finished := make(chan struct{})
+
+		go func() {
+			<-started
+			cancel()
+		}()
+
+		err := vm.tryChangeDriverWithTimeout(ctx, time.Second, func() error {
+			close(started)
+			defer close(finished)
+			<-release
+			return nil
+		})
+		require.ErrorIs(t, err, context.Canceled)
+
+		close(release)
+		requireEventuallyClosed(t, finished)
+	})
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected channel to be closed")
+	}
+}
+
+func requireEventuallyClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for channel to close")
+	}
 }

--- a/cmd/gpu-kubelet-plugin/vfio-device_test.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDriver(t *testing.T) {
+	t.Run("returns empty driver", func(t *testing.T) {
+		pciDevicesPath := t.TempDir()
+		pciAddress := "0000:00:01.0"
+		devicePath := filepath.Join(pciDevicesPath, pciAddress)
+		require.NoError(t, os.MkdirAll(devicePath, 0o755))
+
+		driver, err := getDriver(pciDevicesPath, pciAddress)
+		require.NoError(t, err)
+		require.Empty(t, driver)
+	})
+
+	t.Run("returns valid driver", func(t *testing.T) {
+		pciDevicesPath := t.TempDir()
+		pciDriversPath := t.TempDir()
+		pciAddress := "0000:00:01.0"
+		devicePath := filepath.Join(pciDevicesPath, pciAddress)
+		require.NoError(t, os.MkdirAll(devicePath, 0o755))
+
+		require.NoError(t, os.Symlink(filepath.Join(pciDriversPath, "nvidia"), filepath.Join(devicePath, "driver")))
+		driver, err := getDriver(pciDevicesPath, pciAddress)
+		require.NoError(t, err)
+		require.Equal(t, "nvidia", driver)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
When vfio device preparation gets stuck trying to unbind a GPU, it makes the whole plugin unusable as it takes the `pu.lock` and doesn't let go until the driver switch operation is unstuck.

This change ensures that we time out stuck driver switch operations within 15s and immediately fail the `NodePrepareResources` API call. This frees up the plugin to serve other requests

Additionally, this change introduces robustness in the driver switch operation:
1. Subsequent attempt acts only if the previous attempt was completed/aborted by the node kernel.
2. If GPU was not bound to any driver and there's no inflight attempt, then the plugin automatically proceeds to bind the GPU to the correct driver to proceed with prepare/unprepare.

Note: If there are any stuck driver switch operations, then plugin shutdown is blocked until the reason for the blockage is resolved. A separate instance of the plugin if started may reattempt the driver switch operation since we don't checkpoint the state to track it.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Partially Fixes #1255 

#### Special notes for your reviewer:
Pod events when driver-switch operation is stuck:
```
Events:
  Type     Reason                         Age   From               Message
  ----     ------                         ----  ----               -------
  Warning  FailedPrepareDynamicResources  80s   kubelet            Failed to prepare dynamic resources: prepare dynamic resources: NodePrepareResources failed for ResourceClaim busybox-pod-dra-resource-kfcrm: error preparing devices for claim default/busybox-pod-dra-resource-kfcrm:acb4155b-9111-41ad-a953-3dc4ac29bc6a: prepare devices failed: error applying config: error configuring vfio device "gpu-vfio-0": error changing driver for GPU "0000:3b:00.0": context deadline exceeded
  Warning  FailedPrepareDynamicResources  33s    kubelet            Failed to prepare dynamic resources: prepare dynamic resources: NodePrepareResources failed for ResourceClaim busybox-pod-dra-resource-kfcrm: error preparing devices for claim default/busybox-pod-dra-resource-kfcrm:acb4155b-9111-41ad-a953-3dc4ac29bc6a: prepare devices failed: error applying config: error configuring vfio device "gpu-vfio-0": a driver switch is inflight for GPU "0000:3b:00.0", please check the kernel logs for more details
```

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
