### PR TITLE
Fix ResourceSlice policy kubelet-plugin identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CMD_TARGETS := $(patsubst %,cmd-%, $(CMDS))
 
 CHECK_TARGETS := golangci-lint check-generate
 
-MAKE_TARGETS := binaries build build-image check clean fmt lint-internal test examples cmds coverage generate vendor check-modules helm-lint helm-package $(CHECK_TARGETS)
+MAKE_TARGETS := binaries build build-image check clean fmt lint-internal test examples cmds coverage generate vendor check-modules helm-lint helm-test helm-package $(CHECK_TARGETS)
 
 TARGETS := $(MAKE_TARGETS) $(CMD_TARGETS)
 
@@ -92,8 +92,11 @@ golangci-lint:
 
 lint-internal: golangci-lint
 
-helm-lint:
+helm-lint: helm-test
 	helm lint deployments/helm/dra-driver-nvidia-gpu
+
+helm-test:
+	hack/test-helm-policy-service-account.sh
 
 helm-package:
 	helm package deployments/helm/dra-driver-nvidia-gpu

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/validatingadmissionpolicy.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/validatingadmissionpolicy.yaml
@@ -13,7 +13,7 @@ spec:
   matchConditions:
   - name: isRestrictedUser
     expression: >-
-      request.userInfo.username == "system:serviceaccount:{{ include "dra-driver-nvidia-gpu.namespace" . }}:{{ include "dra-driver-nvidia-gpu.serviceAccountName" . }}"
+      request.userInfo.username == "system:serviceaccount:{{ include "dra-driver-nvidia-gpu.namespace" . }}:{{ include "dra-driver-nvidia-gpu.serviceAccountName" . }}-kubeletplugin"
   variables:
   - name: userNodeName
     expression: >-

--- a/hack/test-helm-policy-service-account.sh
+++ b/hack/test-helm-policy-service-account.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright The Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CHART_PATH="${REPO_ROOT}/deployments/helm/dra-driver-nvidia-gpu"
+RELEASE_NAME=validating-admission-policy-test
+NAMESPACE=validating-admission-policy-test
+
+kubelet_plugin=$(helm template "${RELEASE_NAME}" "${CHART_PATH}" \
+    --namespace "${NAMESPACE}" \
+    --set gpuResourcesEnabledOverride=true \
+    --show-only templates/kubeletplugin.yaml)
+policy=$(helm template "${RELEASE_NAME}" "${CHART_PATH}" \
+    --namespace "${NAMESPACE}" \
+    --set gpuResourcesEnabledOverride=true \
+    --show-only templates/validatingadmissionpolicy.yaml)
+
+mapfile -t service_accounts < <(
+    sed -nE 's/^[[:space:]]*serviceAccountName:[[:space:]]*([^[:space:]#]+).*$/\1/p' \
+        <<<"${kubelet_plugin}"
+)
+if [[ ${#service_accounts[@]} -ne 1 ]]; then
+    echo "expected one kubelet-plugin serviceAccountName, found ${#service_accounts[@]}" >&2
+    exit 1
+fi
+
+expected="request.userInfo.username == \"system:serviceaccount:${NAMESPACE}:${service_accounts[0]}\""
+if [[ "${policy}" != *"${expected}"* ]]; then
+    echo "ValidatingAdmissionPolicy does not target the kubelet-plugin service account" >&2
+    echo "expected: ${expected}" >&2
+    exit 1
+fi


### PR DESCRIPTION
## What this fixes

The Helm chart's ResourceSlice `ValidatingAdmissionPolicy` matches the base service-account name, while the kubelet-plugin DaemonSet runs as the suffixed `-kubeletplugin` service account. Because the policy's sole match condition is false for the actual writer identity, its node-association validations are skipped for kubelet-plugin ResourceSlice writes.

This change makes the policy target the exact service account used by the DaemonSet without broadening the match condition.

Fixes #1317.

## Regression coverage

Adds a Helm render test that:

- renders the kubelet-plugin DaemonSet and admission policy;
- derives the expected Kubernetes username from the DaemonSet's rendered `serviceAccountName`;
- requires that exact identity in the rendered policy;
- is executed by `helm-test`, which is now a prerequisite of `helm-lint` and therefore runs in the existing Helm CI workflow.

The unchanged test fails when the policy is reverted to the base service-account identity.

## Validation

- `make helm-test`
- `make helm-lint` with Helm 3.19.5
- `make helm-lint` with project-pinned Helm 3.18.6
- chart packaging
- shell syntax and `git diff --check`

```release-note
Fixed the NVIDIA DRA Helm chart's ResourceSlice admission policy to constrain writes by the actual kubelet-plugin service account.
```
