### PR TITLE
fix(gpu-kubelet-plugin): reclaim vfio-stranded passthrough GPUs on startup

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -134,12 +134,56 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		return nil, fmt.Errorf("failed to create device library: %w", err)
 	}
 
+	hostDriverRoot := config.flags.hostDriverRoot
+
+	// The managers below, the checkpoint and the boot ID are all set up before
+	// device discovery because reclaiming GPUs stranded on a vfio driver has to
+	// happen first: NVML cannot enumerate a vfio-bound GPU, so discovery would
+	// otherwise produce a VFIO device with no parent GpuInfo, no module ID and no
+	// partitionN attributes. See reconcileStrandedPassthroughGPUs.
+	var vfioPciManager *VfioPciManager
+	if featuregates.Enabled(featuregates.PassthroughSupport) {
+		vfioPciManager, err = NewVfioPciManager(string(containerDriverRoot), string(hostDriverRoot), nvdevlib, true /* nvidiaEnabled */)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create vfio pci manager: %w", err)
+		}
+	}
+
+	fmManager, err := newFabricManager(nvdevlib, containerDriverRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	checkpointManager, err := checkpointmanager.NewCheckpointManager(config.DriverPluginPath())
+	if err != nil {
+		return nil, fmt.Errorf("unable to create checkpoint manager: %w", err)
+	}
+
+	cpLockPath := filepath.Join(config.DriverPluginPath(), "cp.lock")
+
+	currentBootID, err := bootid.GetCurrentBootID()
+	if err != nil {
+		return nil, fmt.Errorf("read node boot id: %w", err)
+	}
+
+	state := &DeviceState{
+		config:            config,
+		nvdevlib:          nvdevlib,
+		vfioPciManager:    vfioPciManager,
+		fmManager:         fmManager,
+		checkpointManager: checkpointManager,
+		cplock:            flock.NewFlock(cpLockPath),
+	}
+
+	if err := state.reconcileStrandedPassthroughGPUs(ctx, currentBootID); err != nil {
+		return nil, fmt.Errorf("reconciling stranded passthrough GPUs: %w", err)
+	}
+
 	perGPUAllocatable, err := nvdevlib.enumerateAllPossibleDevices()
 	if err != nil {
 		return nil, fmt.Errorf("error enumerating all possible devices: %w", err)
 	}
-
-	hostDriverRoot := config.flags.hostDriverRoot
+	state.perGPUAllocatable = perGPUAllocatable
 
 	// Let nvcdi logs see the light of day (emit to standard streams) when we've
 	// been configured with verbosity level 7 or higher.
@@ -194,38 +238,9 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		mpsManager = NewMpsManager(config, nvdevlib, hostDriverRoot, MpsControlDaemonTemplatePath)
 	}
 
-	var vfioPciManager *VfioPciManager
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
-		vfioPciManager, err = NewVfioPciManager(string(containerDriverRoot), string(hostDriverRoot), nvdevlib, true /* nvidiaEnabled */)
-		if err != nil {
-			return nil, fmt.Errorf("unable to create vfio pci manager: %w", err)
-		}
-	}
-
-	fmManager, err := newFabricManager(nvdevlib, containerDriverRoot)
-	if err != nil {
-		return nil, err
-	}
-
-	checkpointManager, err := checkpointmanager.NewCheckpointManager(config.DriverPluginPath())
-	if err != nil {
-		return nil, fmt.Errorf("unable to create checkpoint manager: %w", err)
-	}
-
-	cpLockPath := filepath.Join(config.DriverPluginPath(), "cp.lock")
-
-	state := &DeviceState{
-		cdi:               cdi,
-		tsManager:         tsManager,
-		mpsManager:        mpsManager,
-		vfioPciManager:    vfioPciManager,
-		perGPUAllocatable: perGPUAllocatable,
-		config:            config,
-		nvdevlib:          nvdevlib,
-		checkpointManager: checkpointManager,
-		fmManager:         fmManager,
-		cplock:            flock.NewFlock(cpLockPath),
-	}
+	state.cdi = cdi
+	state.tsManager = tsManager
+	state.mpsManager = mpsManager
 	state.checkpointCleanupManager = NewCheckpointCleanupManager(state, config.clientsets.Resource)
 
 	// Attach Fabric Manager partition mappings to every discovered GPU. The
@@ -243,11 +258,6 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	checkpoints, err := state.checkpointManager.ListCheckpoints()
 	if err != nil {
 		return nil, fmt.Errorf("unable to list checkpoints: %w", err)
-	}
-
-	currentBootID, err := bootid.GetCurrentBootID()
-	if err != nil {
-		return nil, fmt.Errorf("read node boot id: %w", err)
 	}
 
 	for _, c := range checkpoints {
@@ -1353,10 +1363,20 @@ func (s *DeviceState) attachFabricManagerPartitions(gpu *GpuInfo) error {
 		return nil
 	}
 	if gpu.gpuModuleID == 0 {
-		klog.Warningf("GPU %s has no gpuModuleID; skipping Fabric Manager partition attributes. "+
-			"This happens when the GPU was bound to vfio-pci before discovery (e.g. an active passthrough claim across a plugin restart).",
-			gpu.CanonicalName())
-		return nil
+		// NVML did not give us a module ID. FM reports a module ID and a PCI bus
+		// id for every GPU it knows about, so ask FM instead of giving up: a GPU
+		// without partitionN attributes cannot be selected by a claim that
+		// constrains on them, which silently removes it from the pool.
+		moduleID, ok := s.fmManager.ModuleIDByPCIBusID(gpu.pciBusID)
+		if !ok {
+			klog.Warningf("GPU %s (%s) has no gpuModuleID from NVML and Fabric Manager reports no GPU at that PCI address; "+
+				"skipping Fabric Manager partition attributes",
+				gpu.CanonicalName(), gpu.pciBusID)
+			return nil
+		}
+		klog.Infof("GPU %s (%s) has no gpuModuleID from NVML; resolved module ID %d from Fabric Manager",
+			gpu.CanonicalName(), gpu.pciBusID, moduleID)
+		gpu.gpuModuleID = moduleID
 	}
 	bySize, err := s.fmManager.GetPartitionsBySizeByModuleID(gpu.gpuModuleID)
 	if err != nil {

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -221,6 +221,15 @@ func (vm *VfioPciManager) Unconfigure(ctx context.Context, info *VfioDeviceInfo)
 	return nil
 }
 
+// RebindToNvidiaByPCIBusID returns a GPU to the nvidia driver knowing only its
+// PCI bus id. Teardown normally goes through Unconfigure with the
+// VfioDeviceInfo built during discovery, but startup reconciliation runs before
+// discovery and has nothing but the address: NVML cannot see a vfio-bound GPU,
+// so there is no discovered device to hand over.
+func (vm *VfioPciManager) RebindToNvidiaByPCIBusID(ctx context.Context, pciAddress string) error {
+	return vm.Unconfigure(ctx, &VfioDeviceInfo{PciBusID: pciAddress})
+}
+
 // Module names in the modules.alias file will only ever contain underscore
 // characters and not dashes -- this aligns with how the linux kernel
 // stores module names internally. This can sometimes differ from the name of the

--- a/cmd/gpu-kubelet-plugin/vfio-reconcile.go
+++ b/cmd/gpu-kubelet-plugin/vfio-reconcile.go
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/fabricmanager"
+)
+
+// reconcileStrandedPassthroughGPUs returns GPUs that are bound to a vfio driver
+// without a prepared claim behind them to the nvidia driver, and releases any
+// Fabric Manager partition that was left active for them.
+//
+// A GPU ends up in that state when a passthrough consumer's pod goes away
+// without NodeUnprepareResources running -- a force delete is the usual way.
+// The GPU keeps the vfio binding, and nothing ever puts it back, which has two
+// consequences worth undoing at startup:
+//
+//   - NVML can only enumerate GPUs bound to the nvidia driver, so a stranded GPU
+//     is invisible to discovery. It is announced as a VFIO device with no parent
+//     GpuInfo, which means no gpuModuleID and therefore no partitionN attributes
+//     -- a claim constraining on those can never select it again.
+//   - Its FM partition stays active, so no overlapping partition can be
+//     activated for as long as that lasts.
+//
+// This must run before device discovery so that NVML sees the reclaimed GPUs and
+// everything downstream (module IDs, partition attributes, full-GPU
+// announcement) is populated normally.
+//
+// Failure to reclaim one GPU is logged and skipped rather than returned: a
+// single busy GPU must not stop the plugin from starting and serving the rest of
+// the node.
+func (s *DeviceState) reconcileStrandedPassthroughGPUs(ctx context.Context, currentBootID string) error {
+	if s.vfioPciManager == nil {
+		// Passthrough is disabled, so this driver never binds a GPU to vfio-pci.
+		// Anything vfio-bound on this node belongs to someone else.
+		return nil
+	}
+
+	held, err := s.pciBusIDsHeldByPreparedClaims(ctx, currentBootID)
+	if err != nil {
+		return fmt.Errorf("determining which GPUs prepared claims hold: %w", err)
+	}
+
+	pciDevices, err := s.nvdevlib.nvpci.GetGPUs()
+	if err != nil {
+		return fmt.Errorf("enumerating GPU PCI devices: %w", err)
+	}
+
+	var stranded []string
+	for _, pci := range pciDevices {
+		driver, err := getDriver(pciDevicesPath, pci.Address)
+		if err != nil {
+			// No driver bound, or the device went away. Nothing to reclaim.
+			klog.V(6).Infof("Could not determine driver binding for GPU %s: %v", pci.Address, err)
+			continue
+		}
+		if !isVfioDriver(driver) {
+			continue
+		}
+		if _, live := held[fabricmanager.NormalizePCIBusID(pci.Address)]; live {
+			klog.Infof("GPU %s is bound to %q for a still-prepared claim; leaving it as is", pci.Address, driver)
+			continue
+		}
+		klog.Warningf("GPU %s is bound to %q but no prepared claim holds it; reclaiming it for the nvidia driver. "+
+			"A GPU is left in this state when a passthrough consumer's pod is removed without NodeUnprepareResources "+
+			"running, e.g. a force delete", pci.Address, driver)
+		stranded = append(stranded, pci.Address)
+	}
+
+	if len(stranded) == 0 {
+		return nil
+	}
+
+	reclaimed := make(map[string]struct{}, len(stranded))
+	for _, addr := range stranded {
+		if err := s.vfioPciManager.RebindToNvidiaByPCIBusID(ctx, addr); err != nil {
+			klog.Errorf("Failed to reclaim stranded GPU %s for the nvidia driver: %v", addr, err)
+			continue
+		}
+		klog.Infof("Reclaimed stranded GPU %s for the nvidia driver", addr)
+		reclaimed[fabricmanager.NormalizePCIBusID(addr)] = struct{}{}
+	}
+
+	// Release fabric partitions only after the rebind, mirroring the teardown
+	// ordering in Unprepare: FM must not be asked to tear down a partition whose
+	// GPUs are still handed out for passthrough.
+	s.deactivateFabricPartitionsForReclaimedGPUs(reclaimed)
+
+	return nil
+}
+
+// pciBusIDsHeldByPreparedClaims returns the normalized PCI bus ids of the
+// passthrough GPUs that the checkpoint says are still prepared, and therefore
+// legitimately vfio-bound. Claims that only started preparing count too: their
+// devices may already be bound.
+func (s *DeviceState) pciBusIDsHeldByPreparedClaims(ctx context.Context, currentBootID string) (map[string]struct{}, error) {
+	held := make(map[string]struct{})
+
+	checkpoints, err := s.checkpointManager.ListCheckpoints()
+	if err != nil {
+		return nil, fmt.Errorf("listing checkpoints: %w", err)
+	}
+	if !slices.Contains(checkpoints, DriverPluginCheckpointFileBasename) {
+		// Nothing was ever prepared on this node, so nothing is held.
+		return held, nil
+	}
+
+	cp, err := s.getCheckpoint(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading checkpoint: %w", err)
+	}
+
+	// A differing boot ID invalidates every prepared claim in the checkpoint, so
+	// none of them holds anything. Nothing survives a reboot vfio-bound either,
+	// which makes this mostly belt and braces -- but reading stale claims as
+	// live would suppress exactly the reclamation we are here to do.
+	if storedBootID := cp.GetNodeBootID(); storedBootID != "" && storedBootID != currentBootID {
+		klog.Infof("Checkpoint nodeBootID %q != current %q; treating all prepared claims as stale while reconciling passthrough bindings",
+			storedBootID, currentBootID)
+		return held, nil
+	}
+
+	for uid, claim := range cp.V2.PreparedClaims {
+		for _, group := range claim.PreparedDevices {
+			for _, device := range group.Devices {
+				if device.Vfio == nil || device.Vfio.Info == nil {
+					continue
+				}
+				pci := fabricmanager.NormalizePCIBusID(device.Vfio.Info.PciBusID)
+				if pci == "" {
+					continue
+				}
+				held[pci] = struct{}{}
+				klog.V(6).Infof("Claim %s still holds passthrough GPU %s", uid, pci)
+			}
+		}
+	}
+
+	return held, nil
+}
+
+// deactivateFabricPartitionsForReclaimedGPUs deactivates each active FM
+// partition whose GPUs were *all* just reclaimed.
+//
+// Requiring full coverage keeps this tied to the stranding we actually observed
+// instead of asserting ownership over all FM state: a partition that mixes
+// reclaimed GPUs with GPUs this driver knows nothing about is left alone, since
+// deactivating it could disrupt a consumer we cannot see.
+func (s *DeviceState) deactivateFabricPartitionsForReclaimedGPUs(reclaimed map[string]struct{}) {
+	if !s.fabricManagerPartitioningEnabled() || len(reclaimed) == 0 {
+		return
+	}
+
+	active, err := s.fmManager.ActivePartitions()
+	if err != nil {
+		klog.Errorf("Could not list active Fabric Manager partitions; leaving partition state untouched: %v", err)
+		return
+	}
+
+	for _, partition := range active {
+		covered := 0
+		for _, gpu := range partition.GPUs {
+			if _, ok := reclaimed[fabricmanager.NormalizePCIBusID(gpu.PCIBusID)]; ok {
+				covered++
+			}
+		}
+		if covered == 0 {
+			continue
+		}
+		if covered != len(partition.GPUs) {
+			klog.Warningf("Fabric Manager partition %d is active and %d of its %d GPUs were reclaimed, but not all of them; "+
+				"leaving it active because the remaining GPUs may be in use outside this driver",
+				partition.ID, covered, len(partition.GPUs))
+			continue
+		}
+		klog.Warningf("Fabric Manager partition %d is active but all of its GPUs were stranded; deactivating it", partition.ID)
+		if err := s.fmManager.DeactivatePartition(partition.ID); err != nil {
+			klog.Errorf("Failed to deactivate orphaned Fabric Manager partition %d: %v", partition.ID, err)
+		}
+	}
+}
+
+// isVfioDriver reports whether the given kernel driver name is a vfio-pci
+// variant. Besides plain "vfio-pci" this covers the variant drivers used for
+// specific GPU generations, such as "nvgrace_gpu_vfio_pci" on Grace-based
+// systems.
+func isVfioDriver(driver string) bool {
+	return strings.Contains(driver, "vfio")
+}

--- a/cmd/gpu-kubelet-plugin/vfio-reconcile_test.go
+++ b/cmd/gpu-kubelet-plugin/vfio-reconcile_test.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/fabricmanager"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+func TestIsVfioDriver(t *testing.T) {
+	for _, tc := range []struct {
+		driver string
+		want   bool
+	}{
+		{"vfio-pci", true},
+		// Variant drivers used on specific GPU generations must count too,
+		// otherwise a Grace-based GPU is never recognized as stranded.
+		{"nvgrace_gpu_vfio_pci", true},
+		{"vfio_pci", true},
+		{"nvidia", false},
+		{"", false},
+	} {
+		t.Run(tc.driver, func(t *testing.T) {
+			require.Equal(t, tc.want, isVfioDriver(tc.driver))
+		})
+	}
+}
+
+// fmPartition builds a partition whose members carry the PCI bus ids FM
+// reports (8-digit upper-case domain), so the tests exercise the same
+// normalization the production path relies on.
+func fmPartition(id int, active bool, moduleIDs ...int) fabricmanager.Partition {
+	gpus := make([]fabricmanager.PartitionGPU, len(moduleIDs))
+	for i, moduleID := range moduleIDs {
+		gpus[i] = fabricmanager.PartitionGPU{
+			PhysicalID: moduleID,
+			PCIBusID:   fmPCIBusID(moduleID),
+		}
+	}
+	return fabricmanager.Partition{ID: id, IsActive: active, GPUs: gpus}
+}
+
+func fmPCIBusID(moduleID int) string {
+	const hex = "0123456789abcdef"
+	return "00000000:0" + string(hex[moduleID]) + ":00.0"
+}
+
+func reclaimedSet(moduleIDs ...int) map[string]struct{} {
+	out := make(map[string]struct{}, len(moduleIDs))
+	for _, moduleID := range moduleIDs {
+		out[fabricmanager.NormalizePCIBusID(fmPCIBusID(moduleID))] = struct{}{}
+	}
+	return out
+}
+
+func newFMState(t *testing.T, partitions ...fabricmanager.Partition) (*DeviceState, *testFMClient) {
+	t.Helper()
+	client := &testFMClient{partitions: partitions}
+	manager, err := fabricmanager.Open(client)
+	require.NoError(t, err)
+	return &DeviceState{fmManager: manager}, client
+}
+
+func TestDeactivateFabricPartitionsForReclaimedGPUs(t *testing.T) {
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+		string(featuregates.FabricManagerPartitioning): true,
+	}))
+
+	t.Run("all GPUs reclaimed", func(t *testing.T) {
+		state, client := newFMState(t, fmPartition(2, true, 1, 2))
+		state.deactivateFabricPartitionsForReclaimedGPUs(reclaimedSet(1, 2))
+		require.Equal(t, []int{2}, client.deactivatedIDs)
+	})
+
+	t.Run("partially reclaimed partition is left active", func(t *testing.T) {
+		// The unreclaimed GPU may belong to a consumer this driver cannot see;
+		// tearing the partition down would disrupt it.
+		state, client := newFMState(t, fmPartition(1, true, 1, 2, 3, 4))
+		state.deactivateFabricPartitionsForReclaimedGPUs(reclaimedSet(1, 2))
+		require.Empty(t, client.deactivatedIDs)
+	})
+
+	t.Run("unrelated active partition is untouched", func(t *testing.T) {
+		state, client := newFMState(t, fmPartition(3, true, 3, 4))
+		state.deactivateFabricPartitionsForReclaimedGPUs(reclaimedSet(1, 2))
+		require.Empty(t, client.deactivatedIDs)
+	})
+
+	t.Run("inactive partition is not deactivated", func(t *testing.T) {
+		state, client := newFMState(t, fmPartition(2, false, 1, 2))
+		state.deactivateFabricPartitionsForReclaimedGPUs(reclaimedSet(1, 2))
+		require.Empty(t, client.deactivatedIDs)
+	})
+
+	t.Run("only fully covered partitions among several", func(t *testing.T) {
+		state, client := newFMState(t,
+			fmPartition(1, true, 1, 2, 3, 4), // partially covered -> kept
+			fmPartition(2, true, 1, 2),       // fully covered -> released
+			fmPartition(3, true, 3, 4),       // uncovered -> kept
+		)
+		state.deactivateFabricPartitionsForReclaimedGPUs(reclaimedSet(1, 2))
+		require.Equal(t, []int{2}, client.deactivatedIDs)
+	})
+
+	t.Run("nothing reclaimed", func(t *testing.T) {
+		state, client := newFMState(t, fmPartition(2, true, 1, 2))
+		state.deactivateFabricPartitionsForReclaimedGPUs(nil)
+		require.Empty(t, client.deactivatedIDs)
+	})
+}
+
+func TestDeactivateFabricPartitionsForReclaimedGPUsFeatureGateOff(t *testing.T) {
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+		string(featuregates.FabricManagerPartitioning): false,
+	}))
+	t.Cleanup(func() {
+		require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+			string(featuregates.FabricManagerPartitioning): true,
+		}))
+	})
+
+	state, client := newFMState(t, fmPartition(2, true, 1, 2))
+	state.deactivateFabricPartitionsForReclaimedGPUs(reclaimedSet(1, 2))
+	require.Empty(t, client.deactivatedIDs, "FM must not be touched while the feature gate is off")
+}
+
+func TestDeactivateFabricPartitionsForReclaimedGPUsNoFabricManager(t *testing.T) {
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+		string(featuregates.FabricManagerPartitioning): true,
+	}))
+
+	// The gate can be on while this node has no NVSwitch fabric, in which case
+	// newFabricManager returns a nil Manager and reconciliation must still be
+	// safe to run.
+	state := &DeviceState{}
+	require.NotPanics(t, func() {
+		state.deactivateFabricPartitionsForReclaimedGPUs(reclaimedSet(1, 2))
+	})
+}

--- a/pkg/fabricmanager/manager.go
+++ b/pkg/fabricmanager/manager.go
@@ -19,6 +19,7 @@ package fabricmanager
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"k8s.io/klog/v2"
 )
@@ -40,6 +41,10 @@ const (
 type Manager struct {
 	client         Client
 	partitionsByID map[int]Partition
+	// moduleIDByPCI maps a normalized PCI bus id to the gpuModuleID FM reports
+	// for the GPU at that address. FM reports both for every partition member,
+	// which makes it an NVML-independent source for a GPU's module ID.
+	moduleIDByPCI map[string]int
 }
 
 // Open builds a Manager for the caller to subsequently activate and deactivate
@@ -53,6 +58,7 @@ func Open(client Client) (*Manager, error) {
 	m := &Manager{
 		client:         client,
 		partitionsByID: make(map[int]Partition),
+		moduleIDByPCI:  make(map[string]int),
 	}
 
 	if err := client.Init(); err != nil {
@@ -118,6 +124,7 @@ func (m *Manager) Close() error {
 // members).
 func (m *Manager) recordsPartitions(parts []Partition) error {
 	byID := make(map[int]Partition, len(parts))
+	moduleIDByPCI := make(map[string]int)
 
 	for _, p := range parts {
 		if _, dup := byID[p.ID]; dup {
@@ -133,11 +140,72 @@ func (m *Manager) recordsPartitions(parts []Partition) error {
 					p.ID, g.PhysicalID)
 			}
 			seen[g.PhysicalID] = struct{}{}
+
+			// Index PCI bus id -> module id. The same GPU appears in every
+			// partition it is a member of, so repeats are expected; only a
+			// genuine disagreement is a problem, and silently keeping either
+			// value would let us later activate a partition built from the
+			// wrong GPU.
+			pci := NormalizePCIBusID(g.PCIBusID)
+			if pci == "" {
+				continue
+			}
+			if existing, ok := moduleIDByPCI[pci]; ok && existing != g.PhysicalID {
+				return fmt.Errorf(
+					"fabricmanager: PCI bus id %q maps to two gpuModuleIDs (%d and %d)",
+					pci, existing, g.PhysicalID)
+			}
+			moduleIDByPCI[pci] = g.PhysicalID
 		}
 		byID[p.ID] = p
 	}
 	m.partitionsByID = byID
+	m.moduleIDByPCI = moduleIDByPCI
 	return nil
+}
+
+// ModuleIDByPCIBusID returns the gpuModuleID FM reports for the GPU at the
+// given PCI bus id, or false when FM did not report a GPU at that address.
+//
+// This is the NVML-independent path to a module ID. It matters because NVML can
+// only enumerate GPUs bound to the `nvidia` kernel driver, so a GPU that is
+// currently bound to a vfio-pci variant for passthrough has no module ID from
+// NVML -- while FM, which talks to the NVSwitches rather than the GPUs, still
+// reports it.
+func (m *Manager) ModuleIDByPCIBusID(pciBusID string) (int, bool) {
+	id, ok := m.moduleIDByPCI[NormalizePCIBusID(pciBusID)]
+	return id, ok
+}
+
+// ActivePartitions re-queries FM and returns the partitions it currently
+// reports as active. Unlike GetPartition this does not serve the topology
+// recorded at Open time, because activation state changes underneath us.
+func (m *Manager) ActivePartitions() ([]Partition, error) {
+	partitions, err := m.client.GetSupportedFabricPartitions()
+	if err != nil {
+		return nil, fmt.Errorf("fabricmanager: fmGetSupportedFabricPartitions: %w", err)
+	}
+	var active []Partition
+	for _, p := range partitions {
+		if p.IsActive {
+			active = append(active, p)
+		}
+	}
+	return active, nil
+}
+
+// NormalizePCIBusID renders a PCI bus id in the lower-case, 4-digit-domain form
+// used by sysfs ("0000:0f:00.0"). FM reports the same address with an 8-digit
+// domain and upper-case hex ("00000000:0F:00.0"), so the two cannot be compared
+// directly. Anything shorter than a full BDF is returned lower-cased but
+// otherwise untouched, so a malformed value cannot silently match.
+func NormalizePCIBusID(pciBusID string) string {
+	pci := strings.ToLower(strings.TrimSpace(pciBusID))
+	const bdfLen = len("0000:00:00.0")
+	if len(pci) > bdfLen {
+		return pci[len(pci)-bdfLen:]
+	}
+	return pci
 }
 
 // GetPartition returns the FM partition info for the given partitionId, or

--- a/pkg/fabricmanager/manager_test.go
+++ b/pkg/fabricmanager/manager_test.go
@@ -18,6 +18,7 @@ package fabricmanager
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -447,5 +448,140 @@ func TestStubClient(t *testing.T) {
 	}
 	if err := c.Shutdown(); err != nil {
 		t.Errorf("stub Shutdown: %v", err)
+	}
+}
+
+// pciGPUs builds partition members carrying both a module id and a PCI bus id,
+// in the 8-digit upper-case domain form FM actually reports.
+func pciGPUs(ids ...int) []PartitionGPU {
+	out := make([]PartitionGPU, len(ids))
+	for i, id := range ids {
+		out[i] = PartitionGPU{
+			PhysicalID: id,
+			PCIBusID:   fmt.Sprintf("00000000:%02X:00.0", id),
+		}
+	}
+	return out
+}
+
+func TestNormalizePCIBusID(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"fm form", "00000000:0F:00.0", "0000:0f:00.0"},
+		{"sysfs form", "0000:0f:00.0", "0000:0f:00.0"},
+		{"surrounding whitespace", "  00000000:0F:00.0\n", "0000:0f:00.0"},
+		{"already lower 8-digit", "00000000:0f:00.0", "0000:0f:00.0"},
+		// Anything shorter than a full BDF is lower-cased but not truncated, so a
+		// malformed value cannot accidentally equal a well-formed one.
+		{"short value", "0F:00.0", "0f:00.0"},
+		{"empty", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizePCIBusID(tc.in); got != tc.want {
+				t.Errorf("NormalizePCIBusID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModuleIDByPCIBusID(t *testing.T) {
+	client := &fakeClient{partitions: []Partition{
+		{ID: 1, GPUs: pciGPUs(1, 2, 3, 4)},
+		{ID: 2, GPUs: pciGPUs(1, 2)},
+	}}
+	m, err := Open(client)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	// A GPU appearing in several partitions is indexed once, and the caller may
+	// present the address in either the FM or the sysfs form.
+	for _, query := range []string{"00000000:02:00.0", "0000:02:00.0", "0000:02:00.0"} {
+		id, ok := m.ModuleIDByPCIBusID(query)
+		if !ok {
+			t.Fatalf("ModuleIDByPCIBusID(%q): not found", query)
+		}
+		if id != 2 {
+			t.Errorf("ModuleIDByPCIBusID(%q) = %d, want 2", query, id)
+		}
+	}
+
+	if _, ok := m.ModuleIDByPCIBusID("0000:ff:00.0"); ok {
+		t.Error("ModuleIDByPCIBusID for an address FM never reported: got ok=true, want false")
+	}
+}
+
+func TestModuleIDByPCIBusIDMissingAddresses(t *testing.T) {
+	// FM reporting no PCI bus id must not produce a bogus "" -> moduleID entry
+	// that every unknown address would then match.
+	client := &fakeClient{partitions: []Partition{{ID: 1, GPUs: gpus(1, 2)}}}
+	m, err := Open(client)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if id, ok := m.ModuleIDByPCIBusID(""); ok {
+		t.Errorf("ModuleIDByPCIBusID(\"\") = (%d, true), want not found", id)
+	}
+}
+
+func TestOpenRejectsConflictingPCIBusID(t *testing.T) {
+	// The same address reported with two different module ids means we cannot
+	// trust the index; activating a partition built from the wrong GPU would
+	// program the fabric for devices the claim does not hold.
+	client := &fakeClient{partitions: []Partition{
+		{ID: 1, GPUs: []PartitionGPU{{PhysicalID: 1, PCIBusID: "00000000:01:00.0"}}},
+		{ID: 2, GPUs: []PartitionGPU{{PhysicalID: 2, PCIBusID: "00000000:01:00.0"}}},
+	}}
+	if _, err := Open(client); err == nil {
+		t.Fatal("Open with conflicting PCI bus ids: got nil error, want failure")
+	}
+}
+
+func TestActivePartitions(t *testing.T) {
+	client := &fakeClient{partitions: []Partition{
+		{ID: 1, GPUs: pciGPUs(1, 2, 3, 4)},
+		{ID: 2, GPUs: pciGPUs(1, 2)},
+		{ID: 3, GPUs: pciGPUs(3, 4)},
+	}}
+	m, err := Open(client)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	active, err := m.ActivePartitions()
+	if err != nil {
+		t.Fatalf("ActivePartitions: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("ActivePartitions before any activation = %v, want none", active)
+	}
+
+	if err := m.ActivatePartition(2); err != nil {
+		t.Fatalf("ActivatePartition: %v", err)
+	}
+
+	// The result must come from a fresh query, not the topology recorded at Open
+	// time -- activation state changes underneath the Manager.
+	active, err = m.ActivePartitions()
+	if err != nil {
+		t.Fatalf("ActivePartitions: %v", err)
+	}
+	if len(active) != 1 || active[0].ID != 2 {
+		t.Fatalf("ActivePartitions after activating 2 = %v, want just partition 2", active)
+	}
+}
+
+func TestActivePartitionsClientError(t *testing.T) {
+	client := &fakeClient{partitions: designDocPartitions()}
+	m, err := Open(client)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	client.listErr = errors.New("boom")
+	if _, err := m.ActivePartitions(); err == nil {
+		t.Fatal("ActivePartitions with a failing client: got nil error, want failure")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

On an NVSwitch / Fabric Manager (HGX) node with `PassthroughSupport` and `FabricManagerPartitioning` enabled, if the `gpu-kubelet-plugin` restarts **while a VFIO passthrough claim is active** (typical of a node/kubelet restart that also force-restarts the DRA driver DaemonSet and the consumer pod), the vfio-bound GPU is stranded with two consequences:

- **NVML cannot enumerate a vfio-bound GPU**, so at discovery it has `gpuModuleID == 0`, is published with **no `partitionN` attributes**, and silently drops out of the allocatable pool — a claim constraining on those attributes can never select it again (surfaces to the consumer as "CDI: UUID not found").
- **Its Fabric Manager partition is never released**, so no overlapping partition can be activated for as long as that lasts.

This PR adds a startup reconciliation that runs **before** device discovery:

- Rebind every GPU that is bound to a vfio-pci variant driver but **not** held by a still-prepared claim (checked against the checkpoint, honoring the node boot ID) back to the `nvidia` driver, so NVML sees it and discovery populates module IDs / `partitionN` attributes normally. A busy GPU is logged and skipped, never fatal to startup.
- After rebinding, deactivate any active FM partition whose GPUs were **all** reclaimed; a partition mixing reclaimed GPUs with GPUs this driver does not know about is left alone.
- As a fallback, resolve a missing module ID from Fabric Manager (`ModuleIDByPCIBusID`) in `attachFabricManagerPartitions()` instead of dropping the GPU, so a legitimately vfio-bound GPU keeps its partition attributes.

#### Which issue(s) this PR is related to:

Fixes #1331

#### Special notes for your reviewer:

- Reconciliation is guarded: it only acts when `PassthroughSupport` is on (`vfioPciManager != nil`), never deactivates a partially-covered FM partition, and treats a busy GPU as non-fatal.
- Unit tests cover the FM module-ID index (`ModuleIDByPCIBusID`, `NormalizePCIBusID`), `ActivePartitions`, conflicting-PCI rejection, and the partition-deactivation coverage rules (`pkg/fabricmanager` — pure Go, verified passing).
- Original fix authored by Peter Razumovsky (co-authored on the commit).

#### Does this PR introduce a user-facing change?

```release-note
Reclaim passthrough GPUs left bound to vfio across a gpu-kubelet-plugin restart: rebind orphaned GPUs to the nvidia driver at startup so they rejoin the allocatable pool, and release Fabric Manager partitions stranded by a force-deleted consumer pod (HGX).
```

#### Additional documentation (design docs, usage docs, etc.):

```docs
NONE
```

#### Checklist

- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed