### PR TITLE
Prepare: dont rollback partially prepared vfio claims

### DIFF
--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -166,6 +166,26 @@ func (d AllocatableDevices) GetGPUs() []*AllocatableDevice {
 	return devices
 }
 
+func (d AllocatableDevices) GetMigStaticDevices() []*AllocatableDevice {
+	var devices []*AllocatableDevice
+	for _, device := range d {
+		if device.Type() == MigStaticDeviceType {
+			devices = append(devices, device)
+		}
+	}
+	return devices
+}
+
+func (d AllocatableDevices) GetMigDynamicDevices() []*AllocatableDevice {
+	var devices []*AllocatableDevice
+	for _, device := range d {
+		if device.Type() == MigDynamicDeviceType {
+			devices = append(devices, device)
+		}
+	}
+	return devices
+}
+
 func (d AllocatableDevices) GetVfioDevices() []*AllocatableDevice {
 	var devices []*AllocatableDevice
 	for _, device := range d {

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -333,8 +333,8 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	// optimized into filling the gaps).
 	if exists && preparedClaim.CheckpointState == ClaimCheckpointStatePrepareStarted {
 		klog.V(4).Infof("Claim %s already in PrepareStarted state: attempt rollback before new prepare", ResourceClaimToString(claim))
-		if err := s.unpreparePartiallyPrepairedClaim(ctx, claimUID, preparedClaim, cp); err != nil {
-			return nil, fmt.Errorf("unprepare failed for partially prepared claim %s failed: %w", PreparedClaimToString(&preparedClaim, claimUID), err)
+		if err := s.rollbackPartiallyPreparedClaim(ctx, claimUID, preparedClaim, cp); err != nil {
+			return nil, fmt.Errorf("rollback failed for partially prepared claim %s failed: %w", PreparedClaimToString(&preparedClaim, claimUID), err)
 		}
 	}
 
@@ -508,7 +508,7 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 
 	switch pc.CheckpointState {
 	case ClaimCheckpointStatePrepareStarted:
-		if err := s.unpreparePartiallyPrepairedClaim(ctx, claimUID, pc, checkpoint); err != nil {
+		if err := s.unpreparePartiallyPreparedClaim(ctx, claimUID, pc, checkpoint); err != nil {
 			return fmt.Errorf("unprepare failed for partially prepared claim %s failed: %w", claimRef.String(), err)
 		}
 	case ClaimCheckpointStatePrepareCompleted:
@@ -581,6 +581,108 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 	return nil
 }
 
+// Rollback previously partially prepared claim.
+//
+// This is called when a previous Prepare() attempt was partially performed and
+// failed. We rollback the partially prepared claim before re-attempting the
+// prepare workflow.
+//
+// Note: We do not attempt rollback of VFIO devices during Prepare() as its
+// device configuration is idempotent.
+func (s *DeviceState) rollbackPartiallyPreparedClaim(ctx context.Context, cuid string, pc PreparedClaim, checkpoint *Checkpoint) error {
+	// Attempt rollback of MIG devices if DynamicMIG is enabled.
+	if featuregates.Enabled(featuregates.DynamicMIG) {
+		allocDevsForClaim := s.getAllocatableDevicesForClaim(cuid, pc)
+		migDevices := allocDevsForClaim.GetMigDynamicDevices()
+		if len(migDevices) > 0 {
+			klog.V(2).Infof("unprepare: MIG rollback for partially prepared claim %s (devices: %d)", PreparedClaimToString(&pc, cuid), len(migDevices))
+
+			err := s.rollbackPartiallyPreparedMIGDevices(ctx, cuid, pc, checkpoint)
+			if err != nil {
+				return fmt.Errorf("rollback partially prepared MIG devices failed: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Unprepare previously partially prepared claim.
+//
+// This is called during Unprepare() for a claim that is known to be stale (not in the API
+// server or terminating). Here, the `checkpoint` data is fresh enough; there is no other
+// that currently legitimately owns the device represented in `pc`. This usually happens
+// when the Prepare() call failed or did not finish and we want to clean up the
+// `PrepareStarted` claim.
+func (s *DeviceState) unpreparePartiallyPreparedClaim(ctx context.Context, cuid string, pc PreparedClaim, checkpoint *Checkpoint) error {
+	allocDevsForClaim := s.getAllocatableDevicesForClaim(cuid, pc)
+
+	// Attempt rollback of MIG devices if DynamicMIG is enabled.
+	if featuregates.Enabled(featuregates.DynamicMIG) {
+		migDevices := allocDevsForClaim.GetMigDynamicDevices()
+		if len(migDevices) > 0 {
+			klog.V(2).Infof("unprepare: MIG rollback for partially prepared claim %s (devices: %d)", PreparedClaimToString(&pc, cuid), len(migDevices))
+
+			err := s.rollbackPartiallyPreparedMIGDevices(ctx, cuid, pc, checkpoint)
+			if err != nil {
+				return fmt.Errorf("rollback partially prepared MIG devices failed: %w", err)
+			}
+		}
+	}
+
+	// Attempt rollback of VFIO devices if PassthroughSupport is enabled.
+	if featuregates.Enabled(featuregates.PassthroughSupport) {
+		vfioDevices := allocDevsForClaim.GetVfioDevices()
+		if len(vfioDevices) > 0 {
+			klog.V(2).Infof("unprepare: VFIO rollback for partially prepared claim %s (devices: %d)", PreparedClaimToString(&pc, cuid), len(vfioDevices))
+
+			err := s.rollbackPartiallyPreparedVFIODevices(ctx, vfioDevices)
+			if err != nil {
+				return fmt.Errorf("rollback partially prepared VFIO devices failed: %w", err)
+			}
+		}
+	}
+
+	// If FM partitioning is enabled, then deactivate the partition
+	// for the devices in the claim. At this point, the gpuInfo objects
+	// for all devices in the claim are expected to have been discovered.
+	// Note: This is only relevant for GPU/VFIO devices and the operation
+	// itself is idempotent so even if the partitions were never
+	// activated, its safe to call this function and it'll be a no-op.
+	if s.fabricManagerPartitioningEnabled() {
+		if err := s.deactivateFabricPartition(cuid, &pc, checkpoint); err != nil {
+			return fmt.Errorf("error deactivating fabric partition: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// getAllocatableDevicesForClaim returns the allocatable devices for a given
+// checkpointed claim.
+func (s *DeviceState) getAllocatableDevicesForClaim(claimUID string, pc PreparedClaim) AllocatableDevices {
+	allocDevsForClaim := make(AllocatableDevices)
+
+	if pc.Status.Allocation == nil {
+		return allocDevsForClaim
+	}
+
+	for _, r := range pc.Status.Allocation.Devices.Results {
+		if r.Driver != DriverName {
+			continue
+		}
+		device := s.perGPUAllocatable.GetAllocatableDevice(r.Device)
+		if device == nil {
+			// The allocatable may legitimately be absent, e.g. the sibling
+			// GPU was already rediscovered by a previous rollback attempt.
+			klog.V(4).Infof("Partial unprepare: allocatable not found for device %q (claim %s); skipping", r.Device, PreparedClaimToString(&pc, claimUID))
+			continue
+		}
+		allocDevsForClaim[r.Device] = device
+	}
+	return allocDevsForClaim
+}
+
 // Revert previous and potentially partial MIG device creation (not acknowledged
 // by transitioning the claim state to PrepareCompleted). Can we safely revert
 // that based on the information in checkpoint? As we didn't pull through with
@@ -615,69 +717,7 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 //
 // Construct a list of those claims that, according to the current snapshot,
 // have been properly prepared.
-//
-// This is called either for a claim that is known to be stale (not in the API
-// server) or for a claim that is not stale but that _we_ are currently
-// preparing. In both cases, the `checkpoint` data is fresh enough; there is no
-// other entity that currently legitimately owns the device represented in `pc`.
-func (s *DeviceState) unpreparePartiallyPrepairedClaim(ctx context.Context, cuid string, pc PreparedClaim, checkpoint *Checkpoint) error {
-	// Roll back VFIO passthrough side effects. A previous Prepare() attempt may
-	// have already bound one or more GPUs to vfio-pci. Unlike the completed
-	// path that operates on checkpointed PreparedDevices, a partially prepared
-	// claim has no PreparedDevices checkpointed yet, so we resolve the affected
-	// VFIO devices from the allocation results and mirror the completed-path
-	if featuregates.Enabled(featuregates.PassthroughSupport) && pc.Status.Allocation != nil {
-		var vfioDevices []*AllocatableDevice
-		for _, r := range pc.Status.Allocation.Devices.Results {
-			if r.Driver != DriverName {
-				continue
-			}
-			device := s.perGPUAllocatable.GetAllocatableDevice(r.Device)
-			if device == nil {
-				// The allocatable may legitimately be absent, e.g. the sibling
-				// GPU was already rediscovered by a previous rollback attempt.
-				klog.V(4).Infof("Partial VFIO rollback: allocatable not found for device %q (claim %s); skipping", r.Device, cuid)
-				continue
-			}
-			if device.Type() != VfioDeviceType {
-				continue
-			}
-			vfioDevices = append(vfioDevices, device)
-		}
-
-		if len(vfioDevices) > 0 {
-			klog.V(2).Infof("Partial VFIO rollback: unpreparing %d VFIO device(s) for partially prepared claim %s", len(vfioDevices), cuid)
-
-			// Mirror the completed-claim teardown ordering: first switch each
-			// GPU back to the nvidia driver, then rediscover so each VFIO
-			// device's parent GpuInfo is repopulated with fresh Fabric Manager
-			// info, and only then deactivate the FM partition.
-			for _, device := range vfioDevices {
-				info := device.Vfio
-				if err := s.vfioPciManager.Unconfigure(ctx, info); err != nil {
-					return fmt.Errorf("error unconfiguring vfio device %q: %w", info.CanonicalName(), err)
-				}
-			}
-
-			for _, device := range vfioDevices {
-				if err := s.discoverSiblingAllocatables(device); err != nil {
-					return fmt.Errorf("error discovering sibling allocatables for vfio device %q: %w", device.Vfio.CanonicalName(), err)
-				}
-			}
-		}
-	}
-
-	if s.fabricManagerPartitioningEnabled() {
-		if err := s.deactivateFabricPartition(cuid, &pc, checkpoint); err != nil {
-			return fmt.Errorf("error deactivating fabric partition: %w", err)
-		}
-	}
-
-	if !featuregates.Enabled(featuregates.DynamicMIG) {
-		klog.Infof("unprepare: no MIG rollback (DynamicMIG disabled) for partially prepared claim %s (devices: %v)", PreparedClaimToString(&pc, cuid), pc.Status.Allocation.Devices.Results)
-		return nil
-	}
-
+func (s *DeviceState) rollbackPartiallyPreparedMIGDevices(ctx context.Context, claimUID string, pc PreparedClaim, checkpoint *Checkpoint) error {
 	// When DynamicMIG is enabled, try to identify an orphaned MIG device
 	// corresponding to `pc`. To that end, inspect which currently (completely)
 	// prepared claims use which devices.
@@ -702,6 +742,43 @@ func (s *DeviceState) unpreparePartiallyPrepairedClaim(ctx context.Context, cuid
 		klog.V(1).Infof("Device %s is a MIG device, DynamicMIG mode: deleteMigDevIfExistsAndNotUsedByCompletedClaim()", devname)
 		if err := s.deleteMigDevIfExistsAndNotUsedByCompletedClaim(ms, devname, completedClaims); err != nil {
 			return fmt.Errorf("deleteMigDevIfExistsAndNotUsedByCompletedClaim failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Rollback VFIO passthrough side effects. A previous Prepare() attempt may
+// have already bound one or more GPUs to vfio-pci (or variant). Unlike the
+// PrepareCompleted state where we have checkpointed PreparedDevices, a
+// partially prepared claim has no PreparedDevices checkpointed yet, so we
+// retrieve the affected VFIO devices from the allocation results and mirror
+// the completed-path teardown.
+//
+// Note: For VFIO devices in this state, it may be possible that a driver
+// change operation has not completed during the past Prepare() call. In this
+// case, rollback will fail until the driver change operation is unclogged.
+func (s *DeviceState) rollbackPartiallyPreparedVFIODevices(ctx context.Context, vfioDevices []*AllocatableDevice) error {
+	if len(vfioDevices) == 0 {
+		return nil
+	}
+
+	for _, device := range vfioDevices {
+		if device.Type() != VfioDeviceType {
+			continue
+		}
+
+		info := device.Vfio
+		// Unconfigure() is idempotent and is expected to revert any
+		// changes from the past Configure() call.
+		if err := s.vfioPciManager.Unconfigure(ctx, info); err != nil {
+			return fmt.Errorf("error unconfiguring vfio device %q: %w", info.CanonicalName(), err)
+		}
+
+		// Rediscover all siblings of the VFIO device now that the GPU
+		// is back on the nvidia driver.
+		if err := s.discoverSiblingAllocatables(device); err != nil {
+			return fmt.Errorf("error discovering sibling allocatables for vfio device %q: %w", info.CanonicalName(), err)
 		}
 	}
 

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -126,6 +126,106 @@ func TestValidateNoOverlappingPreparedDevices(t *testing.T) {
 	}
 }
 
+func TestGetAllocatableDevicesForClaim(t *testing.T) {
+	gpu0 := &AllocatableDevice{Gpu: &GpuInfo{UUID: "GPU-0000"}}
+	vfio1 := &AllocatableDevice{Vfio: &VfioDeviceInfo{UUID: "VFIO-0001"}}
+	mig2 := &AllocatableDevice{MigDynamic: &MigSpec{Parent: &GpuInfo{UUID: "GPU-0002"}}}
+	claimStatus := func(results ...resourceapi.DeviceRequestAllocationResult) resourceapi.ResourceClaimStatus {
+		return resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{Results: results},
+			},
+		}
+	}
+	state := &DeviceState{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				"0000:00:00.0": {
+					"gpu-0": gpu0,
+				},
+				"0000:00:01.0": {
+					"vfio-1": vfio1,
+				},
+				"0000:00:02.0": {
+					"mig-2": mig2,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		status resourceapi.ResourceClaimStatus
+		want   AllocatableDevices
+	}{
+		{
+			name:   "nil allocation",
+			status: resourceapi.ResourceClaimStatus{},
+			want:   AllocatableDevices{},
+		},
+		{
+			name:   "empty allocation results",
+			status: claimStatus(),
+			want:   AllocatableDevices{},
+		},
+		{
+			name: "returns GPU device",
+			status: claimStatus(
+				resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: "gpu-0"},
+			),
+			want: AllocatableDevices{
+				"gpu-0": gpu0,
+			},
+		},
+		{
+			name: "returns VFIO device",
+			status: claimStatus(
+				resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: "vfio-1"},
+			),
+			want: AllocatableDevices{
+				"vfio-1": vfio1,
+			},
+		},
+		{
+			name: "returns MIG device",
+			status: claimStatus(
+				resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: "mig-2"},
+			),
+			want: AllocatableDevices{
+				"mig-2": mig2,
+			},
+		},
+		{
+			name: "ignores devices from other drivers",
+			status: claimStatus(
+				resourceapi.DeviceRequestAllocationResult{Driver: "other.example.com", Device: "gpu-0"},
+			),
+			want: AllocatableDevices{},
+		},
+		{
+			name: "skips missing allocatable devices",
+			status: claimStatus(
+				resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: "missing"},
+				resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: "gpu-0"},
+			),
+			want: AllocatableDevices{
+				"gpu-0": gpu0,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := PreparedClaim{Status: tc.status}
+
+			got := state.getAllocatableDevicesForClaim("claim-uid", pc)
+
+			require.NotNil(t, got)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestApplySharingConfigMpsDisallowedWithConsumableShares(t *testing.T) {
 	perGPU := &PerGPUAllocatableDevices{
 		allocatablesMap: map[PCIBusID]AllocatableDevices{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
Differentiate between expected functionality for partially prepared claims during `Prepare()` and `Unprepare()`:

During `Prepare()`, if a claim is in `PrepareStarted` state (because the previous `Prepare()` attempt failed due to an error), then we are expected to rollback all dynamically created MIG devices.

During `Unprepare()`, if a claim is in `PrepareStarted` state (because the previous `Prepare()` attempt failed due to an error) and the claim is now terminating, then we are expected to rollback all dynamically created MIG devices and all partially prepared GPU/VFIO devices. For GPU/VFIO devices, if fabric manager partitioning is enabled, any partitions that may have been activated for them should now be deactivated.

The reason for differentiation is specifically due to VFIO devices which are prone to failures if the node is not free of GPU client processes such as `DCGM`. In this scenario, the GPU reconfiguration as a passthrough device may be blocked by the GPU client processes and this will cause `Prepare()` failure after a 15s timeout. Kubelet will continue to issue `NodePrepareResources` requests with exponential backoff until the preparation succeeds. In between this time, if the GPU becomes free and completes reconfiguration, we do not want to revert the painful task and be prone to the same failure again.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Partially Fixes #1255 

#### Special notes for your reviewer:
* Basic testing with `PassthroughSupport` is done.
* Verified no regression with `FabricManagerPartitioning`.

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
