### PR TITLE
Log change: prompt users to check FABRIC_MODE when FM call fails

### DIFF
--- a/pkg/fabricmanager/manager.go
+++ b/pkg/fabricmanager/manager.go
@@ -62,7 +62,7 @@ func Open(client Client) (*Manager, error) {
 	partitions, err := client.GetSupportedFabricPartitions()
 	if err != nil {
 		_ = client.Shutdown()
-		return nil, fmt.Errorf("fabricmanager: fmGetSupportedFabricPartitions: %w", err)
+		return nil, fmt.Errorf("fabricmanager: fmGetSupportedFabricPartitions: %w. Ensure Fabric Manager is running and FABRIC_MODE is correctly set", err)
 	}
 
 	if err := m.recordsPartitions(partitions); err != nil {


### PR DESCRIPTION
A simple log enhancement to prompt users to check FABRIC_MODE when FM call fails.

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind support

#### What this PR does / why we need it:
prompt users to check FABRIC_MODE when FM call fails.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Does this PR introduce a user-facing change?
NO

#### Checklist
 make check test passes locally
 Tests added or updated for the change