### PR TITLE
Reject sharing config for adminAccess requests

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -341,6 +341,10 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		}
 	}
 
+	if err := s.validateAdminAccessDeviceTypes(claim); err != nil {
+		return nil, fmt.Errorf("unable to prepare claim %v: %w", claimUID, err)
+	}
+
 	tucp0 := time.Now()
 	err = s.updateCheckpoint(ctx, func(cp *Checkpoint) {
 		cp.V2.PreparedClaims[claimUID] = PreparedClaim{
@@ -1161,6 +1165,31 @@ func isAdminAccess(r *resourceapi.DeviceRequestAllocationResult) bool {
 	return r.AdminAccess != nil && *r.AdminAccess
 }
 
+// validateAdminAccessDeviceTypes rejects an adminAccess request allocated a device
+// that is not a whole GPU. adminAccess bypasses device exclusivity, which is only
+// meaningful for a whole device.
+func (s *DeviceState) validateAdminAccessDeviceTypes(claim *resourceapi.ResourceClaim) error {
+	if claim.Status.Allocation == nil {
+		return nil
+	}
+	for _, r := range claim.Status.Allocation.Devices.Results {
+		if r.Driver != DriverName || !isAdminAccess(&r) {
+			continue
+		}
+		device := s.perGPUAllocatable.GetAllocatableDevice(r.Device)
+		if device == nil {
+			return fmt.Errorf("allocatable not found for device %q", r.Device)
+		}
+		if device.Type() != GpuDeviceType {
+			return fmt.Errorf(
+				"adminAccess is only supported for full GPU devices: request %q was allocated device %q",
+				r.Request, r.Device,
+			)
+		}
+	}
+	return nil
+}
+
 // sharingRequested reports whether a decoded config asks for a sharing strategy.
 func sharingRequested(c runtime.Object) bool {
 	switch castConfig := c.(type) {
@@ -1526,7 +1555,7 @@ func (s *DeviceState) requestedNonAdminDevices(claim *resourceapi.ResourceClaim)
 		if r.Driver != DriverName {
 			continue
 		}
-		if r.AdminAccess != nil && *r.AdminAccess {
+		if isAdminAccess(&r) {
 			continue
 		}
 		requested[r.Device] = struct{}{}
@@ -1630,13 +1659,14 @@ func (s *DeviceState) getConfigResultsMap(allocation *resourceapi.AllocationResu
 			return nil, fmt.Errorf("allocatable not found for device %q", result.Device)
 		}
 		for _, c := range slices.Backward(configs) {
-			// Sharing inherited from the DeviceClass cannot be removed by the claim
-			// author, so rejecting it would make every monitoring claim against that
-			// class unpreparable. Skip it and fall through to the next candidate,
-			// at worst the default config. Claim-sourced sharing is still rejected
-			// in applySharingConfig.
-			if isAdminAccess(&result) && c.Source == resourceapi.AllocationConfigSourceClass && sharingRequested(c.Config) {
-				klog.V(4).Infof("Ignoring DeviceClass sharing config for adminAccess request %q", result.Request)
+			// Skip a sharing config that does not explicitly name this adminAccess
+			// request: DeviceClass sharing cannot be removed by the claim author,
+			// and a claim-sourced config with an empty Requests list is exactly
+			// what the webhook also admits. A config that does name the request is
+			// still rejected in applySharingConfig.
+			if isAdminAccess(&result) && sharingRequested(c.Config) &&
+				(c.Source == resourceapi.AllocationConfigSourceClass || len(c.Requests) == 0) {
+				klog.V(4).Infof("Ignoring untargeted sharing config for adminAccess request %q", result.Request)
 				continue
 			}
 			if slices.Contains(c.Requests, result.Request) {

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -56,6 +56,9 @@ import (
 type OpaqueDeviceConfig struct {
 	Requests []string
 	Config   runtime.Object
+	// Source records whether the config came from the claim or was inherited from
+	// the DeviceClass. Only the claim author can change a claim-sourced config.
+	Source resourceapi.AllocationConfigSource
 }
 
 type DeviceConfigState struct {
@@ -1152,7 +1155,71 @@ func (s *DeviceState) applyConfig(ctx context.Context, config configapi.Interfac
 	}
 }
 
+// isAdminAccess reports whether an allocation result was allocated with admin
+// access. AdminAccess is a *bool, where nil means "not admin access".
+func isAdminAccess(r *resourceapi.DeviceRequestAllocationResult) bool {
+	return r.AdminAccess != nil && *r.AdminAccess
+}
+
+// sharingRequested reports whether a decoded config asks for a sharing strategy.
+// Configs without a Sharing field can never request one.
+func sharingRequested(c runtime.Object) bool {
+	switch castConfig := c.(type) {
+	case *configapi.GpuConfig:
+		return castConfig.Sharing.IsTimeSlicing() || castConfig.Sharing.IsMps()
+	case *configapi.MigDeviceConfig:
+		return castConfig.Sharing.IsTimeSlicing() || castConfig.Sharing.IsMps()
+	}
+	return false
+}
+
+// validateNoSharingWithAdminAccess rejects a sharing configuration (TimeSlicing or
+// MPS) that is being applied over a request allocated with admin access.
+//
+// A claim with adminAccess is a read-only observer: it deliberately bypasses the
+// exclusivity check in validateNoOverlappingPreparedDevices so it can attach to a
+// device another claim already owns. Sharing settings are device-global, so applying
+// them on Prepare overwrites the owning workload's settings, and tearing them down on
+// Unprepare disrupts a workload that is still running. A plain adminAccess claim with
+// no sharing config is unaffected: Sharing is nil and both IsTimeSlicing() and
+// IsMps() are nil-receiver-safe.
+func validateNoSharingWithAdminAccess(config configapi.Sharing, results []*resourceapi.DeviceRequestAllocationResult) error {
+	// Identify the requested strategy so the error message can name it. This is
+	// deliberately not guarded by the TimeSlicingSettings/MPSSupport feature gates:
+	// a claim that would corrupt device state as soon as an operator enables a gate
+	// should not be accepted while that gate happens to be disabled.
+	var strategy string
+	switch {
+	case config.IsTimeSlicing():
+		strategy = configapi.TimeSlicingStrategy
+	case config.IsMps():
+		strategy = configapi.MpsStrategy
+	default:
+		return nil
+	}
+
+	// Check every result, not just the first: a config with an empty Requests list
+	// applies to every request in the claim, so one group can contain both a workload
+	// request and an adminAccess request, in any order.
+	for _, r := range results {
+		if isAdminAccess(r) {
+			return fmt.Errorf(
+				"%s sharing configuration is not allowed for request %q: the request is allocated with adminAccess, and sharing settings apply to the whole device",
+				strategy, r.Request,
+			)
+		}
+	}
+	return nil
+}
+
 func (s *DeviceState) applySharingConfig(ctx context.Context, config configapi.Sharing, claim *resourceapi.ResourceClaim, results []*resourceapi.DeviceRequestAllocationResult, cp *Checkpoint) (*DeviceConfigState, error) {
+	// Reject before anything reads or mutates device state: applyConfig routes both
+	// GpuConfig and MigDeviceConfig here, so this one guard covers both, and failing
+	// first means the GPU is never touched on the rejected path.
+	if err := validateNoSharingWithAdminAccess(config, results); err != nil {
+		return nil, err
+	}
+
 	// Get the list of claim requests this config is being applied over.
 	var requests []string
 	for _, r := range results {
@@ -1450,6 +1517,7 @@ func GetOpaqueDeviceConfigs(
 		resultConfig := &OpaqueDeviceConfig{
 			Requests: config.Requests,
 			Config:   decodedConfig,
+			Source:   config.Source,
 		}
 
 		resultConfigs = append(resultConfigs, resultConfig)
@@ -1571,6 +1639,16 @@ func (s *DeviceState) getConfigResultsMap(allocation *resourceapi.AllocationResu
 			return nil, fmt.Errorf("allocatable not found for device %q", result.Device)
 		}
 		for _, c := range slices.Backward(configs) {
+			// A sharing config inherited from the DeviceClass must not be applied to
+			// an adminAccess request. The claim author cannot remove it, so letting it
+			// reach applySharingConfig would make every monitoring claim against that
+			// class permanently unpreparable. Skip it and fall through to the next
+			// candidate, which is at worst the default config with no sharing.
+			// Sharing that the claim itself asks for is still rejected there.
+			if isAdminAccess(&result) && c.Source == resourceapi.AllocationConfigSourceClass && sharingRequested(c.Config) {
+				klog.V(4).Infof("Ignoring DeviceClass sharing config for adminAccess request %q", result.Request)
+				continue
+			}
 			if slices.Contains(c.Requests, result.Request) {
 				if err := validateDeviceConfigType(c.Config, device, &result); err != nil {
 					return nil, err

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -1155,14 +1155,13 @@ func (s *DeviceState) applyConfig(ctx context.Context, config configapi.Interfac
 	}
 }
 
-// isAdminAccess reports whether an allocation result was allocated with admin
-// access. AdminAccess is a *bool, where nil means "not admin access".
+// isAdminAccess reports whether a result was allocated with admin access.
+// AdminAccess is a *bool, where nil means "not admin access".
 func isAdminAccess(r *resourceapi.DeviceRequestAllocationResult) bool {
 	return r.AdminAccess != nil && *r.AdminAccess
 }
 
 // sharingRequested reports whether a decoded config asks for a sharing strategy.
-// Configs without a Sharing field can never request one.
 func sharingRequested(c runtime.Object) bool {
 	switch castConfig := c.(type) {
 	case *configapi.GpuConfig:
@@ -1174,20 +1173,14 @@ func sharingRequested(c runtime.Object) bool {
 }
 
 // validateNoSharingWithAdminAccess rejects a sharing configuration (TimeSlicing or
-// MPS) that is being applied over a request allocated with admin access.
-//
-// A claim with adminAccess is a read-only observer: it deliberately bypasses the
-// exclusivity check in validateNoOverlappingPreparedDevices so it can attach to a
-// device another claim already owns. Sharing settings are device-global, so applying
-// them on Prepare overwrites the owning workload's settings, and tearing them down on
-// Unprepare disrupts a workload that is still running. A plain adminAccess claim with
-// no sharing config is unaffected: Sharing is nil and both IsTimeSlicing() and
-// IsMps() are nil-receiver-safe.
+// MPS) applied over a request allocated with admin access. Such a request is a
+// read-only observer of a device another claim owns, but sharing settings are
+// device-global: applying them on Prepare overwrites the owning workload's
+// settings, and tearing them down on Unprepare disrupts it while it still runs.
 func validateNoSharingWithAdminAccess(config configapi.Sharing, results []*resourceapi.DeviceRequestAllocationResult) error {
-	// Identify the requested strategy so the error message can name it. This is
-	// deliberately not guarded by the TimeSlicingSettings/MPSSupport feature gates:
-	// a claim that would corrupt device state as soon as an operator enables a gate
-	// should not be accepted while that gate happens to be disabled.
+	// Not guarded by the TimeSlicingSettings/MPSSupport feature gates: a claim that
+	// would corrupt device state as soon as an operator enables a gate should not be
+	// accepted while that gate happens to be disabled.
 	var strategy string
 	switch {
 	case config.IsTimeSlicing():
@@ -1198,9 +1191,8 @@ func validateNoSharingWithAdminAccess(config configapi.Sharing, results []*resou
 		return nil
 	}
 
-	// Check every result, not just the first: a config with an empty Requests list
-	// applies to every request in the claim, so one group can contain both a workload
-	// request and an adminAccess request, in any order.
+	// Every result, not just the first: a config with an empty Requests list applies
+	// to the whole claim, so one group can mix workload and adminAccess requests.
 	for _, r := range results {
 		if isAdminAccess(r) {
 			return fmt.Errorf(
@@ -1213,9 +1205,8 @@ func validateNoSharingWithAdminAccess(config configapi.Sharing, results []*resou
 }
 
 func (s *DeviceState) applySharingConfig(ctx context.Context, config configapi.Sharing, claim *resourceapi.ResourceClaim, results []*resourceapi.DeviceRequestAllocationResult, cp *Checkpoint) (*DeviceConfigState, error) {
-	// Reject before anything reads or mutates device state: applyConfig routes both
-	// GpuConfig and MigDeviceConfig here, so this one guard covers both, and failing
-	// first means the GPU is never touched on the rejected path.
+	// First statement, so the GPU is never touched on the rejected path. applyConfig
+	// routes both GpuConfig and MigDeviceConfig here, so one guard covers both.
 	if err := validateNoSharingWithAdminAccess(config, results); err != nil {
 		return nil, err
 	}
@@ -1639,12 +1630,11 @@ func (s *DeviceState) getConfigResultsMap(allocation *resourceapi.AllocationResu
 			return nil, fmt.Errorf("allocatable not found for device %q", result.Device)
 		}
 		for _, c := range slices.Backward(configs) {
-			// A sharing config inherited from the DeviceClass must not be applied to
-			// an adminAccess request. The claim author cannot remove it, so letting it
-			// reach applySharingConfig would make every monitoring claim against that
-			// class permanently unpreparable. Skip it and fall through to the next
-			// candidate, which is at worst the default config with no sharing.
-			// Sharing that the claim itself asks for is still rejected there.
+			// Sharing inherited from the DeviceClass cannot be removed by the claim
+			// author, so rejecting it would make every monitoring claim against that
+			// class unpreparable. Skip it and fall through to the next candidate,
+			// at worst the default config. Claim-sourced sharing is still rejected
+			// in applySharingConfig.
 			if isAdminAccess(&result) && c.Source == resourceapi.AllocationConfigSourceClass && sharingRequested(c.Config) {
 				klog.V(4).Infof("Ignoring DeviceClass sharing config for adminAccess request %q", result.Request)
 				continue

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/fabricmanager"
@@ -384,4 +385,89 @@ func TestDeactivateFabricPartitionRefCounting(t *testing.T) {
 	err = state.deactivateFabricPartition("claim-1", &pc1, checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, []int{1}, fmClient.deactivatedIDs, "FM partition deactivation MUST be called when no active claims remain")
+}
+
+func TestValidateAdminAccessDeviceTypes(t *testing.T) {
+	state := &DeviceState{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				"0000:00:00.0": {
+					"gpu-0":    &AllocatableDevice{Gpu: &GpuInfo{minor: 0}},
+					"mig-0":    &AllocatableDevice{MigStatic: &MigDeviceInfo{}},
+					"migdyn-0": &AllocatableDevice{MigDynamic: &MigSpec{}},
+					"vfio-0":   &AllocatableDevice{Vfio: &VfioDeviceInfo{index: 0}},
+				},
+			},
+		},
+	}
+
+	claim := func(results ...resourceapi.DeviceRequestAllocationResult) *resourceapi.ResourceClaim {
+		return &resourceapi.ResourceClaim{
+			Status: resourceapi.ResourceClaimStatus{
+				Allocation: &resourceapi.AllocationResult{
+					Devices: resourceapi.DeviceAllocationResult{Results: results},
+				},
+			},
+		}
+	}
+	admin := func(request, device string) resourceapi.DeviceRequestAllocationResult {
+		return resourceapi.DeviceRequestAllocationResult{
+			Request: request, Driver: DriverName, Device: device, AdminAccess: ptr.To(true),
+		}
+	}
+	workload := func(request, device string) resourceapi.DeviceRequestAllocationResult {
+		return resourceapi.DeviceRequestAllocationResult{
+			Request: request, Driver: DriverName, Device: device,
+		}
+	}
+
+	testCases := map[string]struct {
+		claim       *resourceapi.ResourceClaim
+		errContains string
+	}{
+		"adminAccess on a full GPU is allowed": {
+			claim: claim(admin("monitor", "gpu-0")),
+		},
+		"workload on a MIG device is allowed": {
+			claim: claim(workload("workload", "mig-0")),
+		},
+		"adminAccess on a static MIG device is rejected": {
+			claim:       claim(admin("monitor", "mig-0")),
+			errContains: `adminAccess is only supported for full GPU devices: request "monitor"`,
+		},
+		"adminAccess on a dynamic MIG device is rejected": {
+			claim:       claim(admin("monitor", "migdyn-0")),
+			errContains: `adminAccess is only supported for full GPU devices: request "monitor"`,
+		},
+		"adminAccess on a VFIO device is rejected": {
+			claim:       claim(admin("monitor", "vfio-0")),
+			errContains: `adminAccess is only supported for full GPU devices: request "monitor"`,
+		},
+		// The admin result is second on purpose: an implementation that only
+		// inspected results[0] passes every other case in this table.
+		"adminAccess on MIG alongside a workload request is rejected": {
+			claim:       claim(workload("workload", "gpu-0"), admin("monitor", "mig-0")),
+			errContains: `adminAccess is only supported for full GPU devices: request "monitor"`,
+		},
+		"results for another driver are ignored": {
+			claim: claim(resourceapi.DeviceRequestAllocationResult{
+				Request: "monitor", Driver: "other.example.com", Device: "unknown-0",
+				AdminAccess: ptr.To(true),
+			}),
+		},
+		"unallocated claim is allowed": {
+			claim: &resourceapi.ResourceClaim{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := state.validateAdminAccessDeviceTypes(tc.claim)
+			if tc.errContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.errContains)
+		})
+	}
 }

--- a/cmd/gpu-kubelet-plugin/prepared.go
+++ b/cmd/gpu-kubelet-plugin/prepared.go
@@ -262,7 +262,7 @@ func (c *PreparedClaim) GetNonAdminDevices() map[string]struct{} {
 		if r.Driver != DriverName {
 			continue
 		}
-		if r.AdminAccess != nil && *r.AdminAccess {
+		if isAdminAccess(&r) {
 			continue
 		}
 		requested[r.Device] = struct{}{}

--- a/cmd/gpu-kubelet-plugin/sharing_test.go
+++ b/cmd/gpu-kubelet-plugin/sharing_test.go
@@ -17,12 +17,19 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	configapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
 )
 
 // mockFileChecker implements fileChecker for tests.
@@ -90,4 +97,218 @@ func TestRenderMpsControlDaemonDeploymentImagePullSettings(t *testing.T) {
 	}, deployment.Spec.Template.Spec.ImagePullSecrets)
 	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 	require.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+}
+
+// TestValidateNoSharingWithAdminAccess covers the validation in isolation. It needs no
+// NVML, no MPS daemon and no DeviceState at all, because the function under test is a
+// pure function of (config, results) — that is the reason it was factored out of
+// applySharingConfig rather than written inline.
+//
+// The two axes being crossed are "does the config request sharing" and "is any result
+// allocated with adminAccess". Only the both-true corner may be rejected; the other
+// three corners are existing supported behaviour and would be regressions if broken.
+func TestValidateNoSharingWithAdminAccess(t *testing.T) {
+	// Small constructor so each case reads as intent rather than struct literal noise.
+	// Driver is set to DriverName because prepareDevices only ever passes this
+	// function results belonging to our driver (it filters on result.Driver first).
+	result := func(request string, adminAccess bool) *resourceapi.DeviceRequestAllocationResult {
+		return &resourceapi.DeviceRequestAllocationResult{
+			Request:     request,
+			Driver:      DriverName,
+			AdminAccess: ptr.To(adminAccess),
+		}
+	}
+
+	// Map-based table, matching the style used elsewhere in this file. An empty
+	// errContains means "must be accepted"; a non-empty one is matched as a substring
+	// so the assertion pins the meaningful part of the message without becoming
+	// brittle about the trailing explanation.
+	testCases := map[string]struct {
+		config      configapi.Sharing
+		results     []*resourceapi.DeviceRequestAllocationResult
+		errContains string
+	}{
+		// The important negative case: this is what a normal monitoring/debug claim
+		// looks like. DefaultGpuConfig().Sharing is a nil *GpuSharing, which reaches
+		// the function as a non-nil interface holding a nil pointer. It must be
+		// accepted, and it exercises the nil-receiver safety of IsTimeSlicing/IsMps.
+		"no sharing config with admin access is allowed": {
+			config:  configapi.DefaultGpuConfig().Sharing,
+			results: []*resourceapi.DeviceRequestAllocationResult{result("admin", true)},
+		},
+		// Ordinary time-slicing workload: sharing is exactly what it is for.
+		"time-slicing without admin access is allowed": {
+			config:  &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
+			results: []*resourceapi.DeviceRequestAllocationResult{result("workload", false)},
+		},
+		// AdminAccess is a *bool, and nil is the common real-world encoding of "not
+		// an admin request". Constructed literally here (not via the helper) so the
+		// pointer really is nil, proving the guard does not treat nil as true.
+		"admin access without the flag set is allowed": {
+			config: &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
+			results: []*resourceapi.DeviceRequestAllocationResult{
+				{Request: "workload", Driver: DriverName},
+			},
+		},
+		// The bug from the issue, TimeSlicing half.
+		"time-slicing with admin access is rejected": {
+			config:      &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
+			results:     []*resourceapi.DeviceRequestAllocationResult{result("admin", true)},
+			errContains: `TimeSlicing sharing configuration is not allowed for request "admin"`,
+		},
+		// The bug from the issue, MPS half. Worth covering separately from
+		// TimeSlicing: they are different branches of the switch, and MPS is the more
+		// destructive of the two (a stopped daemon kills running CUDA contexts).
+		"MPS with admin access is rejected": {
+			config:      &configapi.GpuSharing{Strategy: configapi.MpsStrategy},
+			results:     []*resourceapi.DeviceRequestAllocationResult{result("admin", true)},
+			errContains: `MPS sharing configuration is not allowed for request "admin"`,
+		},
+		// MigDeviceSharing is a different concrete type implementing the same
+		// configapi.Sharing interface. It reaches applySharingConfig through the
+		// MigDeviceConfig arm of applyConfig, so it must be covered too — this is the
+		// case that would break if someone later type-asserted to *GpuSharing.
+		"MPS on a MIG device with admin access is rejected": {
+			config:      &configapi.MigDeviceSharing{Strategy: configapi.MpsStrategy},
+			results:     []*resourceapi.DeviceRequestAllocationResult{result("admin", true)},
+			errContains: `MPS sharing configuration is not allowed for request "admin"`,
+		},
+		// The subtle one. A config whose Requests list is empty applies to every
+		// request in the claim, so a single group can hold both kinds of request. The
+		// admin result is placed SECOND on purpose: an implementation that only
+		// inspected results[0] would pass every other case in this table and still
+		// ship the bug.
+		"admin access mixed with a workload request is rejected": {
+			config: &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
+			results: []*resourceapi.DeviceRequestAllocationResult{
+				result("workload", false),
+				result("admin", true),
+			},
+			errContains: `TimeSlicing sharing configuration is not allowed for request "admin"`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := validateNoSharingWithAdminAccess(tc.config, tc.results)
+			if tc.errContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.errContains)
+		})
+	}
+}
+
+// TestApplySharingConfigRejectsAdminAccess asserts that the validation is actually
+// REACHED from the prepare path.
+//
+// Why a second test at all: TestValidateNoSharingWithAdminAccess above tests the
+// function directly, so it keeps passing even if someone deletes the call site in
+// applySharingConfig. That would leave the bug fully reintroduced with a green suite.
+// This test fails in that scenario, so it is the one protecting the fix.
+//
+// Why a zero-value DeviceState works, with no mocks, no NVML and no fixtures: the
+// guard is the first statement in applySharingConfig, so for a rejected input the
+// function returns before it dereferences s.perGPUAllocatable, s.tsManager or
+// s.mpsManager. Those being nil is not an oversight in the test — it is the assertion.
+// If the guard is moved down or removed, this test does not merely fail, it panics with
+// a nil pointer dereference, which is a loud signal that the ordering invariant broke.
+// TestGetConfigResultsMapSharingSourceForAdminAccess pins which sharing configs are
+// allowed to reach applySharingConfig for an adminAccess result.
+//
+// A DeviceClass-sourced sharing config applies to every matching request in every
+// claim and the claim author cannot remove it, so rejecting it would leave monitoring
+// pods permanently unpreparable on that class. It is skipped here instead, and the
+// result falls through to the default config, which requests no sharing. A
+// claim-sourced config is the author's own mistake, so it is left in place and
+// validateNoSharingWithAdminAccess reports it.
+func TestGetConfigResultsMapSharingSourceForAdminAccess(t *testing.T) {
+	sharingConfig := configapi.DefaultGpuConfig()
+	sharingConfig.Sharing = &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy}
+	raw, err := json.Marshal(sharingConfig)
+	require.NoError(t, err)
+
+	for name, tc := range map[string]struct {
+		source          resourceapi.AllocationConfigSource
+		expectedSharing bool
+	}{
+		"DeviceClass sharing config is not applied to an adminAccess result": {
+			source:          resourceapi.AllocationConfigSourceClass,
+			expectedSharing: false,
+		},
+		"claim sharing config still reaches the adminAccess result": {
+			source:          resourceapi.AllocationConfigSourceClaim,
+			expectedSharing: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := &DeviceState{
+				perGPUAllocatable: &PerGPUAllocatableDevices{
+					allocatablesMap: map[PCIBusID]AllocatableDevices{
+						"0000:00:00.0": {
+							"gpu-0": &AllocatableDevice{Gpu: &GpuInfo{UUID: "GPU-0000"}},
+						},
+					},
+				},
+			}
+
+			allocation := &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{
+					Results: []resourceapi.DeviceRequestAllocationResult{
+						{
+							Request:     "monitor",
+							Driver:      DriverName,
+							Device:      "gpu-0",
+							AdminAccess: ptr.To(true),
+						},
+					},
+					Config: []resourceapi.DeviceAllocationConfiguration{
+						{
+							Source: tc.source,
+							DeviceConfiguration: resourceapi.DeviceConfiguration{
+								Opaque: &resourceapi.OpaqueDeviceConfiguration{
+									Driver:     DriverName,
+									Parameters: runtime.RawExtension{Raw: raw},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			configResultsMap, err := state.getConfigResultsMap(allocation)
+			require.NoError(t, err)
+			require.Len(t, configResultsMap, 1, "the result must be grouped under exactly one config")
+
+			for c := range configResultsMap {
+				require.Equal(t, tc.expectedSharing, sharingRequested(c))
+			}
+		})
+	}
+}
+
+func TestApplySharingConfigRejectsAdminAccess(t *testing.T) {
+	state := &DeviceState{}
+
+	// An empty claim is fine: the guard never reads the claim. It only appears in the
+	// error messages further down the function, which we never get to here.
+	claim := &resourceapi.ResourceClaim{}
+
+	results := []*resourceapi.DeviceRequestAllocationResult{
+		{Request: "admin", Driver: DriverName, AdminAccess: ptr.To(true)},
+	}
+
+	// The checkpoint is nil for the same reason the DeviceState fields are: the guard
+	// returns before anything downstream touches it.
+	_, err := state.applySharingConfig(
+		context.Background(),
+		&configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
+		claim,
+		results,
+		nil,
+	)
+	// Deliberately a looser substring than the table test uses: this test is about the
+	// call being wired up, not about the exact wording, which is pinned above.
+	require.ErrorContains(t, err, `not allowed for request "admin"`)
 }

--- a/cmd/gpu-kubelet-plugin/sharing_test.go
+++ b/cmd/gpu-kubelet-plugin/sharing_test.go
@@ -99,18 +99,10 @@ func TestRenderMpsControlDaemonDeploymentImagePullSettings(t *testing.T) {
 	require.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 }
 
-// TestValidateNoSharingWithAdminAccess covers the validation in isolation. It needs no
-// NVML, no MPS daemon and no DeviceState at all, because the function under test is a
-// pure function of (config, results) — that is the reason it was factored out of
-// applySharingConfig rather than written inline.
-//
-// The two axes being crossed are "does the config request sharing" and "is any result
-// allocated with adminAccess". Only the both-true corner may be rejected; the other
-// three corners are existing supported behaviour and would be regressions if broken.
+// TestValidateNoSharingWithAdminAccess crosses "does the config request sharing"
+// with "is any result allocated with adminAccess". Only the both-true corner is
+// rejected; the other three are supported behaviour today.
 func TestValidateNoSharingWithAdminAccess(t *testing.T) {
-	// Small constructor so each case reads as intent rather than struct literal noise.
-	// Driver is set to DriverName because prepareDevices only ever passes this
-	// function results belonging to our driver (it filters on result.Driver first).
 	result := func(request string, adminAccess bool) *resourceapi.DeviceRequestAllocationResult {
 		return &resourceapi.DeviceRequestAllocationResult{
 			Request:     request,
@@ -119,65 +111,50 @@ func TestValidateNoSharingWithAdminAccess(t *testing.T) {
 		}
 	}
 
-	// Map-based table, matching the style used elsewhere in this file. An empty
-	// errContains means "must be accepted"; a non-empty one is matched as a substring
-	// so the assertion pins the meaningful part of the message without becoming
-	// brittle about the trailing explanation.
+	// An empty errContains means the config must be accepted.
 	testCases := map[string]struct {
 		config      configapi.Sharing
 		results     []*resourceapi.DeviceRequestAllocationResult
 		errContains string
 	}{
-		// The important negative case: this is what a normal monitoring/debug claim
-		// looks like. DefaultGpuConfig().Sharing is a nil *GpuSharing, which reaches
-		// the function as a non-nil interface holding a nil pointer. It must be
-		// accepted, and it exercises the nil-receiver safety of IsTimeSlicing/IsMps.
+		// The normal monitoring claim. DefaultGpuConfig().Sharing is a nil
+		// *GpuSharing inside a non-nil interface, so this also covers the
+		// nil-receiver safety of IsTimeSlicing/IsMps.
 		"no sharing config with admin access is allowed": {
 			config:  configapi.DefaultGpuConfig().Sharing,
 			results: []*resourceapi.DeviceRequestAllocationResult{result("admin", true)},
 		},
-		// Ordinary time-slicing workload: sharing is exactly what it is for.
 		"time-slicing without admin access is allowed": {
 			config:  &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
 			results: []*resourceapi.DeviceRequestAllocationResult{result("workload", false)},
 		},
-		// AdminAccess is a *bool, and nil is the common real-world encoding of "not
-		// an admin request". Constructed literally here (not via the helper) so the
-		// pointer really is nil, proving the guard does not treat nil as true.
+		// Built literally, not via the helper, so AdminAccess really is nil: the
+		// guard must not read nil as true.
 		"admin access without the flag set is allowed": {
 			config: &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
 			results: []*resourceapi.DeviceRequestAllocationResult{
 				{Request: "workload", Driver: DriverName},
 			},
 		},
-		// The bug from the issue, TimeSlicing half.
 		"time-slicing with admin access is rejected": {
 			config:      &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
 			results:     []*resourceapi.DeviceRequestAllocationResult{result("admin", true)},
 			errContains: `TimeSlicing sharing configuration is not allowed for request "admin"`,
 		},
-		// The bug from the issue, MPS half. Worth covering separately from
-		// TimeSlicing: they are different branches of the switch, and MPS is the more
-		// destructive of the two (a stopped daemon kills running CUDA contexts).
 		"MPS with admin access is rejected": {
 			config:      &configapi.GpuSharing{Strategy: configapi.MpsStrategy},
 			results:     []*resourceapi.DeviceRequestAllocationResult{result("admin", true)},
 			errContains: `MPS sharing configuration is not allowed for request "admin"`,
 		},
-		// MigDeviceSharing is a different concrete type implementing the same
-		// configapi.Sharing interface. It reaches applySharingConfig through the
-		// MigDeviceConfig arm of applyConfig, so it must be covered too — this is the
-		// case that would break if someone later type-asserted to *GpuSharing.
+		// MigDeviceSharing is a second implementation of configapi.Sharing: this
+		// case breaks if anyone type-asserts to *GpuSharing.
 		"MPS on a MIG device with admin access is rejected": {
 			config:      &configapi.MigDeviceSharing{Strategy: configapi.MpsStrategy},
 			results:     []*resourceapi.DeviceRequestAllocationResult{result("admin", true)},
 			errContains: `MPS sharing configuration is not allowed for request "admin"`,
 		},
-		// The subtle one. A config whose Requests list is empty applies to every
-		// request in the claim, so a single group can hold both kinds of request. The
-		// admin result is placed SECOND on purpose: an implementation that only
-		// inspected results[0] would pass every other case in this table and still
-		// ship the bug.
+		// The admin result is second on purpose: an implementation that only
+		// inspected results[0] passes every other case in this table.
 		"admin access mixed with a workload request is rejected": {
 			config: &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
 			results: []*resourceapi.DeviceRequestAllocationResult{
@@ -200,29 +177,10 @@ func TestValidateNoSharingWithAdminAccess(t *testing.T) {
 	}
 }
 
-// TestApplySharingConfigRejectsAdminAccess asserts that the validation is actually
-// REACHED from the prepare path.
-//
-// Why a second test at all: TestValidateNoSharingWithAdminAccess above tests the
-// function directly, so it keeps passing even if someone deletes the call site in
-// applySharingConfig. That would leave the bug fully reintroduced with a green suite.
-// This test fails in that scenario, so it is the one protecting the fix.
-//
-// Why a zero-value DeviceState works, with no mocks, no NVML and no fixtures: the
-// guard is the first statement in applySharingConfig, so for a rejected input the
-// function returns before it dereferences s.perGPUAllocatable, s.tsManager or
-// s.mpsManager. Those being nil is not an oversight in the test — it is the assertion.
-// If the guard is moved down or removed, this test does not merely fail, it panics with
-// a nil pointer dereference, which is a loud signal that the ordering invariant broke.
-// TestGetConfigResultsMapSharingSourceForAdminAccess pins which sharing configs are
-// allowed to reach applySharingConfig for an adminAccess result.
-//
-// A DeviceClass-sourced sharing config applies to every matching request in every
-// claim and the claim author cannot remove it, so rejecting it would leave monitoring
-// pods permanently unpreparable on that class. It is skipped here instead, and the
-// result falls through to the default config, which requests no sharing. A
-// claim-sourced config is the author's own mistake, so it is left in place and
-// validateNoSharingWithAdminAccess reports it.
+// TestGetConfigResultsMapSharingSourceForAdminAccess pins which sharing configs
+// reach applySharingConfig for an adminAccess result. DeviceClass-sourced sharing
+// is skipped, so the result falls through to the default config; claim-sourced
+// sharing is left in place for validateNoSharingWithAdminAccess to reject.
 func TestGetConfigResultsMapSharingSourceForAdminAccess(t *testing.T) {
 	sharingConfig := configapi.DefaultGpuConfig()
 	sharingConfig.Sharing = &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy}
@@ -288,19 +246,22 @@ func TestGetConfigResultsMapSharingSourceForAdminAccess(t *testing.T) {
 	}
 }
 
+// TestApplySharingConfigRejectsAdminAccess asserts the validation is reached from
+// the prepare path: the table test above keeps passing if the call site is deleted.
+//
+// The zero-value DeviceState is the assertion, not a shortcut. The guard is the
+// first statement in applySharingConfig, so a rejected input returns before any of
+// the nil fields is dereferenced. Move the guard down and this test panics.
 func TestApplySharingConfigRejectsAdminAccess(t *testing.T) {
 	state := &DeviceState{}
 
-	// An empty claim is fine: the guard never reads the claim. It only appears in the
-	// error messages further down the function, which we never get to here.
+	// The claim and the checkpoint are empty because the guard reads neither.
 	claim := &resourceapi.ResourceClaim{}
 
 	results := []*resourceapi.DeviceRequestAllocationResult{
 		{Request: "admin", Driver: DriverName, AdminAccess: ptr.To(true)},
 	}
 
-	// The checkpoint is nil for the same reason the DeviceState fields are: the guard
-	// returns before anything downstream touches it.
 	_, err := state.applySharingConfig(
 		context.Background(),
 		&configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy},
@@ -308,7 +269,5 @@ func TestApplySharingConfigRejectsAdminAccess(t *testing.T) {
 		results,
 		nil,
 	)
-	// Deliberately a looser substring than the table test uses: this test is about the
-	// call being wired up, not about the exact wording, which is pinned above.
 	require.ErrorContains(t, err, `not allowed for request "admin"`)
 }

--- a/cmd/gpu-kubelet-plugin/sharing_test.go
+++ b/cmd/gpu-kubelet-plugin/sharing_test.go
@@ -178,9 +178,10 @@ func TestValidateNoSharingWithAdminAccess(t *testing.T) {
 }
 
 // TestGetConfigResultsMapSharingSourceForAdminAccess pins which sharing configs
-// reach applySharingConfig for an adminAccess result. DeviceClass-sourced sharing
-// is skipped, so the result falls through to the default config; claim-sourced
-// sharing is left in place for validateNoSharingWithAdminAccess to reject.
+// reach applySharingConfig for an adminAccess result. A config is skipped for
+// that result unless it is claim-sourced AND names the request explicitly; that
+// is exactly the case validateNoSharingWithAdminAccess also rejects, matching
+// what the webhook admits.
 func TestGetConfigResultsMapSharingSourceForAdminAccess(t *testing.T) {
 	sharingConfig := configapi.DefaultGpuConfig()
 	sharingConfig.Sharing = &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy}
@@ -189,15 +190,21 @@ func TestGetConfigResultsMapSharingSourceForAdminAccess(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		source          resourceapi.AllocationConfigSource
+		requests        []string
 		expectedSharing bool
 	}{
 		"DeviceClass sharing config is not applied to an adminAccess result": {
 			source:          resourceapi.AllocationConfigSourceClass,
 			expectedSharing: false,
 		},
-		"claim sharing config still reaches the adminAccess result": {
+		"claim sharing config naming the admin request still reaches it": {
 			source:          resourceapi.AllocationConfigSourceClaim,
+			requests:        []string{"monitor"},
 			expectedSharing: true,
+		},
+		"claim sharing config with no named request is not applied to an adminAccess result": {
+			source:          resourceapi.AllocationConfigSourceClaim,
+			expectedSharing: false,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -223,7 +230,8 @@ func TestGetConfigResultsMapSharingSourceForAdminAccess(t *testing.T) {
 					},
 					Config: []resourceapi.DeviceAllocationConfiguration{
 						{
-							Source: tc.source,
+							Source:   tc.source,
+							Requests: tc.requests,
 							DeviceConfiguration: resourceapi.DeviceConfiguration{
 								Opaque: &resourceapi.OpaqueDeviceConfiguration{
 									Driver:     DriverName,

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -289,14 +289,9 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 			continue
 		}
 
-		// Reject sharing settings that apply to an adminAccess request. The kubelet
-		// plugin enforces the same rule at Prepare() time (see
-		// validateNoSharingWithAdminAccess in cmd/gpu-kubelet-plugin); checking here
-		// as well surfaces the error at admission time instead of at pod start.
-		//
 		// Only on CREATE: spec is immutable on both objects, so an object admitted
-		// before this check existed can never be brought into compliance, and failing
-		// its UPDATEs would block finalizer removal and wedge deletion.
+		// before this check existed can never comply, and failing its UPDATEs would
+		// block finalizer removal.
 		if ar.Request.Operation == admissionv1.Create {
 			if err := validateNoSharingWithAdminAccess(configInterface, config.Requests, adminRequests); err != nil {
 				errs = append(errs, fmt.Errorf("object at %s is invalid: %w", fieldPath, err))
@@ -324,9 +319,9 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 	}
 }
 
-// requestsWithAdminAccess returns the names of all requests in the claim spec that
-// set adminAccess, in spec order. AdminAccess only exists on exact requests:
-// prioritized-list subrequests (firstAvailable) cannot set it.
+// requestsWithAdminAccess returns the names of the requests that set adminAccess.
+// AdminAccess only exists on exact requests: prioritized-list subrequests cannot
+// set it, so a request with no Exactly section is never an admin request.
 func requestsWithAdminAccess(requests []resourceapi.DeviceRequest) []string {
 	var admin []string
 	for _, r := range requests {
@@ -337,22 +332,14 @@ func requestsWithAdminAccess(requests []resourceapi.DeviceRequest) []string {
 	return admin
 }
 
-// validateNoSharingWithAdminAccess rejects a sharing configuration (TimeSlicing or
-// MPS) that applies to a request marked adminAccess. Such a claim is meant to be a
-// read-only observer of a device, but sharing settings are device-global: applying
-// them on Prepare, and tearing them down on Unprepare, would modify state that the
-// workload owning the device depends on. The kubelet plugin rejects the combination
-// at Prepare() time; this check reports the same error at admission time.
+// validateNoSharingWithAdminAccess reports, at admission time, the rule the kubelet
+// plugin enforces at Prepare() time: sharing settings are device-global, so they
+// must not apply to a request that only asks for read-only admin access.
 //
-// Only configs that name their requests explicitly are checked. A config with an
-// empty request list applies to every request in the claim, but the kubelet plugin
-// narrows it further by device type, which the webhook cannot do from the claim spec
-// alone: rejecting on a name match that the plugin would never make would deny valid
-// claims. The plugin catches that case at Prepare() time instead.
-//
-// adminRequests only ever contains names of exact requests, so references to
-// subrequests ("<request>/<subrequest>") can never match, which is correct:
-// subrequests cannot set adminAccess.
+// Only configs that name their requests are checked. A config with an empty request
+// list applies to the whole claim, but the plugin narrows it further by device type,
+// which the webhook cannot see, so matching on name alone would deny claims the
+// plugin would accept. The plugin catches that case instead.
 func validateNoSharingWithAdminAccess(config nvapi.Interface, targetRequests []string, adminRequests []string) error {
 	if len(adminRequests) == 0 || len(targetRequests) == 0 {
 		return nil

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -201,6 +202,7 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 	klog.V(2).Info("admitting resource claim parameters")
 
 	var deviceConfigs []resourceapi.DeviceClaimConfiguration
+	var deviceRequests []resourceapi.DeviceRequest
 	var specPath string
 
 	switch ar.Request.Resource {
@@ -216,6 +218,7 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 			}
 		}
 		deviceConfigs = claim.Spec.Devices.Config
+		deviceRequests = claim.Spec.Devices.Requests
 		specPath = "spec"
 	case resourceClaimTemplateResourceV1, resourceClaimTemplateResourceV1Beta1, resourceClaimTemplateResourceV1Beta2:
 		claimTemplate, err := extractResourceClaimTemplate(ar)
@@ -229,6 +232,7 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 			}
 		}
 		deviceConfigs = claimTemplate.Spec.Spec.Devices.Config
+		deviceRequests = claimTemplate.Spec.Spec.Devices.Requests
 		specPath = "spec.spec"
 	default:
 		msg := fmt.Sprintf("expected resource to be one of the supported versions for resourceclaims or resourceclaimtemplates, got %s", ar.Request.Resource)
@@ -240,6 +244,8 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 			},
 		}
 	}
+
+	adminRequests := requestsWithAdminAccess(deviceRequests)
 
 	var errs []error
 	for configIndex, config := range deviceConfigs {
@@ -280,6 +286,21 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 		// Validate the config to ensure its integrity
 		if err := configInterface.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("object at %s is invalid: %w", fieldPath, err))
+			continue
+		}
+
+		// Reject sharing settings that apply to an adminAccess request. The kubelet
+		// plugin enforces the same rule at Prepare() time (see
+		// validateNoSharingWithAdminAccess in cmd/gpu-kubelet-plugin); checking here
+		// as well surfaces the error at admission time instead of at pod start.
+		//
+		// Only on CREATE: spec is immutable on both objects, so an object admitted
+		// before this check existed can never be brought into compliance, and failing
+		// its UPDATEs would block finalizer removal and wedge deletion.
+		if ar.Request.Operation == admissionv1.Create {
+			if err := validateNoSharingWithAdminAccess(configInterface, config.Requests, adminRequests); err != nil {
+				errs = append(errs, fmt.Errorf("object at %s is invalid: %w", fieldPath, err))
+			}
 		}
 	}
 
@@ -301,4 +322,75 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
+}
+
+// requestsWithAdminAccess returns the names of all requests in the claim spec that
+// set adminAccess, in spec order. AdminAccess only exists on exact requests:
+// prioritized-list subrequests (firstAvailable) cannot set it.
+func requestsWithAdminAccess(requests []resourceapi.DeviceRequest) []string {
+	var admin []string
+	for _, r := range requests {
+		if r.Exactly != nil && r.Exactly.AdminAccess != nil && *r.Exactly.AdminAccess {
+			admin = append(admin, r.Name)
+		}
+	}
+	return admin
+}
+
+// validateNoSharingWithAdminAccess rejects a sharing configuration (TimeSlicing or
+// MPS) that applies to a request marked adminAccess. Such a claim is meant to be a
+// read-only observer of a device, but sharing settings are device-global: applying
+// them on Prepare, and tearing them down on Unprepare, would modify state that the
+// workload owning the device depends on. The kubelet plugin rejects the combination
+// at Prepare() time; this check reports the same error at admission time.
+//
+// Only configs that name their requests explicitly are checked. A config with an
+// empty request list applies to every request in the claim, but the kubelet plugin
+// narrows it further by device type, which the webhook cannot do from the claim spec
+// alone: rejecting on a name match that the plugin would never make would deny valid
+// claims. The plugin catches that case at Prepare() time instead.
+//
+// adminRequests only ever contains names of exact requests, so references to
+// subrequests ("<request>/<subrequest>") can never match, which is correct:
+// subrequests cannot set adminAccess.
+func validateNoSharingWithAdminAccess(config nvapi.Interface, targetRequests []string, adminRequests []string) error {
+	if len(adminRequests) == 0 || len(targetRequests) == 0 {
+		return nil
+	}
+
+	var sharing nvapi.Sharing
+	switch castConfig := config.(type) {
+	case *nvapi.GpuConfig:
+		sharing = castConfig.Sharing
+	case *nvapi.MigDeviceConfig:
+		sharing = castConfig.Sharing
+	default:
+		return nil
+	}
+
+	var strategy string
+	switch {
+	case sharing.IsTimeSlicing():
+		strategy = nvapi.TimeSlicingStrategy
+	case sharing.IsMps():
+		strategy = nvapi.MpsStrategy
+	default:
+		return nil
+	}
+
+	offending := ""
+	for _, t := range targetRequests {
+		if slices.Contains(adminRequests, t) {
+			offending = t
+			break
+		}
+	}
+	if offending == "" {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%s sharing configuration is not allowed for request %q: the request sets adminAccess, and sharing settings apply to the whole device",
+		strategy, offending,
+	)
 }

--- a/cmd/webhook/main_test.go
+++ b/cmd/webhook/main_test.go
@@ -385,6 +385,164 @@ func TestResourceClaimValidatingWebhook(t *testing.T) {
 			expectedAllowed: false,
 			expectedMessage: `1 configs failed to validate: object at spec.spec.devices.config[0].opaque.parameters is invalid: "TimeSlicing" is selected as the GPU sharing strategy, but the "TimeSlicingSettings" feature gate is not enabled`,
 		},
+		// adminAccess + sharing tests: a sharing configuration must not apply to a
+		// request that sets adminAccess (issue #1280).
+		"TimeSlicing sharing targeting an adminAccess request is rejected": {
+			featureGates: map[string]bool{
+				string(featuregates.TimeSlicingSettings): true,
+			},
+			admissionReview: admissionReviewWithObject(
+				resourceClaimWithRequestsAndConfigs(
+					resourceClaimResourceV1Beta1,
+					[]resourceapi.DeviceRequest{
+						deviceRequest("monitor", true),
+					},
+					[]resourceapi.DeviceClaimConfiguration{
+						gpuDeviceConfig(&configapi.GpuConfig{
+							Sharing: &configapi.GpuSharing{
+								Strategy: configapi.TimeSlicingStrategy,
+							},
+						}, "monitor"),
+					},
+				),
+			),
+			expectedAllowed: false,
+			expectedMessage: `1 configs failed to validate: object at spec.devices.config[0].opaque.parameters is invalid: TimeSlicing sharing configuration is not allowed for request "monitor": the request sets adminAccess, and sharing settings apply to the whole device`,
+		},
+		// A config with no request names applies to every request in the claim, but
+		// the kubelet plugin narrows it further by device type and the webhook cannot
+		// see device types. Admitting it here and letting Prepare() reject it is the
+		// conservative choice: the opposite would deny claims the plugin would accept.
+		"MPS sharing applying to all requests is admitted even when a request sets adminAccess": {
+			featureGates: map[string]bool{
+				string(featuregates.MPSSupport): true,
+			},
+			admissionReview: admissionReviewWithObject(
+				resourceClaimWithRequestsAndConfigs(
+					resourceClaimResourceV1Beta1,
+					[]resourceapi.DeviceRequest{
+						deviceRequest("workload", false),
+						deviceRequest("monitor", true),
+					},
+					[]resourceapi.DeviceClaimConfiguration{
+						gpuDeviceConfig(&configapi.GpuConfig{
+							Sharing: &configapi.GpuSharing{
+								Strategy: configapi.MpsStrategy,
+							},
+						}),
+					},
+				),
+			),
+			expectedAllowed: true,
+		},
+		// spec is immutable on both objects, so an object admitted before this check
+		// existed can never comply. Failing its UPDATEs would block finalizer removal.
+		"sharing targeting an adminAccess request is admitted on UPDATE": {
+			featureGates: map[string]bool{
+				string(featuregates.TimeSlicingSettings): true,
+			},
+			admissionReview: asUpdate(admissionReviewWithObject(
+				resourceClaimWithRequestsAndConfigs(
+					resourceClaimResourceV1Beta1,
+					[]resourceapi.DeviceRequest{
+						deviceRequest("monitor", true),
+					},
+					[]resourceapi.DeviceClaimConfiguration{
+						gpuDeviceConfig(&configapi.GpuConfig{
+							Sharing: &configapi.GpuSharing{
+								Strategy: configapi.TimeSlicingStrategy,
+							},
+						}, "monitor"),
+					},
+				),
+			)),
+			expectedAllowed: true,
+		},
+		"sharing targeting only workload requests is allowed alongside an adminAccess request": {
+			featureGates: map[string]bool{
+				string(featuregates.TimeSlicingSettings): true,
+			},
+			admissionReview: admissionReviewWithObject(
+				resourceClaimWithRequestsAndConfigs(
+					resourceClaimResourceV1Beta1,
+					[]resourceapi.DeviceRequest{
+						deviceRequest("workload", false),
+						deviceRequest("monitor", true),
+					},
+					[]resourceapi.DeviceClaimConfiguration{
+						gpuDeviceConfig(&configapi.GpuConfig{
+							Sharing: &configapi.GpuSharing{
+								Strategy: configapi.TimeSlicingStrategy,
+							},
+						}, "workload"),
+					},
+				),
+			),
+			expectedAllowed: true,
+		},
+		"adminAccess request without sharing config is allowed": {
+			admissionReview: admissionReviewWithObject(
+				resourceClaimWithRequestsAndConfigs(
+					resourceClaimResourceV1Beta1,
+					[]resourceapi.DeviceRequest{
+						deviceRequest("monitor", true),
+					},
+					[]resourceapi.DeviceClaimConfiguration{
+						gpuDeviceConfig(&configapi.GpuConfig{}),
+					},
+				),
+			),
+			expectedAllowed: true,
+		},
+		// A prioritized-list request has no Exactly section, so it can never set
+		// adminAccess, and a config that targets one of its subrequests
+		// ("<request>/<subrequest>") must not be matched against the adminAccess
+		// request names.
+		"sharing targeting a subrequest is allowed alongside an adminAccess request": {
+			featureGates: map[string]bool{
+				string(featuregates.TimeSlicingSettings): true,
+			},
+			admissionReview: admissionReviewWithObject(
+				resourceClaimWithRequestsAndConfigs(
+					resourceClaimResourceV1Beta1,
+					[]resourceapi.DeviceRequest{
+						deviceRequestWithSubRequest("workload", "big"),
+						deviceRequest("monitor", true),
+					},
+					[]resourceapi.DeviceClaimConfiguration{
+						gpuDeviceConfig(&configapi.GpuConfig{
+							Sharing: &configapi.GpuSharing{
+								Strategy: configapi.TimeSlicingStrategy,
+							},
+						}, "workload/big"),
+					},
+				),
+			),
+			expectedAllowed: true,
+		},
+		"TimeSlicing sharing targeting an adminAccess request in ResourceClaimTemplate is rejected": {
+			featureGates: map[string]bool{
+				string(featuregates.TimeSlicingSettings): true,
+			},
+			admissionReview: admissionReviewWithObject(
+				resourceClaimTemplateWithRequestsAndConfigs(
+					resourceClaimTemplateResourceV1Beta1,
+					[]resourceapi.DeviceRequest{
+						deviceRequest("monitor", true),
+					},
+					[]resourceapi.DeviceClaimConfiguration{
+						gpuDeviceConfig(&configapi.GpuConfig{
+							Sharing: &configapi.GpuSharing{
+								Strategy: configapi.TimeSlicingStrategy,
+							},
+						}, "monitor"),
+					},
+				),
+			),
+			expectedAllowed: false,
+			expectedMessage: `1 configs failed to validate: object at spec.spec.devices.config[0].opaque.parameters is invalid: TimeSlicing sharing configuration is not allowed for request "monitor": the request sets adminAccess, and sharing settings apply to the whole device`,
+		},
+
 		"MpsStrategy rejected in ResourceClaimTemplate when MPSSupport feature gate is disabled": {
 			featureGates: map[string]bool{
 				string(featuregates.MPSSupport): false,
@@ -465,7 +623,8 @@ func admissionReviewWithObject(obj runtime.Object) *admissionv1.AdmissionReview 
 
 	requestedAdmissionReview := &admissionv1.AdmissionReview{
 		Request: &admissionv1.AdmissionRequest{
-			Resource: resource,
+			Resource:  resource,
+			Operation: admissionv1.Create,
 			Object: runtime.RawExtension{
 				Object: obj,
 			},
@@ -473,6 +632,96 @@ func admissionReviewWithObject(obj runtime.Object) *admissionv1.AdmissionReview 
 	}
 	requestedAdmissionReview.SetGroupVersionKind(admissionv1.SchemeGroupVersion.WithKind("AdmissionReview"))
 	return requestedAdmissionReview
+}
+
+// asUpdate rewrites an admission review to look like an UPDATE of an existing
+// object rather than a CREATE.
+func asUpdate(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionReview {
+	ar.Request.Operation = admissionv1.Update
+	return ar
+}
+
+// deviceRequest builds a v1beta1 device request. In v1beta1 adminAccess is a flat
+// field on the request; the webhook's conversion to v1 moves it under `exactly`.
+func deviceRequest(name string, adminAccess bool) resourceapi.DeviceRequest {
+	r := resourceapi.DeviceRequest{
+		Name:            name,
+		DeviceClassName: DriverName,
+	}
+	if adminAccess {
+		r.AdminAccess = ptr.To(true)
+	}
+	return r
+}
+
+// deviceRequestWithSubRequest builds a prioritized-list request. Such a request
+// carries its details in FirstAvailable rather than at the top level, so after
+// conversion to v1 its Exactly section is nil and it cannot set adminAccess.
+func deviceRequestWithSubRequest(name, subRequestName string) resourceapi.DeviceRequest {
+	return resourceapi.DeviceRequest{
+		Name: name,
+		FirstAvailable: []resourceapi.DeviceSubRequest{
+			{
+				Name:            subRequestName,
+				DeviceClassName: DriverName,
+				AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+				Count:           1,
+			},
+		},
+	}
+}
+
+// gpuDeviceConfig wraps a GpuConfig in a DeviceClaimConfiguration applying to the
+// given request names (none means "applies to all requests").
+func gpuDeviceConfig(gpuConfig *configapi.GpuConfig, requests ...string) resourceapi.DeviceClaimConfiguration {
+	gpuConfig.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   configapi.GroupName,
+		Version: configapi.Version,
+		Kind:    "GpuConfig",
+	})
+	return resourceapi.DeviceClaimConfiguration{
+		Requests: requests,
+		DeviceConfiguration: resourceapi.DeviceConfiguration{
+			Opaque: &resourceapi.OpaqueDeviceConfiguration{
+				Driver: DriverName,
+				Parameters: runtime.RawExtension{
+					Object: gpuConfig,
+				},
+			},
+		},
+	}
+}
+
+func resourceClaimWithRequestsAndConfigs(gvr metav1.GroupVersionResource, requests []resourceapi.DeviceRequest, configs []resourceapi.DeviceClaimConfiguration) *resourceapi.ResourceClaim {
+	return &resourceapi.ResourceClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gvr.Group + "/" + gvr.Version,
+			Kind:       "ResourceClaim",
+		},
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{
+				Requests: requests,
+				Config:   configs,
+			},
+		},
+	}
+}
+
+func resourceClaimTemplateWithRequestsAndConfigs(gvr metav1.GroupVersionResource, requests []resourceapi.DeviceRequest, configs []resourceapi.DeviceClaimConfiguration) *resourceapi.ResourceClaimTemplate {
+	return &resourceapi.ResourceClaimTemplate{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gvr.Group + "/" + gvr.Version,
+			Kind:       "ResourceClaimTemplate",
+		},
+		Spec: resourceapi.ResourceClaimTemplateSpec{
+			Spec: resourceapi.ResourceClaimSpec{
+				Devices: resourceapi.DeviceClaim{
+					Requests: requests,
+					Config:   configs,
+				},
+			},
+		},
+	}
 }
 
 func resourceClaimWithGpuConfigs(gvr metav1.GroupVersionResource, gpuConfigs ...*configapi.GpuConfig) *resourceapi.ResourceClaim {


### PR DESCRIPTION
Fixes #1280

## Problem

A request allocated with `adminAccess` is meant to be a read-only observer: it deliberately bypasses the exclusivity check so a monitoring or debugging pod can attach to a device another claim already owns.

Sharing settings (TimeSlicing, MPS) break that contract, because they are properties of the **device**, not of the claim that asks for them. There is one time-slice setting per GPU, and one MPS control daemon per GPU. So an `adminAccess` claim carrying a sharing config does damage twice:

1. On `Prepare()`, `applySharingConfig` writes the observer's settings over the settings the owning workload established.
2. On `Unprepare()`, teardown stops the MPS daemon and resets the time slice, because from its point of view it is cleaning up its own config. The owning workload is still running and still depends on that state, so deleting a debug pod disrupts production.

## Solution

Reject the combination rather than making `adminAccess` claims participate in reference counting and prepare/unprepare lifecycle coordination, as the issue proposes.

**Kubelet plugin** (`applySharingConfig`): the guard is the first statement of the function, before anything reads `perGPUAllocatable` or calls `tsManager.SetTimeSlice` / starts an MPS daemon, so a rejected claim never touches the GPU. `applyConfig` routes both `GpuConfig` and `MigDeviceConfig` through this function, so one guard covers both. The check loops over every allocation result in the group, since a config with an empty `requests` list can cover a workload request and an `adminAccess` request together, in either order.

**DeviceClass-sourced sharing is skipped rather than rejected.** A sharing config inherited from the DeviceClass applies to every claim against that class and the claim author cannot remove it, so rejecting it would leave every monitoring claim against that class permanently unpreparable. `OpaqueDeviceConfig` now carries the `AllocationConfigSource` that `GetOpaqueDeviceConfigs` was already discarding, and `getConfigResultsMap` skips such a config for `adminAccess` results, falling through to the default config, which requests no sharing. Sharing the claim itself asks for is still rejected.

**Validating webhook**: reports the same error at admission time so the failure surfaces at `kubectl apply` instead of at pod start. Two deliberate limits:

- It checks only configs that name their requests. A claim-wide config is narrowed further by device type in the plugin (`matchesDeviceType`), which the webhook cannot do from the claim spec alone, so rejecting on a name match the plugin would never make would deny valid claims. The plugin catches that case at `Prepare()`.
- It checks only on `CREATE`. `spec` is immutable on both objects, so an object admitted before this check existed can never be brought into compliance, and failing its `UPDATE`s would block finalizer removal.

## Notes for the reviewer

- The issue says "during validation or preparation". This does both. The plugin check is the enforcement; the webhook check is only there for the earlier, clearer error. Happy to drop the webhook half if you prefer the smaller change.
- Skipping DeviceClass-sourced sharing is slightly beyond the literal ask. Without it, a single DeviceClass default would break every `adminAccess` claim in the cluster.
- The check is not gated behind `TimeSlicingSettings`/`MPSSupport`. A claim that would corrupt device state as soon as an operator enables a gate should not be accepted while that gate happens to be disabled.

## Testing

- `TestValidateNoSharingWithAdminAccess`: 7 cases crossing "config requests sharing" against "any result is adminAccess", including MPS on a MIG device and an admin result placed second in a mixed group.
- `TestApplySharingConfigRejectsAdminAccess`: asserts the guard is reached from the prepare path, using a zero-value `DeviceState` so that moving the guard below any device-state access panics rather than silently passing.
- `TestGetConfigResultsMapSharingSourceForAdminAccess`: DeviceClass-sourced sharing does not reach an `adminAccess` result; claim-sourced sharing still does.
- Webhook table: rejections for a named `adminAccess` request on both ResourceClaim and ResourceClaimTemplate, and acceptances for workload-only targets, no sharing, a subrequest target, a claim-wide config, and `UPDATE`.

`go test ./...`, `go vet ./cmd/...` and `golangci-lint run` are clean on Linux. Not exercised on real hardware.
