### PR TITLE
checkpoint: marshal empty mpsControlDaemonID to avoid corruption

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -59,7 +59,7 @@ type OpaqueDeviceConfig struct {
 }
 
 type DeviceConfigState struct {
-	MpsControlDaemonID string              `json:"mpsControlDaemonID,omitempty"`
+	MpsControlDaemonID string              `json:"mpsControlDaemonID"`
 	MpsApplied         *bool               `json:"mpsApplied,omitempty"`
 	Config             configapi.Interface `json:"-"` // don't serialize this.
 	containerEdits     *cdiapi.ContainerEdits


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/commit/75a2d69f43bd7980b4ba2149bd02a2d55f8d4dc9 introduced a breaking change when it made `mpsControlDaemonID` optional in JSON marshaling. This causes checkpoint corruption in the following scenario:
1. Run DRA driver v0.4.0
2. Deploy GPU workloads
3. Upgrade to a ToT build

The upgrade fails due to the checkpoint corruption with the following issue:
```
E0811 18:00:54.746215       1 device_state.go:854] checkpoint failed checksum verification; unified diff (on-disk vs re-marshaled by current binary):
--- on-disk
+++ re-marshaled
@@ -85,9 +85,7 @@
                 "mig": null
               }
             ],
-            "configState": {
-              "mpsControlDaemonID": ""
-            }
+            "configState": {}
           }
         ]
       },
```

This change just reverts the json `omitempty` tag for `mpsControlDaemonID` to quickly mitigate the corruption.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
N/A

#### Special notes for your reviewer:
Tested the failing scenario and validated there's no corruption with the fix

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note

```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
