### PR TITLE
mig: skip other drivers' results during partial rollback

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -740,6 +740,9 @@ func (s *DeviceState) rollbackPartiallyPreparedMIGDevices(ctx context.Context, c
 	}
 
 	for _, r := range pc.Status.Allocation.Devices.Results {
+		if r.Driver != DriverName {
+			continue
+		}
 		devname := r.Device
 		ms, err := NewMigSpecTupleFromCanonicalName(devname)
 		if err != nil {

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -674,14 +675,45 @@ func TestIsAdminAccessIgnoresOtherDrivers(t *testing.T) {
 	require.True(t, isAdminAccess(results))
 }
 
+// nvmlStub answers the handful of calls the MIG teardown path makes and counts
+// the parent lookup. Anything else it is asked for panics, which is the signal
+// we want if that path ever grows.
+type nvmlStub struct {
+	nvml.Interface
+	handleLookups int
+}
+
+func (s *nvmlStub) InitWithFlags(uint32) nvml.Return { return nvml.SUCCESS }
+func (s *nvmlStub) Shutdown() nvml.Return            { return nvml.SUCCESS }
+
+func (s *nvmlStub) DeviceGetHandleByUUID(string) (nvml.Device, nvml.Return) {
+	s.handleLookups++
+	return migFreeGPU{}, nvml.SUCCESS
+}
+
+// migFreeGPU is a GPU with no MIG devices on it. A real one answers a count of
+// zero here, so the spec lookup iterates nothing and finds nothing to delete.
+type migFreeGPU struct {
+	nvml.Device
+}
+
+func (migFreeGPU) GetMaxMigDeviceCount() (int, nvml.Return) { return 0, nvml.SUCCESS }
+
 // Prepare() checkpoints the claim status whole, so a ResourceClaim allocated
 // from more than one driver leaves results here that we do not own.
 func TestRollbackPartiallyPreparedMIGDevicesIgnoresOtherDrivers(t *testing.T) {
 	const ownedMIG = "gpu-0-mig-1g10gb-19-0"
 
-	// nvdevlib is the only part of this path that talks to hardware, so leaving
-	// it nil turns reaching MIG teardown into a panic the test can see.
-	state := &DeviceState{}
+	// MIG teardown reaches hardware by looking the parent GPU up through NVML, so
+	// counting that lookup is how a case sees which results got that far.
+	newState := func() (*DeviceState, *nvmlStub) {
+		nvmllib := &nvmlStub{}
+		state := &DeviceState{nvdevlib: &deviceLib{
+			nvmllib:         nvmllib,
+			devhandleByUUID: make(map[string]nvml.Device),
+		}}
+		return state, nvmllib
+	}
 
 	claimWith := func(results ...resourceapi.DeviceRequestAllocationResult) PreparedClaim {
 		return PreparedClaim{Status: resourceapi.ResourceClaimStatus{
@@ -694,6 +726,8 @@ func TestRollbackPartiallyPreparedMIGDevicesIgnoresOtherDrivers(t *testing.T) {
 	// Only a dynamic MIG device of ours brings either caller here, so the mixed
 	// claim carries one, held back from teardown by a completed claim.
 	t.Run("another driver's MIG-shaped name", func(t *testing.T) {
+		state, nvmllib := newState()
+
 		completed := claimWith(resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: ownedMIG})
 		completed.CheckpointState = ClaimCheckpointStatePrepareCompleted
 
@@ -702,22 +736,26 @@ func TestRollbackPartiallyPreparedMIGDevicesIgnoresOtherDrivers(t *testing.T) {
 			resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: ownedMIG},
 		)
 
-		var err error
-		require.NotPanics(t, func() {
-			err = state.rollbackPartiallyPreparedMIGDevices(context.Background(), "claim-uid", pc,
-				&Checkpoint{V2: &CheckpointV2{PreparedClaims: PreparedClaimsByUID{"completed": completed}}})
-		}, "a result owned by another driver MUST NOT reach MIG teardown")
+		err := state.rollbackPartiallyPreparedMIGDevices(context.Background(), "claim-uid", pc,
+			&Checkpoint{V2: &CheckpointV2{PreparedClaims: PreparedClaimsByUID{"completed": completed}}})
+
 		require.NoError(t, err)
+		require.Zero(t, nvmllib.handleLookups,
+			"a result owned by another driver MUST NOT reach MIG teardown")
 	})
 
 	// Without this the case above would pass just as well if the loop stopped
 	// looking at MIG devices at all.
 	t.Run("our own MIG name", func(t *testing.T) {
+		state, nvmllib := newState()
+
 		pc := claimWith(resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: ownedMIG})
 
-		require.Panics(t, func() {
-			_ = state.rollbackPartiallyPreparedMIGDevices(context.Background(), "claim-uid", pc,
-				&Checkpoint{V2: &CheckpointV2{PreparedClaims: PreparedClaimsByUID{}}})
-		}, "our own result MUST still reach MIG teardown")
+		err := state.rollbackPartiallyPreparedMIGDevices(context.Background(), "claim-uid", pc,
+			&Checkpoint{V2: &CheckpointV2{PreparedClaims: PreparedClaimsByUID{}}})
+
+		require.NoError(t, err)
+		require.Equal(t, 1, nvmllib.handleLookups,
+			"our own result MUST still reach MIG teardown")
 	})
 }

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -673,3 +673,51 @@ func TestIsAdminAccessIgnoresOtherDrivers(t *testing.T) {
 
 	require.True(t, isAdminAccess(results))
 }
+
+// Prepare() checkpoints the claim status whole, so a ResourceClaim allocated
+// from more than one driver leaves results here that we do not own.
+func TestRollbackPartiallyPreparedMIGDevicesIgnoresOtherDrivers(t *testing.T) {
+	const ownedMIG = "gpu-0-mig-1g10gb-19-0"
+
+	// nvdevlib is the only part of this path that talks to hardware, so leaving
+	// it nil turns reaching MIG teardown into a panic the test can see.
+	state := &DeviceState{}
+
+	claimWith := func(results ...resourceapi.DeviceRequestAllocationResult) PreparedClaim {
+		return PreparedClaim{Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{Results: results},
+			},
+		}}
+	}
+
+	// Only a dynamic MIG device of ours brings either caller here, so the mixed
+	// claim carries one, held back from teardown by a completed claim.
+	t.Run("another driver's MIG-shaped name", func(t *testing.T) {
+		completed := claimWith(resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: ownedMIG})
+		completed.CheckpointState = ClaimCheckpointStatePrepareCompleted
+
+		pc := claimWith(
+			resourceapi.DeviceRequestAllocationResult{Driver: "other.driver.com", Device: "gpu-0-mig-foreign-19-0"},
+			resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: ownedMIG},
+		)
+
+		var err error
+		require.NotPanics(t, func() {
+			err = state.rollbackPartiallyPreparedMIGDevices(context.Background(), "claim-uid", pc,
+				&Checkpoint{V2: &CheckpointV2{PreparedClaims: PreparedClaimsByUID{"completed": completed}}})
+		}, "a result owned by another driver MUST NOT reach MIG teardown")
+		require.NoError(t, err)
+	})
+
+	// Without this the case above would pass just as well if the loop stopped
+	// looking at MIG devices at all.
+	t.Run("our own MIG name", func(t *testing.T) {
+		pc := claimWith(resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: ownedMIG})
+
+		require.Panics(t, func() {
+			_ = state.rollbackPartiallyPreparedMIGDevices(context.Background(), "claim-uid", pc,
+				&Checkpoint{V2: &CheckpointV2{PreparedClaims: PreparedClaimsByUID{}}})
+		}, "our own result MUST still reach MIG teardown")
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

After #1324, partial DynamicMIG rollback from both the Prepare and the Unprepare path goes through `rollbackPartiallyPreparedMIGDevices`. The callers do check who owns a result, through `getAllocatableDevicesForClaim`, but only far enough to decide whether the claim holds a MIG device worth rolling back. Inside, the helper walks the whole list again and hands every device name to `NewMigSpecTupleFromCanonicalName` and on to MIG teardown, so a mixed claim carrying one device of ours brings the rest along.

Those names are not always ours to interpret. `checkpoint.json` is ours alone to write, but `Prepare()` stores the claim status whole, and kubelet hands the same claim to every driver named in its allocation results, so a mixed-driver claim leaves another driver's results in one of our entries. #1327 has the full chain. The MIG name grammar is `^gpu-(\d+)-mig-(.+)-(\d+)-(\d+)$`, and the middle group is matched but never used to build the tuple, so a foreign name with the same outer shape parses without having been crafted to.

On current main the lookup that follows fails before anything is torn down, because the tuple parsed from a name carries no `ParentPCIBusID` and `FindMigDevBySpec` resolves the parent through that field. That is the regression in #1452, and once it is fixed the teardown behind this loop becomes reachable again, which is why the ownership check should be in place first.

#### Which issue(s) this PR is related to:

Part of #1327. Not `Fixes`, because the issue also covers not checkpointing results we do not own; that half is #1371. The completed-claim identity mismatch is tracked separately in #1337.

#### Special notes for your reviewer:

**Where the check lives.** In `rollbackPartiallyPreparedMIGDevices`, the action boundary both rollback callers share, so one `continue` covers the Prepare path, the Unprepare path, and checkpoints written by older versions. It matches the bare `continue` the other loops over this list already use.

**The test.** It wires the device lib to the NVML fakes this package already has (`fakeNVMLGPU` and friends from `nvlib_nvml_test.go`, `mockNVMLLibrary` from `device_health_test.go`, which gains the `DeviceGetHandleByUUID` counter it lacked) and counts the parent GPU lookup, the first call MIG teardown makes. A result that gets that far shows up as one call, a result that does not shows up as none, and both cases return no error, so the count is the only thing separating them. The fake parent holds one MIG device on a placement no case names, and the device lib carries it (`GPU-0`, minor 0) under both keys a parent lookup may use, so the owned case keeps working once #1452 resolves the parent through the minor number.

Three cases: a foreign MIG-shaped name next to a device of ours never reaches the lookup; our own name does; our own name held by a completed claim does not. The third one is the premise the first one rests on.

**Why the foreign name is `gpu-1-mig-foreign-14-4` and not a look-alike of the owned device.** A foreign name that only differed in the profile string would parse to the same placement as the owned device, and a completed-claim guard that compares placements instead of strings (the direction #1337 points in) would then hold it back too. With that guard in place and the ownership check removed, the old fixture still passed; the new one fails. I checked both by patching the guard locally.

**Mutation checks.** Removing the three lines fails the foreign case; making the loop skip every result fails the owned case; removing the completed-claim guard fails the third case. Each case fails on exactly the change it exists for.

**Rebase.** Rebased onto current main and squashed the earlier "assert through NVML instead of a panic" commit into the one change, since main keeps individual commits.

**Testing.** `golangci-lint run ./...` (0 issues, which covers gofmt and goimports here), `go vet` and `go test -race ./...` are clean on this head; `go.mod`, `go.sum` and `vendor` are untouched, so `check-generate` and `check-modules` are unaffected.

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.

#### Does this PR introduce a user-facing change?

```release-note
Partial DynamicMIG rollback no longer acts on allocation results that belong to another DRA driver.
```

#### Additional documentation (design docs, usage docs, etc.):

```docs

```

#### Checklist

- [x] `make check test` passes locally (golangci-lint, go test -race; codegen and modules untouched)
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
