### PR TITLE
test(gpu-kubelet-plugin): add unit tests for root.go & types.go

### DIFF
--- a/cmd/gpu-kubelet-plugin/root_test.go
+++ b/cmd/gpu-kubelet-plugin/root_test.go
@@ -122,3 +122,91 @@ func TestFindFile(t *testing.T) {
 		})
 	}
 }
+
+func TestFindFileFollowsSymlink(t *testing.T) {
+	const name = "libnvidia-ml.so.1"
+
+	t.Run("symlink to a regular file is resolved", func(t *testing.T) {
+		testRoot := t.TempDir()
+		target := filepath.Join(testRoot, "opt", name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+		require.NoError(t, os.WriteFile(target, []byte{}, 0o644))
+
+		linkDir := filepath.Join(testRoot, "usr", "lib64")
+		require.NoError(t, os.MkdirAll(linkDir, 0o755))
+		require.NoError(t, os.Symlink(target, filepath.Join(linkDir, name)))
+
+		found, err := root(testRoot).findFile(name, "usr/lib64")
+		require.NoError(t, err)
+		want, err := filepath.EvalSymlinks(target)
+		require.NoError(t, err)
+		require.Equal(t, want, found)
+	})
+
+	t.Run("symlink to a directory is rejected", func(t *testing.T) {
+		testRoot := t.TempDir()
+		targetDir := filepath.Join(testRoot, "opt", name)
+		require.NoError(t, os.MkdirAll(targetDir, 0o755))
+
+		linkDir := filepath.Join(testRoot, "usr", "lib64")
+		require.NoError(t, os.MkdirAll(linkDir, 0o755))
+		require.NoError(t, os.Symlink(targetDir, filepath.Join(linkDir, name)))
+
+		_, err := root(testRoot).findFile(name, "usr/lib64")
+		require.Error(t, err)
+	})
+
+	t.Run("dangling symlink is rejected", func(t *testing.T) {
+		testRoot := t.TempDir()
+		linkDir := filepath.Join(testRoot, "usr", "lib64")
+		require.NoError(t, os.MkdirAll(linkDir, 0o755))
+		require.NoError(t, os.Symlink(filepath.Join(testRoot, "missing.so"), filepath.Join(linkDir, name)))
+
+		_, err := root(testRoot).findFile(name, "usr/lib64")
+		require.Error(t, err)
+	})
+}
+
+func TestRootGetDevRoot(t *testing.T) {
+	withDev := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(withDev, "dev"), 0o755))
+	require.Equal(t, withDev, root(withDev).getDevRoot())
+
+	require.Equal(t, "/", root(t.TempDir()).getDevRoot())
+
+	devIsFile := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(devIsFile, "dev"), []byte{}, 0o644))
+	require.Equal(t, "/", root(devIsFile).getDevRoot())
+}
+
+func TestRootGetDriverAndBinaryPaths(t *testing.T) {
+	testRoot := t.TempDir()
+	writeFile := func(rel string) string {
+		p := filepath.Join(testRoot, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte{}, 0o644))
+		want, err := filepath.EvalSymlinks(p)
+		require.NoError(t, err)
+		return want
+	}
+	wantNVML := writeFile("usr/lib64/libnvidia-ml.so.1")
+	wantFM := writeFile("usr/lib64/libnvfm.so")
+	wantSMI := writeFile("usr/bin/nvidia-smi")
+
+	r := root(testRoot)
+
+	got, err := r.getDriverLibraryPath()
+	require.NoError(t, err)
+	require.Equal(t, wantNVML, got)
+
+	got, err = r.getFMLibraryPath()
+	require.NoError(t, err)
+	require.Equal(t, wantFM, got)
+
+	got, err = r.getNvidiaSMIPath()
+	require.NoError(t, err)
+	require.Equal(t, wantSMI, got)
+
+	_, err = root(t.TempDir()).getDriverLibraryPath()
+	require.Error(t, err)
+}

--- a/cmd/gpu-kubelet-plugin/types_test.go
+++ b/cmd/gpu-kubelet-plugin/types_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+)
+
+func TestResourceClaimToString(t *testing.T) {
+	rc := &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "claim-a", UID: "uid-1"},
+	}
+	assert.Equal(t, "ns/claim-a:uid-1", ResourceClaimToString(rc))
+}
+
+func TestPreparedClaimToString(t *testing.T) {
+	pc := &PreparedClaim{Name: "claim-b", Namespace: "ns"}
+	assert.Equal(t, "ns/claim-b:uid-9", PreparedClaimToString(pc, "uid-9"))
+}
+
+func TestClaimsToStrings(t *testing.T) {
+	claims := []*resourcev1.ResourceClaim{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "a", UID: "1"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "b", UID: "2"}},
+	}
+	assert.Equal(t, []string{"ns/a:1", "ns/b:2"}, ClaimsToStrings(claims))
+	assert.Empty(t, ClaimsToStrings(nil))
+}
+
+func TestClaimRefsToStrings(t *testing.T) {
+	refs := []kubeletplugin.NamespacedObject{
+		{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "r1"}, UID: "u1"},
+		{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "r2"}}, // no UID
+	}
+	assert.Equal(t, []string{"ns/r1:u1", "ns/r2"}, ClaimRefsToStrings(refs))
+
+	assert.Empty(t, ClaimRefsToStrings(nil))
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds unit tests for `cmd/gpu-kubelet-plugin/root.go` and
`cmd/gpu-kubelet-plugin/types.go`:

* `root.go`: findFile symlink handling (a symlink to a regular file is
  resolved; a symlink to a directory or a dangling symlink is rejected),
  getDevRoot (root with a /dev directory vs a missing or non-directory /dev),
  and the getDriverLibraryPath / getFMLibraryPath / getNvidiaSMIPath wrappers.
* `types.go`: the string formatters ResourceClaimToString,
  PreparedClaimToString, ClaimsToStrings, and ClaimRefsToStrings.

This is a test-only change; no production code is modified.

#### Which issue(s) this PR is related to:

Fixes #1301

#### Special notes for your reviewer:

Part of #1297.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

```docs

```

#### Checklist

- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed