### PR TITLE
WIP: Publish node allocatable resource overhead for GPU devices (KEP-5517)

### DIFF
--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -101,16 +101,20 @@ func (d *AllocatableDevice) GetDevice(config *Config) resourceapi.Device {
 	case GpuDeviceType:
 		dev := d.Gpu.GetDevice()
 		applyConsumableShares(&dev, config)
+		applyNodeAllocatableOverheads(&dev, config, overheadClassGpu)
 		return dev
 	case MigStaticDeviceType:
 		dev := d.MigStatic.GetDevice()
 		applyConsumableShares(&dev, config)
+		applyNodeAllocatableOverheads(&dev, config, overheadClassMig)
 		return dev
 	case MigDynamicDeviceType:
 		panic("GetDevice() must currently not be called for MigDynamicDeviceType")
 	case VfioDeviceType:
 		// VFIO passthrough devices do not support consumable shares.
-		return d.Vfio.GetDevice()
+		dev := d.Vfio.GetDevice()
+		applyNodeAllocatableOverheads(&dev, config, overheadClassVfio)
+		return dev
 	default:
 		panic("unexpected type for AllocatableDevice")
 	}

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/component-base/logs"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/klog/v2"
@@ -68,13 +70,18 @@ type Flags struct {
 	klogVerbosity                 int
 	additionalXidsToIgnore        string
 	consumableShares              string
+
+	gpuNodeAllocatableOverhead  nodeAllocatableOverheadValues
+	migNodeAllocatableOverhead  nodeAllocatableOverheadValues
+	vfioNodeAllocatableOverhead nodeAllocatableOverheadValues
 }
 
 type Config struct {
-	flags                *Flags
-	clientsets           pkgflags.ClientSets
-	imagePullSecretNames []string
-	imagePullPolicy      string
+	flags                    *Flags
+	clientsets               pkgflags.ClientSets
+	imagePullSecretNames     []string
+	imagePullPolicy          string
+	nodeAllocatableOverheads map[string]map[corev1.ResourceName]resourceapi.NodeAllocatableResource
 }
 
 func (c Config) DriverPluginPath() string {
@@ -218,6 +225,7 @@ func newApp() *cli.App {
 			EnvVars:     []string{"CONSUMABLE_SHARES"},
 		},
 	}
+	cliFlags = append(cliFlags, nodeAllocatableOverheadCLIFlags(flags)...)
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)
 	cliFlags = append(cliFlags, featureGateConfig.Flags()...)
 	cliFlags = append(cliFlags, loggingConfig.Flags()...)
@@ -256,11 +264,17 @@ func newApp() *cli.App {
 				return fmt.Errorf("create client: %w", err)
 			}
 
+			nodeAllocatableOverheads, err := parseNodeAllocatableOverheadFlags(flags)
+			if err != nil {
+				return err
+			}
+
 			config := &Config{
-				flags:                flags,
-				clientsets:           clientSets,
-				imagePullSecretNames: strings.Fields(strings.ReplaceAll(strings.TrimSpace(flags.imagePullSecrets), ",", " ")),
-				imagePullPolicy:      strings.TrimSpace(flags.imagePullPolicy),
+				flags:                    flags,
+				clientsets:               clientSets,
+				imagePullSecretNames:     strings.Fields(strings.ReplaceAll(strings.TrimSpace(flags.imagePullSecrets), ",", " ")),
+				imagePullPolicy:          strings.TrimSpace(flags.imagePullPolicy),
+				nodeAllocatableOverheads: nodeAllocatableOverheads,
 			}
 
 			return RunPlugin(c.Context, config)

--- a/cmd/gpu-kubelet-plugin/node_allocatable.go
+++ b/cmd/gpu-kubelet-plugin/node_allocatable.go
@@ -1,0 +1,172 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+// Device classes that can carry node-allocatable overhead. The mig class
+// covers both statically and dynamically partitioned MIG devices.
+const (
+	overheadClassGpu  = "gpu"
+	overheadClassMig  = "mig"
+	overheadClassVfio = "vfio"
+)
+
+// nodeAllocatableOverheadValues holds the raw overhead flag values for one
+// device class.
+type nodeAllocatableOverheadValues struct {
+	memoryPerPod       string
+	memoryPerContainer string
+	cpuPerPod          string
+	cpuPerContainer    string
+}
+
+type overheadFlagField struct {
+	suffix      string
+	example     string
+	resource    corev1.ResourceName
+	perPod      bool
+	destination func(*nodeAllocatableOverheadValues) *string
+}
+
+// overheadFlagFields is the single source of truth for the per-class overhead
+// flag surface: flag registration, env var names, and parsing all derive from
+// it.
+var overheadFlagFields = []overheadFlagField{
+	{"memory-overhead-per-pod", "100Mi", corev1.ResourceMemory, true, func(v *nodeAllocatableOverheadValues) *string { return &v.memoryPerPod }},
+	{"memory-overhead-per-container", "10Mi", corev1.ResourceMemory, false, func(v *nodeAllocatableOverheadValues) *string { return &v.memoryPerContainer }},
+	{"cpu-overhead-per-pod", "100m", corev1.ResourceCPU, true, func(v *nodeAllocatableOverheadValues) *string { return &v.cpuPerPod }},
+	{"cpu-overhead-per-container", "10m", corev1.ResourceCPU, false, func(v *nodeAllocatableOverheadValues) *string { return &v.cpuPerContainer }},
+}
+
+func overheadFlagName(class string, field overheadFlagField) string {
+	return fmt.Sprintf("node-allocatable-%s-%s", class, field.suffix)
+}
+
+func overheadClassValues(flags *Flags) map[string]*nodeAllocatableOverheadValues {
+	return map[string]*nodeAllocatableOverheadValues{
+		overheadClassGpu:  &flags.gpuNodeAllocatableOverhead,
+		overheadClassMig:  &flags.migNodeAllocatableOverhead,
+		overheadClassVfio: &flags.vfioNodeAllocatableOverhead,
+	}
+}
+
+func nodeAllocatableOverheadCLIFlags(flags *Flags) []cli.Flag {
+	var cliFlags []cli.Flag
+	for _, class := range []string{overheadClassGpu, overheadClassMig, overheadClassVfio} {
+		values := overheadClassValues(flags)[class]
+		for _, field := range overheadFlagFields {
+			name := overheadFlagName(class, field)
+			cliFlags = append(cliFlags, &cli.StringFlag{
+				Name: name,
+				Usage: fmt.Sprintf(
+					"Node-allocatable overhead incurred by pods referencing a %s device (resource quantity, e.g. '%s'). Requires the NodeAllocatableResources feature gate.",
+					class, field.example),
+				Destination: field.destination(values),
+				EnvVars:     []string{strings.ToUpper(strings.ReplaceAll(name, "-", "_"))},
+			})
+		}
+	}
+	return cliFlags
+}
+
+// parseNodeAllocatableOverheadFlags validates and parses the per-class
+// node-allocatable overhead flags once at startup. It returns the overheads to
+// publish keyed by device class, or nil when nothing is configured.
+// Unparseable or negative values are rejected, as is any value set while the
+// NodeAllocatableResources feature gate is disabled (matching the
+// --consumable-shares contract). Zero values are treated as unset.
+func parseNodeAllocatableOverheadFlags(flags *Flags) (map[string]map[corev1.ResourceName]resourceapi.NodeAllocatableResource, error) {
+	overheads := map[string]map[corev1.ResourceName]resourceapi.NodeAllocatableResource{}
+	anySet := false
+
+	for class, values := range overheadClassValues(flags) {
+		classOverheads := map[corev1.ResourceName]resourceapi.NodeAllocatableResource{}
+		for _, field := range overheadFlagFields {
+			value := strings.TrimSpace(*field.destination(values))
+			if value == "" {
+				continue
+			}
+			anySet = true
+			quantity, err := resource.ParseQuantity(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for --%s: %q: %w", overheadFlagName(class, field), value, err)
+			}
+			if quantity.Sign() < 0 {
+				return nil, fmt.Errorf("invalid value for --%s: %q (must not be negative)", overheadFlagName(class, field), value)
+			}
+			if quantity.Sign() == 0 {
+				continue
+			}
+
+			entry := classOverheads[field.resource]
+			if entry.Overhead == nil {
+				entry.Overhead = &resourceapi.NodeAllocatableOverhead{}
+			}
+			if field.perPod {
+				entry.Overhead.PerPod = &quantity
+			} else {
+				entry.Overhead.PerContainer = &quantity
+			}
+			classOverheads[field.resource] = entry
+		}
+		if len(classOverheads) > 0 {
+			overheads[class] = classOverheads
+		}
+	}
+
+	if !anySet {
+		return nil, nil
+	}
+	if !featuregates.Enabled(featuregates.NodeAllocatableResources) {
+		return nil, fmt.Errorf("node-allocatable overhead flags require feature gate %s to be enabled", featuregates.NodeAllocatableResources)
+	}
+	if len(overheads) == 0 {
+		return nil, nil
+	}
+	return overheads, nil
+}
+
+// applyNodeAllocatableOverheads attaches the startup-parsed
+// NodeAllocatableResources overhead entries for the given device class to a
+// published device. Only the Overhead branch is ever set: none of these
+// devices are node resources themselves, so there is nothing to express via
+// Mapping.
+func applyNodeAllocatableOverheads(dev *resourceapi.Device, config *Config, class string) {
+	if config == nil {
+		return
+	}
+	classOverheads := config.nodeAllocatableOverheads[class]
+	if len(classOverheads) == 0 {
+		return
+	}
+	dev.NodeAllocatableResources = make(map[corev1.ResourceName]resourceapi.NodeAllocatableResource, len(classOverheads))
+	for name, overhead := range classOverheads {
+		dev.NodeAllocatableResources[name] = *overhead.DeepCopy()
+	}
+}

--- a/cmd/gpu-kubelet-plugin/node_allocatable_test.go
+++ b/cmd/gpu-kubelet-plugin/node_allocatable_test.go
@@ -1,0 +1,379 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	nvdev "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+// expectedOverhead describes the expected parsed overhead for one resource;
+// an empty string means the corresponding pointer must be nil.
+type expectedOverhead struct {
+	perPod       string
+	perContainer string
+}
+
+func requireOverheadQuantity(t *testing.T, expected string, actual *resource.Quantity) {
+	t.Helper()
+
+	if expected == "" {
+		require.Nil(t, actual)
+		return
+	}
+	require.NotNil(t, actual)
+	require.True(t, resource.MustParse(expected).Equal(*actual))
+}
+
+func requireOverheads(t *testing.T, expected map[corev1.ResourceName]expectedOverhead, actual map[corev1.ResourceName]resourceapi.NodeAllocatableResource) {
+	t.Helper()
+
+	if expected == nil {
+		require.Nil(t, actual)
+		return
+	}
+	require.Len(t, actual, len(expected))
+	for name, want := range expected {
+		entry, ok := actual[name]
+		require.True(t, ok, "expected a NodeAllocatableResources entry for %q", name)
+		require.Nil(t, entry.Mapping)
+		require.NotNil(t, entry.Overhead)
+		requireOverheadQuantity(t, want.perPod, entry.Overhead.PerPod)
+		requireOverheadQuantity(t, want.perContainer, entry.Overhead.PerContainer)
+	}
+}
+
+func TestParseNodeAllocatableOverheadFlags(t *testing.T) {
+	tests := []struct {
+		name              string
+		featureGate       bool
+		gpu               nodeAllocatableOverheadValues
+		mig               nodeAllocatableOverheadValues
+		vfio              nodeAllocatableOverheadValues
+		expectedOverheads map[string]map[corev1.ResourceName]expectedOverhead
+		expectedErr       string
+	}{
+		{
+			name:        "nothing configured",
+			featureGate: false,
+		},
+		{
+			name:        "feature gate enabled but nothing configured",
+			featureGate: true,
+		},
+		{
+			name:        "values set with feature gate disabled are rejected",
+			featureGate: false,
+			gpu:         nodeAllocatableOverheadValues{memoryPerPod: "100Mi"},
+			expectedErr: "node-allocatable overhead flags require feature gate NodeAllocatableResources to be enabled",
+		},
+		{
+			name:        "gpu memory per-pod only",
+			featureGate: true,
+			gpu:         nodeAllocatableOverheadValues{memoryPerPod: "100Mi"},
+			expectedOverheads: map[string]map[corev1.ResourceName]expectedOverhead{
+				overheadClassGpu: {corev1.ResourceMemory: {perPod: "100Mi"}},
+			},
+		},
+		{
+			name:        "distinct values per class",
+			featureGate: true,
+			gpu:         nodeAllocatableOverheadValues{memoryPerPod: "1Gi", cpuPerPod: "500m"},
+			mig:         nodeAllocatableOverheadValues{memoryPerPod: "128Mi", memoryPerContainer: "32Mi"},
+			vfio:        nodeAllocatableOverheadValues{cpuPerContainer: "50m"},
+			expectedOverheads: map[string]map[corev1.ResourceName]expectedOverhead{
+				overheadClassGpu: {
+					corev1.ResourceMemory: {perPod: "1Gi"},
+					corev1.ResourceCPU:    {perPod: "500m"},
+				},
+				overheadClassMig: {
+					corev1.ResourceMemory: {perPod: "128Mi", perContainer: "32Mi"},
+				},
+				overheadClassVfio: {
+					corev1.ResourceCPU: {perContainer: "50m"},
+				},
+			},
+		},
+		{
+			name:        "class with only zero values publishes nothing",
+			featureGate: true,
+			gpu:         nodeAllocatableOverheadValues{memoryPerPod: "100Mi"},
+			mig:         nodeAllocatableOverheadValues{memoryPerPod: "0", cpuPerPod: "0m"},
+			expectedOverheads: map[string]map[corev1.ResourceName]expectedOverhead{
+				overheadClassGpu: {corev1.ResourceMemory: {perPod: "100Mi"}},
+			},
+		},
+		{
+			name:        "all-zero values yield no overheads",
+			featureGate: true,
+			gpu:         nodeAllocatableOverheadValues{memoryPerPod: "0", cpuPerPod: "0"},
+		},
+		{
+			name:        "whitespace-only value is treated as unset",
+			featureGate: true,
+			mig:         nodeAllocatableOverheadValues{cpuPerContainer: "   "},
+		},
+		{
+			name:        "negative value is rejected with class-scoped flag name",
+			featureGate: true,
+			mig:         nodeAllocatableOverheadValues{memoryPerPod: "-100Mi"},
+			expectedErr: "invalid value for --node-allocatable-mig-memory-overhead-per-pod: \"-100Mi\" (must not be negative)",
+		},
+		{
+			name:        "unparseable value is rejected with class-scoped flag name",
+			featureGate: true,
+			vfio:        nodeAllocatableOverheadValues{cpuPerPod: "lots"},
+			expectedErr: "invalid value for --node-allocatable-vfio-cpu-overhead-per-pod: \"lots\"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+				string(featuregates.NodeAllocatableResources): tc.featureGate,
+			}))
+
+			flags := &Flags{
+				gpuNodeAllocatableOverhead:  tc.gpu,
+				migNodeAllocatableOverhead:  tc.mig,
+				vfioNodeAllocatableOverhead: tc.vfio,
+			}
+
+			overheads, err := parseNodeAllocatableOverheadFlags(flags)
+
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				require.Nil(t, overheads)
+				return
+			}
+			require.NoError(t, err)
+			if tc.expectedOverheads == nil {
+				require.Nil(t, overheads)
+				return
+			}
+			require.Len(t, overheads, len(tc.expectedOverheads))
+			for class, expected := range tc.expectedOverheads {
+				requireOverheads(t, expected, overheads[class])
+			}
+		})
+	}
+}
+
+func TestNodeAllocatableOverheadCLIFlags(t *testing.T) {
+	flags := &Flags{}
+	cliFlags := nodeAllocatableOverheadCLIFlags(flags)
+	require.Len(t, cliFlags, 12)
+
+	names := map[string]bool{}
+	for _, f := range cliFlags {
+		for _, name := range f.Names() {
+			names[name] = true
+		}
+	}
+	for _, expected := range []string{
+		"node-allocatable-gpu-memory-overhead-per-pod",
+		"node-allocatable-gpu-cpu-overhead-per-container",
+		"node-allocatable-mig-memory-overhead-per-container",
+		"node-allocatable-mig-cpu-overhead-per-pod",
+		"node-allocatable-vfio-memory-overhead-per-pod",
+		"node-allocatable-vfio-cpu-overhead-per-container",
+	} {
+		require.True(t, names[expected], "missing flag %s", expected)
+	}
+}
+
+func newOverheadTestConfig(t *testing.T, gpu, mig, vfio nodeAllocatableOverheadValues) *Config {
+	t.Helper()
+
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+		string(featuregates.NodeAllocatableResources): true,
+	}))
+	overheads, err := parseNodeAllocatableOverheadFlags(&Flags{
+		gpuNodeAllocatableOverhead:  gpu,
+		migNodeAllocatableOverhead:  mig,
+		vfioNodeAllocatableOverhead: vfio,
+	})
+	require.NoError(t, err)
+	return &Config{
+		flags:                    &Flags{},
+		nodeAllocatableOverheads: overheads,
+	}
+}
+
+func TestApplyNodeAllocatableOverheadsPerClassIsolation(t *testing.T) {
+	config := newOverheadTestConfig(t,
+		nodeAllocatableOverheadValues{memoryPerPod: "100Mi", cpuPerPod: "250m"},
+		nodeAllocatableOverheadValues{memoryPerPod: "32Mi"},
+		nodeAllocatableOverheadValues{},
+	)
+
+	gpuDev := resourceapi.Device{Name: "gpu-0"}
+	migDev := resourceapi.Device{Name: "gpu-0-mig-1g5gb-0"}
+	vfioDev := resourceapi.Device{Name: "gpu-0-vfio"}
+	applyNodeAllocatableOverheads(&gpuDev, config, overheadClassGpu)
+	applyNodeAllocatableOverheads(&migDev, config, overheadClassMig)
+	applyNodeAllocatableOverheads(&vfioDev, config, overheadClassVfio)
+
+	requireOverheads(t, map[corev1.ResourceName]expectedOverhead{
+		corev1.ResourceMemory: {perPod: "100Mi"},
+		corev1.ResourceCPU:    {perPod: "250m"},
+	}, gpuDev.NodeAllocatableResources)
+	requireOverheads(t, map[corev1.ResourceName]expectedOverhead{
+		corev1.ResourceMemory: {perPod: "32Mi"},
+	}, migDev.NodeAllocatableResources)
+	require.Nil(t, vfioDev.NodeAllocatableResources)
+}
+
+func TestApplyNodeAllocatableOverheadsNoSharedState(t *testing.T) {
+	config := newOverheadTestConfig(t,
+		nodeAllocatableOverheadValues{memoryPerPod: "100Mi"},
+		nodeAllocatableOverheadValues{},
+		nodeAllocatableOverheadValues{},
+	)
+
+	expected := map[corev1.ResourceName]expectedOverhead{
+		corev1.ResourceMemory: {perPod: "100Mi"},
+	}
+
+	devA := resourceapi.Device{Name: "gpu-0"}
+	devB := resourceapi.Device{Name: "gpu-1"}
+	applyNodeAllocatableOverheads(&devA, config, overheadClassGpu)
+	applyNodeAllocatableOverheads(&devB, config, overheadClassGpu)
+
+	requireOverheads(t, expected, devA.NodeAllocatableResources)
+	requireOverheads(t, expected, devB.NodeAllocatableResources)
+
+	// Devices must not share mutable state with each other or with the config.
+	require.NotSame(t,
+		devA.NodeAllocatableResources[corev1.ResourceMemory].Overhead,
+		devB.NodeAllocatableResources[corev1.ResourceMemory].Overhead)
+	devA.NodeAllocatableResources[corev1.ResourceMemory].Overhead.PerPod.Add(resource.MustParse("1Mi"))
+	requireOverheads(t, expected, devB.NodeAllocatableResources)
+	requireOverheads(t, expected, config.nodeAllocatableOverheads[overheadClassGpu])
+}
+
+func TestApplyNodeAllocatableOverheadsNoConfig(t *testing.T) {
+	dev := resourceapi.Device{Name: "gpu-0"}
+
+	require.NotPanics(t, func() {
+		applyNodeAllocatableOverheads(&dev, nil, overheadClassGpu)
+	})
+	require.Nil(t, dev.NodeAllocatableResources)
+
+	require.NotPanics(t, func() {
+		applyNodeAllocatableOverheads(&dev, &Config{}, overheadClassGpu)
+	})
+	require.Nil(t, dev.NodeAllocatableResources)
+}
+
+func newTestMigDeviceInfo(parent *GpuInfo) *MigDeviceInfo {
+	return &MigDeviceInfo{
+		UUID:           "MIG-test",
+		Profile:        "1g.5gb",
+		ParentUUID:     parent.UUID,
+		PlacementStart: 0,
+		PlacementSize:  1,
+		parent:         parent,
+		giProfileInfo:  &nvml.GpuInstanceProfileInfo{MemorySizeMB: 4864},
+	}
+}
+
+func newTestMigSpec(parent *GpuInfo) *MigSpec {
+	return &MigSpec{
+		Parent:        parent,
+		Profile:       &nvdev.MigProfileInfo{C: 1, G: 1, GB: 5},
+		GIProfileInfo: nvml.GpuInstanceProfileInfo{MemorySizeMB: 4864},
+		Placement:     nvml.GpuInstancePlacement{Start: 0, Size: 1},
+	}
+}
+
+func TestDevicePublishPathsCarryPerClassOverheads(t *testing.T) {
+	config := newOverheadTestConfig(t,
+		nodeAllocatableOverheadValues{memoryPerPod: "100Mi"},
+		nodeAllocatableOverheadValues{memoryPerPod: "32Mi"},
+		nodeAllocatableOverheadValues{memoryPerPod: "16Mi"},
+	)
+
+	parent := newTestGpuInfo(nil)
+	gpuDevice := AllocatableDevice{Gpu: parent}
+	migStaticDevice := AllocatableDevice{MigStatic: newTestMigDeviceInfo(parent)}
+	migDynamicDevice := AllocatableDevice{MigDynamic: newTestMigSpec(parent)}
+	vfioDevice := AllocatableDevice{
+		Vfio: &VfioDeviceInfo{
+			UUID:                   "vfio-test",
+			deviceID:               "0x1234",
+			vendorID:               "0x10de",
+			index:                  0,
+			productName:            "NVIDIA Test GPU",
+			numaNodeAttr:           newScalarNumaNodeAttribute(0),
+			addressableMemoryBytes: 1024,
+		},
+	}
+
+	for name, tc := range map[string]struct {
+		dev            resourceapi.Device
+		expectedPerPod string
+	}{
+		"gpu GetDevice":         {gpuDevice.GetDevice(config), "100Mi"},
+		"gpu PartGetDevice":     {gpuDevice.PartGetDevice(config), "100Mi"},
+		"mig static GetDevice":  {migStaticDevice.GetDevice(config), "32Mi"},
+		"mig dyn PartGetDevice": {migDynamicDevice.PartGetDevice(config), "32Mi"},
+		"vfio GetDevice":        {vfioDevice.GetDevice(config), "16Mi"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			requireOverheads(t, map[corev1.ResourceName]expectedOverhead{
+				corev1.ResourceMemory: {perPod: tc.expectedPerPod},
+			}, tc.dev.NodeAllocatableResources)
+		})
+	}
+}
+
+func TestDevicePublishPathsUnconfiguredClassStaysNil(t *testing.T) {
+	// Only the gpu class is configured: MIG and VFIO devices must stay nil.
+	config := newOverheadTestConfig(t,
+		nodeAllocatableOverheadValues{memoryPerPod: "100Mi"},
+		nodeAllocatableOverheadValues{},
+		nodeAllocatableOverheadValues{},
+	)
+
+	parent := newTestGpuInfo(nil)
+	migStaticDevice := AllocatableDevice{MigStatic: newTestMigDeviceInfo(parent)}
+	migDynamicDevice := AllocatableDevice{MigDynamic: newTestMigSpec(parent)}
+	vfioDevice := AllocatableDevice{
+		Vfio: &VfioDeviceInfo{
+			UUID:                   "vfio-test",
+			deviceID:               "0x1234",
+			vendorID:               "0x10de",
+			index:                  0,
+			productName:            "NVIDIA Test GPU",
+			numaNodeAttr:           newScalarNumaNodeAttribute(0),
+			addressableMemoryBytes: 1024,
+		},
+	}
+
+	require.Nil(t, migStaticDevice.GetDevice(config).NodeAllocatableResources)
+	require.Nil(t, migDynamicDevice.PartGetDevice(config).NodeAllocatableResources)
+	require.Nil(t, vfioDevice.GetDevice(config).NodeAllocatableResources)
+}

--- a/cmd/gpu-kubelet-plugin/partitions.go
+++ b/cmd/gpu-kubelet-plugin/partitions.go
@@ -219,12 +219,14 @@ func (d *AllocatableDevice) PartGetDevice(config *Config) resourceapi.Device {
 	case GpuDeviceType:
 		dev := d.Gpu.PartGetDevice()
 		applyConsumableShares(&dev, config)
+		applyNodeAllocatableOverheads(&dev, config, overheadClassGpu)
 		return dev
 	case MigStaticDeviceType:
 		panic("PartGetDevice() called for MigStaticDeviceType")
 	case MigDynamicDeviceType:
 		dev := d.MigDynamic.PartGetDevice()
 		applyConsumableShares(&dev, config)
+		applyNodeAllocatableOverheads(&dev, config, overheadClassMig)
 		return dev
 	case VfioDeviceType:
 		panic("not yet implemented")

--- a/demo/specs/node-allocatable-overhead/README.md
+++ b/demo/specs/node-allocatable-overhead/README.md
@@ -1,0 +1,80 @@
+# Node-Allocatable Overhead Demo
+
+This directory demonstrates [KEP-5517 node allocatable
+resources](https://github.com/kubernetes/enhancements/issues/5517): the driver
+declares, per published device, how much of the node's standard `memory` and
+`cpu` budget a pod consuming that device implicitly costs (for example host
+memory pinned by the GPU driver and CUDA runtime). The Kubernetes scheduler
+then debits those amounts from the node's allocatable budget, and the kubelet
+inflates the pod-level and container-level cgroup limits so the workload is
+not throttled or OOM-killed for using memory it was never able to declare in
+its pod spec.
+
+Only the `overhead` branch of the API is used: GPUs are not themselves node
+resources, so there is nothing to express via `mapping`.
+
+## Prerequisites
+
+- Kubernetes 1.37 or newer with the `DRANodeAllocatableResources` feature gate
+  (alpha) enabled on the API server, scheduler, and kubelet.
+- The driver's `NodeAllocatableResources` feature gate enabled, with overhead
+  values configured (see below). Setting overhead values without the driver
+  gate is a startup error.
+
+## Configuration
+
+Overhead values are configured per device class through Helm values (or the
+matching `--node-allocatable-<class>-<resource>-overhead-per-<granularity>`
+flags / `NODE_ALLOCATABLE_*` environment variables of the GPU kubelet plugin):
+
+```bash
+helm upgrade -i ... \
+  --set featureGates.NodeAllocatableResources=true \
+  --set nodeAllocatableOverhead.gpu.memory.perPod=256Mi \
+  --set nodeAllocatableOverhead.gpu.memory.perContainer=64Mi \
+  --set nodeAllocatableOverhead.gpu.cpu.perPod=500m
+```
+
+The three device classes are `gpu` (full GPUs), `mig` (statically and
+dynamically partitioned MIG devices), and `vfio` (passthrough devices). A
+class with no configured values publishes nothing. `perPod` is charged once
+per pod referencing a claim; `perContainer` is charged for each container
+referencing it.
+
+Caution for `vfio`: VM stacks such as KubeVirt typically already account for
+pinned guest RAM through the VM pod's own memory requests, so configuring
+vfio overhead on top of that double counts. Additionally, `PassthroughSupport`
+requires an IOMMU-capable host.
+
+## Running the demo
+
+```bash
+kubectl apply -f gpu-overhead-pod.yaml
+```
+
+The pod requests a `128Mi` memory limit and one full GPU. With the example
+configuration above, observe the three effects:
+
+1. The published device carries the overhead:
+
+   ```bash
+   kubectl get resourceslices -o yaml | grep -B2 -A8 nodeAllocatableResources
+   ```
+
+2. The scheduler records what it charged in the pod status:
+
+   ```bash
+   kubectl get pod gpu-overhead-pod \
+     -o jsonpath='{.status.nodeAllocatableResourceClaimStatuses}' | jq
+   ```
+
+3. The kubelet inflates the pod's cgroup ceiling: the pod-level
+   `memory.max` becomes `469762048` (448Mi = 128Mi spec limit + 256Mi perPod
+   + 64Mi perContainer) instead of the spec-only 128Mi, and the pod's
+   `cpu.weight` reflects the 500m CPU overhead even though the pod spec
+   requests no CPU.
+
+Because the scheduler debits the overhead against the same ledger used for
+standard pod-spec requests, a pod whose spec request fits the node but whose
+claim overhead does not will remain `Pending` with `Insufficient memory`
+rather than overcommitting the node.

--- a/demo/specs/node-allocatable-overhead/gpu-overhead-pod.yaml
+++ b/demo/specs/node-allocatable-overhead/gpu-overhead-pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: single-gpu
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-overhead-pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c", "nvidia-smi -L; sleep 3600"]
+    resources:
+      requests:
+        memory: 128Mi
+      limits:
+        memory: 128Mi
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: single-gpu

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -309,6 +309,18 @@ spec:
         - name: CONSUMABLE_SHARES
           value: "{{ .Values.consumableShares }}"
         {{- end }}
+        {{- range $class := tuple "gpu" "mig" "vfio" }}
+        {{- $classValues := get (default (dict) $.Values.nodeAllocatableOverhead) $class | default (dict) }}
+        {{- range $res := tuple "memory" "cpu" }}
+        {{- $resValues := get $classValues $res | default (dict) }}
+        {{- range $granularity := tuple "Pod" "Container" }}
+        {{- with get $resValues (printf "per%s" $granularity) }}
+        - name: NODE_ALLOCATABLE_{{ upper $class }}_{{ upper $res }}_OVERHEAD_PER_{{ upper $granularity }}
+          value: {{ . | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.featureGates }}
         - name: FEATURE_GATES
           value: "{{ range $key, $value := .Values.featureGates }}{{ $key }}={{ $value }},{{ end }}"

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -41,6 +41,44 @@ gpuResourcesEnabledOverride: false
 # Configure consumable shares support ("disabled", "memory", "unlimited", or a positive integer)
 consumableShares: ""
 
+# Node-allocatable overhead published on devices, per device class: gpu
+# (full GPUs), mig (statically and dynamically partitioned MIG devices), and
+# vfio (passthrough devices). Each value is an optional Kubernetes resource
+# quantity (e.g. "100Mi", "250m") describing the node memory/CPU overhead
+# consumed per pod or per container using such a device. Empty or zero values
+# are omitted from the published ResourceSlices; a class with no values
+# publishes nothing. Setting any value requires
+# featureGates.NodeAllocatableResources=true; the plugin fails to start
+# otherwise. The cluster must also enable the Kubernetes feature gate
+# DRANodeAllocatableResources for the field to be accepted by the API server.
+# Caution for vfio: when passthrough devices are consumed by VMs (e.g.
+# KubeVirt), guest RAM pinning is typically already accounted through the VM
+# pod's own memory requests; configuring vfio overhead on top of that double
+# counts. Leave the vfio values empty unless you know your VM stack does not
+# account for it.
+nodeAllocatableOverhead:
+  gpu:
+    memory:
+      perPod: ""
+      perContainer: ""
+    cpu:
+      perPod: ""
+      perContainer: ""
+  mig:
+    memory:
+      perPod: ""
+      perContainer: ""
+    cpu:
+      perPod: ""
+      perContainer: ""
+  vfio:
+    memory:
+      perPod: ""
+      perContainer: ""
+    cpu:
+      perPod: ""
+      perContainer: ""
+
 allowDefaultNamespace: false
 
 # resourceApiVersion sets the resource.k8s.io API version used for DRA resources (DeviceClass,
@@ -118,6 +156,7 @@ resources:
 #   HostManagedIMEXDaemon: false       # Gate allowing resources.computeDomains.imex.mode=hostManaged
 #   DRAListTypeAttributes: false       # Publish list-valued DRA device attributes
 #   ConsumableShares: false            # Publish consumable capacity and multi-allocation support for devices
+#   NodeAllocatableResources: false    # Publish node-allocatable overhead for gpu, mig, and vfio devices (see nodeAllocatableOverhead)
 featureGates: {}
 
 # Log verbosity for all components. Zero or greater, higher number means higher

--- a/hack/ci/mock-nvml/e2e-test.sh
+++ b/hack/ci/mock-nvml/e2e-test.sh
@@ -200,11 +200,14 @@ if [ "${K8S_MINOR}" -ge 35 ]; then
   echo "K8s >= 1.35 (${RESOLVED_K8S_VERSION}): enabling DRAExtendedResource,DRAPartitionableDevices"
 fi
 TEST_DRA_LIST_TYPE_ATTRIBUTES=false
+TEST_DRA_NODE_ALLOCATABLE_RESOURCES=false
 if [ "${K8S_MINOR}" -ge 37 ]; then
   TEST_DRA_LIST_TYPE_ATTRIBUTES=true
-  echo "K8s >= 1.37 (${RESOLVED_K8S_VERSION}): enabling DRAListTypeAttributes"
+  TEST_DRA_NODE_ALLOCATABLE_RESOURCES=true
+  echo "K8s >= 1.37 (${RESOLVED_K8S_VERSION}): enabling DRAListTypeAttributes,DRANodeAllocatableResources"
 fi
 export TEST_DRA_LIST_TYPE_ATTRIBUTES
+export TEST_DRA_NODE_ALLOCATABLE_RESOURCES
 
 # --- Step 4: Create Kind cluster ---
 echo ""
@@ -262,11 +265,23 @@ fi
 if [ "${TEST_DRA_LIST_TYPE_ATTRIBUTES}" = "true" ]; then
   sed -i '/DynamicResourceAllocation: true/a\  DRAListTypeAttributes: true' "${KIND_CONFIG}"
 fi
+if [ "${TEST_DRA_NODE_ALLOCATABLE_RESOURCES}" = "true" ]; then
+  # KEP-5517 (alpha in 1.37): lets test_gpu_node_allocatable.bats verify
+  # node-allocatable overhead publishing and scheduler accounting.
+  sed -i '/DynamicResourceAllocation: true/a\  DRANodeAllocatableResources: true' "${KIND_CONFIG}"
+fi
 
 # Select Kind node image if k8s version specified
 KIND_IMAGE_ARG=""
 if [ -n "${K8S_VERSION}" ]; then
   KIND_IMAGE_ARG="--image kindest/node:${K8S_VERSION}"
+  # Pre-release versions have no published kindest/node image; build one from
+  # source so the script also works for release candidates.
+  if ! docker image inspect "kindest/node:${K8S_VERSION}" > /dev/null 2>&1 \
+     && ! docker manifest inspect "kindest/node:${K8S_VERSION}" > /dev/null 2>&1; then
+    echo "No kindest/node:${K8S_VERSION} image available; building it from source"
+    kind build node-image "${K8S_VERSION}" --image "kindest/node:${K8S_VERSION}"
+  fi
 fi
 
 kind create cluster \

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -103,6 +103,14 @@ const (
 	// via --consumable-shares. Note: MPS sharing is not supported when consumable
 	// shares is enabled.
 	ConsumableShares featuregate.Feature = "ConsumableShares"
+
+	// NodeAllocatableResources enables publishing node-allocatable overhead
+	// (KEP-5517) for full-GPU devices in ResourceSlices. Overhead values are
+	// configured via the --node-allocatable-*-overhead-per-* flags of the GPU
+	// kubelet plugin. The cluster must have the Kubernetes feature gate
+	// DRANodeAllocatableResources enabled for the API server to accept the
+	// published field.
+	NodeAllocatableResources featuregate.Feature = "NodeAllocatableResources"
 )
 
 // Feature gate Version fields use driver SemVer major.minor.
@@ -199,6 +207,13 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 		},
 	},
 	ConsumableShares: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(0, 5),
+		},
+	},
+	NodeAllocatableResources: {
 		{
 			Default:    false,
 			PreRelease: featuregate.Alpha,

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -146,7 +146,20 @@ func TestDefaultFeatureGates(t *testing.T) {
 		// Test that real features have expected defaults
 		require.False(t, fg.Enabled(TimeSlicingSettings), "TimeSlicingSettings should be disabled by default (alpha)")
 		require.False(t, fg.Enabled(HostManagedIMEXDaemon), "HostManagedIMEXDaemon should be disabled by default (alpha)")
+		require.False(t, fg.Enabled(NodeAllocatableResources), "NodeAllocatableResources should be disabled by default (alpha)")
 	})
+}
+
+func TestNodeAllocatableResourcesFeatureGate(t *testing.T) {
+	fg := newFeatureGates(TestVersion)
+
+	require.False(t, fg.Enabled(NodeAllocatableResources), "NodeAllocatableResources should be disabled by default (alpha)")
+
+	err := fg.SetFromMap(map[string]bool{
+		string(NodeAllocatableResources): true,
+	})
+	require.NoError(t, err, "SetFromMap should not fail")
+	require.True(t, fg.Enabled(NodeAllocatableResources), "NodeAllocatableResources should be enabled after SetFromMap")
 }
 
 func TestEnabledConvenienceFunction(t *testing.T) {

--- a/site/content/docs/guides/node-allocatable-overhead.md
+++ b/site/content/docs/guides/node-allocatable-overhead.md
@@ -1,0 +1,103 @@
+---
+title: Node-allocatable overhead
+linkTitle: Node-allocatable overhead
+weight: 65
+description: >
+  Declare per-device host memory and CPU overhead so the scheduler reserves it
+  and the kubelet sizes cgroups accordingly (KEP-5517).
+---
+
+Workloads that use GPUs also consume ordinary node resources that never appear
+in their pod spec: the NVIDIA driver and CUDA runtime pin host memory per
+process, and auxiliary threads consume CPU. Without accounting, the scheduler
+can overcommit node memory, and the kubelet sizes the pod's cgroups purely
+from the pod spec, so a workload can be OOM-killed for host allocations made
+on its behalf.
+
+The `NodeAllocatableResources` feature gate enables
+[KEP-5517](https://github.com/kubernetes/enhancements/issues/5517) support:
+each published device carries a `nodeAllocatableResources` entry declaring the
+host `memory` and `cpu` overhead a pod incurs by claiming it. The Kubernetes
+scheduler debits these amounts from the node's allocatable budget (the same
+ledger used by standard pod-spec requests) and records the result in
+`pod.status.nodeAllocatableResourceClaimStatuses`; the kubelet reads that
+status and adds the amounts to the pod-level cgroup requests and limits and to
+the container-level limits.
+
+Only the `overhead` branch of the KEP-5517 API is published. GPUs are not
+themselves node resources, so the `mapping` branch (used by CPU or memory DRA
+drivers) does not apply.
+
+## Prerequisites
+
+- Kubernetes 1.37 or newer with the `DRANodeAllocatableResources` feature gate
+  (alpha) enabled on the API server, kube-scheduler, and kubelet. Without it,
+  the API server silently drops the field from published ResourceSlices.
+- The driver's `NodeAllocatableResources` feature gate enabled via
+  `featureGates.NodeAllocatableResources=true`.
+
+## Configuration
+
+Overhead values are optional Kubernetes resource quantities, configured per
+device class:
+
+| Device class | Covers | Helm values |
+|---|---|---|
+| `gpu` | full GPUs | `nodeAllocatableOverhead.gpu.{memory,cpu}.{perPod,perContainer}` |
+| `mig` | statically and dynamically partitioned MIG devices | `nodeAllocatableOverhead.mig.{memory,cpu}.{perPod,perContainer}` |
+| `vfio` | passthrough devices | `nodeAllocatableOverhead.vfio.{memory,cpu}.{perPod,perContainer}` |
+
+`perPod` is charged once per pod referencing a claim for the device;
+`perContainer` is charged for each container referencing the claim. Empty or
+zero values are omitted, and a class with no values publishes nothing, so the
+default configuration changes nothing. Setting any value while the driver
+feature gate is disabled is a startup error.
+
+Example:
+
+```bash
+helm upgrade -i nvidia dra-driver-nvidia-gpu \
+  --set featureGates.NodeAllocatableResources=true \
+  --set nodeAllocatableOverhead.gpu.memory.perPod=256Mi \
+  --set nodeAllocatableOverhead.gpu.memory.perContainer=64Mi \
+  --set nodeAllocatableOverhead.gpu.cpu.perPod=500m \
+  --set nodeAllocatableOverhead.mig.memory.perPod=128Mi
+```
+
+The equivalent kubelet-plugin flags are
+`--node-allocatable-<class>-<resource>-overhead-per-<pod|container>` with
+matching `NODE_ALLOCATABLE_*` environment variables.
+
+## What to expect
+
+With the example values above, a pod with a `128Mi` memory limit claiming one
+full GPU results in:
+
+- the `gpu-0` device in the node's ResourceSlice carrying
+  `nodeAllocatableResources` with the configured overhead,
+- `pod.status.nodeAllocatableResourceClaimStatuses` listing the claim, the
+  referencing containers, and the charged overhead,
+- a pod-level cgroup `memory.max` of 448Mi (128Mi limit + 256Mi perPod + 64Mi
+  perContainer) and a pod-level `cpu.weight` reflecting the 500m CPU overhead,
+- unschedulable (`Insufficient memory`) pods instead of node overcommit when
+  the overhead does not fit the node's remaining allocatable budget.
+
+The pod's QoS class is unchanged by DRA overhead (a KEP-5517 design decision):
+a pod with no pod-spec requests remains BestEffort even when its claims carry
+overhead. Give pods at least a small standard request to avoid BestEffort
+eviction behavior.
+
+## Caveats
+
+- `vfio`: VM stacks such as KubeVirt typically account for pinned guest RAM
+  through the VM launcher pod's own memory requests; configuring vfio overhead
+  on top of that double counts. Leave the vfio values empty unless your VM
+  stack does not account for it. Note that `PassthroughSupport` itself
+  requires an IOMMU-capable host.
+- Overhead values are supplied by the cluster administrator. Measure your
+  workloads' real per-process host footprint before choosing values;
+  over-reserving wastes node capacity, under-reserving reintroduces the OOM
+  risk the feature exists to prevent.
+- If the cluster-side `DRANodeAllocatableResources` gate is missing, the field
+  is dropped by the API server and the resourceslice controller logs recurring
+  `features are disabled` errors while overhead accounting silently stays off.

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -193,6 +193,7 @@ tests-mock-nvml: runner-image
 		tests/bats/test_gpu_sharing.bats \
 		tests/bats/test_gpu_robustness.bats \
 		tests/bats/test_gpu_extres.bats \
+		tests/bats/test_gpu_node_allocatable.bats \
 		tests/bats/test_gpu_stress.bats \
 		tests/bats/test_gpu_updowngrade.bats \
 		tests/bats/test_cd_imex_chan_inject.bats \

--- a/tests/bats/specs/gpu-node-allocatable.yaml
+++ b/tests/bats/specs/gpu-node-allocatable.yaml
@@ -1,0 +1,37 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-node-allocatable-gpu
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-node-allocatable-0
+  labels:
+    env: batssuite
+spec:
+  restartPolicy: Never
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      requests:
+        memory: 128Mi
+      limits:
+        memory: 128Mi
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-node-allocatable-gpu

--- a/tests/bats/test_gpu_node_allocatable.bats
+++ b/tests/bats/test_gpu_node_allocatable.bats
@@ -1,0 +1,202 @@
+# shellcheck disable=SC2148
+# shellcheck disable=SC2329
+
+# Tests for KEP-5517 node-allocatable overhead publishing.
+# Requires driver feature gate: NodeAllocatableResources=true.
+# Requires cluster feature gate: DRANodeAllocatableResources=true (alpha,
+# Kubernetes 1.37+); tests are skipped when the API server drops the field.
+
+setup_file() {
+  load 'helpers.sh'
+  _common_setup
+  local _iargs=("--set" "logVerbosity=6"
+    "--set" "featureGates.NodeAllocatableResources=true"
+    "--set" "nodeAllocatableOverhead.gpu.memory.perPod=256Mi"
+    "--set" "nodeAllocatableOverhead.gpu.memory.perContainer=64Mi"
+    "--set" "nodeAllocatableOverhead.gpu.cpu.perPod=500m")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+}
+
+setup() {
+  load 'helpers.sh'
+  _common_setup
+  log_objects
+}
+
+bats::on_failure() {
+  echo -e "\n\nFAILURE HOOK START"
+  log_objects
+  show_kubelet_plugin_error_logs
+  show_gpu_plugin_log_tails
+  echo -e "FAILURE HOOK END\n\n"
+}
+
+# Skip when the cluster's API server does not retain the (alpha, 1.37+)
+# nodeAllocatableResources field: a server-side dry-run create of a minimal
+# ResourceSlice reveals whether the field survives or is pruned. The slice must
+# reference an existing node, otherwise admission rejects it outright.
+skip_without_cluster_gate() {
+  local _node _out _rc
+  _node=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+  _out=$(kubectl create --dry-run=server -o json -f - 2>&1 <<EOF
+apiVersion: resource.k8s.io/v1
+kind: ResourceSlice
+metadata:
+  name: bats-nar-gate-probe
+spec:
+  driver: probe.batssuite.example.com
+  nodeName: ${_node}
+  pool:
+    name: bats-nar-gate-probe
+    generation: 1
+    resourceSliceCount: 1
+  devices:
+  - name: probe
+    nodeAllocatableResources:
+      memory:
+        overhead:
+          perPod: 1Mi
+EOF
+  ) && _rc=0 || _rc=$?
+  if [ "${_rc}" -ne 0 ]; then
+    echo "gate probe dry-run failed: ${_out}"
+    return 1
+  fi
+  if ! grep -q nodeAllocatableResources <<< "${_out}"; then
+    skip "cluster does not enable DRANodeAllocatableResources (field dropped by API server)"
+  fi
+}
+
+# bats test_tags=fastfeedback,node-allocatable
+@test "GPUs: NodeAllocatableResources — ResourceSlice publishes gpu overhead" {
+  skip_without_cluster_gate
+
+  local _overheads=""
+  for _ in $(seq 1 12); do
+    _overheads=$(kubectl get resourceslices.resource.k8s.io -o json \
+      | jq -c '[.items[].spec.devices[]
+                | select(.nodeAllocatableResources != null)
+                | {name, nar: .nodeAllocatableResources}]')
+    [ "${_overheads}" != "[]" ] && break
+    sleep 5
+  done
+  echo "devices with overhead: ${_overheads}"
+
+  run jq -r '.[0].nar.memory.overhead.perPod' <<< "${_overheads}"
+  assert_output "256Mi"
+  run jq -r '.[0].nar.memory.overhead.perContainer' <<< "${_overheads}"
+  assert_output "64Mi"
+  run jq -r '.[0].nar.cpu.overhead.perPod' <<< "${_overheads}"
+  assert_output "500m"
+  # Overhead is the only branch this driver publishes; Mapping must be unset.
+  run jq -r '[.[] | .nar[] | has("mapping")] | any' <<< "${_overheads}"
+  assert_output "false"
+}
+
+# bats test_tags=fastfeedback,node-allocatable
+@test "GPUs: NodeAllocatableResources — scheduler records overhead in pod status" {
+  skip_without_cluster_gate
+
+  local _specpath="tests/bats/specs/gpu-node-allocatable.yaml"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "pod-node-allocatable-0" --timeout=60s
+
+  run kubectl logs "pod-node-allocatable-0" -c ctr
+  assert_output --partial "UUID: GPU-"
+
+  local _status
+  _status=$(kubectl get pod "pod-node-allocatable-0" -o json \
+    | jq -c '.status.nodeAllocatableResourceClaimStatuses')
+  echo "nodeAllocatableResourceClaimStatuses: ${_status}"
+
+  run jq -r '.[0].containers[0]' <<< "${_status}"
+  assert_output "ctr"
+  run jq -r '.[0].overhead[] | select(.name == "memory") | .perPod' <<< "${_status}"
+  assert_output "256Mi"
+  run jq -r '.[0].overhead[] | select(.name == "memory") | .perContainer' <<< "${_status}"
+  assert_output "64Mi"
+  run jq -r '.[0].overhead[] | select(.name == "cpu") | .perPod' <<< "${_status}"
+  assert_output "500m"
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods "pod-node-allocatable-0" --timeout=30s
+}
+
+# The two negative-path tests below reinstall the driver with the feature gate
+# disabled and are ordered last: bats runs the tests of a file in order, and the
+# next test file's setup_file() reinstalls its own configuration.
+
+# bats test_tags=fastfeedback,node-allocatable
+@test "GPUs: NodeAllocatableResources — values set with gate disabled fail startup" {
+  skip_without_cluster_gate
+
+  local _iargs=("--set" "logVerbosity=6"
+    "--set" "featureGates.NodeAllocatableResources=false"
+    "--set" "nodeAllocatableOverhead.gpu.memory.perPod=256Mi")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  # The gpus container is expected to fail to start, so iupgrade_wait (which
+  # waits for READY plugin pods) cannot be used; run the same helm command
+  # without --wait instead.
+  local _mock_args=()
+  if [ -n "${TEST_ALT_PROC_DEVICES:-}" ]; then
+    _mock_args+=("--set" "altProcDevices=${TEST_ALT_PROC_DEVICES}")
+  fi
+  if [ "${MOCK_NVML:-}" = "true" ]; then
+    _mock_args+=(
+      "--set" "kubeletPlugin.containers.gpus.env[0].name=NVIDIA_DRA_SYSFS_ROOT"
+      "--set" "kubeletPlugin.containers.gpus.env[0].value=/driver-root/sys")
+  fi
+  timeout -v 120 helm upgrade --install "${TEST_HELM_RELEASE_NAME}" \
+    "${TEST_CHART_REPO}" \
+    --version="${TEST_CHART_VERSION}" \
+    --create-namespace \
+    --namespace dra-driver-nvidia-gpu \
+    --set gpuResourcesEnabledOverride=true \
+    --set nvidiaDriverRoot="${TEST_NVIDIA_DRIVER_ROOT}" "${_mock_args[@]}" "${_iargs[@]}"
+
+  local _pod=""
+  local _logs=""
+  for _ in $(seq 1 24); do
+    _pod=$(kubectl get pod -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin \
+      -o name 2>/dev/null | head -1)
+    if [ -n "${_pod}" ]; then
+      # Either fetch may fail transiently (no previous container yet, or the
+      # container restarting), so both are tolerated inside the poll loop.
+      _logs=$( { kubectl logs -n dra-driver-nvidia-gpu "${_pod}" -c gpus --tail=20 2>/dev/null || true; \
+                 kubectl logs -n dra-driver-nvidia-gpu "${_pod}" -c gpus --previous --tail=20 2>/dev/null || true; } )
+      grep -q "node-allocatable overhead flags require feature gate NodeAllocatableResources" <<< "${_logs}" && break
+    fi
+    sleep 5
+  done
+  echo "gpus container logs: ${_logs}"
+  run grep -c "node-allocatable overhead flags require feature gate NodeAllocatableResources" <<< "${_logs}"
+  refute_output "0"
+}
+
+# bats test_tags=fastfeedback,node-allocatable
+@test "GPUs: NodeAllocatableResources — gate disabled and no values publishes no field" {
+  skip_without_cluster_gate
+
+  local _iargs=("--set" "logVerbosity=6"
+    "--set" "featureGates.NodeAllocatableResources=false")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+
+  # Give the plugin time to republish its ResourceSlices after the rollout.
+  local _count="-1"
+  for _ in $(seq 1 12); do
+    _count=$(kubectl get resourceslices.resource.k8s.io -o json \
+      | jq '[.items[].spec.devices[] | select(.nodeAllocatableResources != null)] | length')
+    [ "${_count}" = "0" ] && break
+    sleep 5
+  done
+  assert_equal "${_count}" "0"
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implements KEP-5517 node allocatable resources support in the GPU kubelet plugin, behind a new NodeAllocatableResources feature gate with overhead values configured per device class (gpu, mig, vfio) through plugin flags and helm values. Includes unit tests, a docs guide, a bats e2e test that skips automatically on clusters without the DRANodeAllocatableResources gate, and a demo spec under demo/specs/node-allocatable-overhead.

The e2e also runs in the existing mock NVML CI job, so overhead publishing, scheduler accounting and the gate disabled paths are exercised on runners without GPUs. That job currently pins the latest stable kindest/node image (1.36), where the gate does not exist and these four checks skip with an explicit reason; the job now builds a node image when an explicit K8S_VERSION has none published, so the checks can be run against 1.37 today.

#### Which issue(s) this PR is related to:

KEP: kubernetes/enhancements#5517

#### Special notes for your reviewer:

**This is intentionally a draft, so please don't spend review time on it yet.**

It is part of an experiment in bringing the three DRA drivers (dra-example-driver, dra-driver-nvidia-gpu and dra-driver-google-tpu) closer to feature parity, along with a few bugs found along the way.

**How it was produced:** the implementation was written largely by autonomous coding agents working under my direction, one per feature, each in its own branch. I am not asking you to take that on trust, which is exactly why it opens as a draft.

**Verified so far, unattended:** go build, go vet, unit tests, the full module race suite, and the mock NVML CI job on kind built from kubernetes v1.37.0-rc.0, where the whole suite passed at 48 ok and 0 failures including the four new node allocatable checks; plus an automated code review pass whose findings were applied and then retested. Tested end to end on real hardware across three environments: full GPU on a T4, MIG on an A100, and vfio publishing on a T4, covering ResourceSlice contents, scheduler accounting, pod status, cgroup enforcement, and negative paths. Detailed test reports with expected and actual values are posted as comments below.

**Not done yet:** my own reading of the full diff, and testing it again by hand under my supervision. That happens before this leaves draft, so no CI approval, `/ok-to-test`, or reviewer attention is needed until then.

I will drop the `WIP:` prefix and mark it ready for review only after that human pass.

Technical notes:

Requires Kubernetes 1.37 or newer with the alpha DRANodeAllocatableResources feature gate enabled cluster side. Only the overhead branch of the KEP API is published since GPUs are not themselves node resources. Setting overhead values while the driver gate is disabled is a startup error, matching kubernetes-sigs/dra-driver-google-tpu#30. One environment limitation worth calling out: vfio prepare could not be exercised on GCE because the host has no IOMMU, so publishing, scheduling and cgroup effects were verified with a test only IOMMU bypass while prepare itself needs bare metal or a virtual IOMMU.

#### Does this PR introduce a user-facing change?

```release-note
The GPU kubelet plugin can publish node allocatable memory and CPU overhead for GPU, MIG, and vfio devices (KEP-5517) when the NodeAllocatableResources feature gate is enabled.
```
