### PR TITLE
Adding rejection logic for invalid admin access claims

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -289,6 +289,11 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 }
 
 func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceClaim) ([]kubeletplugin.Device, error) {
+
+	if err := s.validateAdminAccessRequest(claim); err != nil {
+		return nil, err
+	}
+
 	tplock0 := time.Now()
 	s.Lock()
 	defer s.Unlock()
@@ -824,6 +829,56 @@ func (s *DeviceState) deleteClaimFromCheckpoint(ctx context.Context, claimRef ku
 	return nil
 }
 
+// validateAdminAccessRequest rejects admin-access requests that are incompatible
+// with how this driver treats admin access. Admin access is meant for host-side
+// monitoring/management of a full GPU, so it must not be combined with:
+//   - a non-full-GPU device (e.g. a VFIO passthrough or MIG device), or
+//   - any device configuration that applies to the admin-access request.
+func (s *DeviceState) validateAdminAccessRequest(claim *resourceapi.ResourceClaim) error {
+	if claim.Status.Allocation == nil {
+		return nil
+	}
+
+	// Reject admin access on any device that is not a full GPU.
+	adminRequests := make(map[string]struct{})
+	for _, r := range claim.Status.Allocation.Devices.Results {
+		if r.Driver != DriverName {
+			continue
+		}
+		if r.AdminAccess == nil || !*r.AdminAccess {
+			continue
+		}
+		adminRequests[r.Request] = struct{}{}
+		device := s.perGPUAllocatable.GetAllocatableDevice(r.Device)
+		if device != nil && device.Type() != GpuDeviceType {
+			return fmt.Errorf("claim %s requests admin access on a non-full-GPU device, which is not supported", ResourceClaimToString(claim))
+		}
+	}
+
+	if len(adminRequests) == 0 {
+		return nil
+	}
+
+	// Reject admin access combined with any device configuration for this driver
+	// that applies to an admin-access request.
+	for _, cfg := range claim.Status.Allocation.Devices.Config {
+		if cfg.Opaque == nil || cfg.Opaque.Driver != DriverName {
+			continue
+		}
+		// An empty Requests list means the config applies to every request in the
+		// claim, including the admin-access ones.
+		if len(cfg.Requests) == 0 {
+			return fmt.Errorf("claim %s requests admin access with a device configuration, which is not supported", ResourceClaimToString(claim))
+		}
+		for _, req := range cfg.Requests {
+			if _, ok := adminRequests[req]; ok {
+				return fmt.Errorf("claim %s requests admin access with a device configuration, which is not supported", ResourceClaimToString(claim))
+			}
+		}
+	}
+	return nil
+}
+
 func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.ResourceClaim, cp *Checkpoint) (PreparedDevices, error) {
 	if claim.Status.Allocation == nil {
 		return nil, fmt.Errorf("claim not yet allocated")
@@ -1314,7 +1369,7 @@ func (s *DeviceState) gpuInfosFromPreparedClaim(results []resourceapi.DeviceRequ
 // Callers that include VFIO devices must first rebind those GPUs to the nvidia
 // driver and rediscover so each VFIO device's parent is repopulated.
 func (s *DeviceState) deactivateFabricPartition(claimUID string, pc *PreparedClaim, checkpoint *Checkpoint) error {
-	if !s.fabricManagerPartitioningEnabled() || pc.Status.Allocation == nil {
+	if !s.fabricManagerPartitioningEnabled() || pc.Status.Allocation == nil || isAdminAccess(pc.Status.Allocation.Devices.Results) {
 		return nil
 	}
 	gpus := s.gpuInfosFromPreparedClaim(pc.Status.Allocation.Devices.Results)
@@ -1374,6 +1429,10 @@ func (s *DeviceState) fabricManagerPartitioningEnabled() bool {
 // GPUs backing the claim's allocation results. The caller must ensure
 // fabricManagerPartitioningEnabled() is true and that the claim is allocated.
 func (s *DeviceState) activateFabricPartition(claim *resourceapi.ResourceClaim) error {
+	if isAdminAccess(claim.Status.Allocation.Devices.Results) {
+		return nil
+	}
+
 	gpus := s.gpuInfosFromPreparedClaim(claim.Status.Allocation.Devices.Results)
 	if len(gpus) == 0 {
 		return nil
@@ -1728,10 +1787,33 @@ func isGpuUUIDInUseByOtherClaims(checkpoint *Checkpoint, claimUID string, gpuUUI
 		if otherClaim.CheckpointState != ClaimCheckpointStatePrepareCompleted {
 			continue
 		}
-		for _, u := range otherClaim.PreparedDevices.GpuUUIDs() {
-			if u == gpuUUID {
-				return true
+		for _, group := range otherClaim.PreparedDevices {
+			for _, dev := range group.Devices {
+				if dev.Gpu == nil || dev.Gpu.Info == nil || dev.Gpu.Device == nil {
+					continue
+				}
+				if preparedClaimDeviceHasAdminAccess(&otherClaim, dev.Gpu.Device.DeviceName) {
+					continue
+				}
+				if dev.Gpu.Info.UUID == gpuUUID {
+					return true
+				}
 			}
+		}
+	}
+	return false
+}
+
+func preparedClaimDeviceHasAdminAccess(claim *PreparedClaim, deviceName DeviceName) bool {
+	if claim == nil || claim.Status.Allocation == nil {
+		return false
+	}
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		if result.Driver != DriverName || result.Device != deviceName {
+			continue
+		}
+		if result.AdminAccess != nil && *result.AdminAccess {
+			return true
 		}
 	}
 	return false
@@ -1811,6 +1893,18 @@ func (s *DeviceState) AddDeviceTaint(d *AllocatableDevice, taint *resourceapi.De
 func (s *DeviceState) IsMigCapable() bool {
 	for _, gpu := range s.nvdevlib.gpuInfosByUUID {
 		if gpu.migCapable {
+			return true
+		}
+	}
+	return false
+}
+
+func isAdminAccess(results []resourceapi.DeviceRequestAllocationResult) bool {
+	for _, r := range results {
+		if r.Driver != DriverName {
+			continue
+		}
+		if r.AdminAccess != nil && *r.AdminAccess {
 			return true
 		}
 	}

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/fabricmanager"
@@ -211,6 +212,16 @@ func TestSharingReferenceCountingHelpers(t *testing.T) {
 			PreparedClaims: PreparedClaimsByUID{
 				"claim-1": {
 					CheckpointState: ClaimCheckpointStatePrepareCompleted,
+					Status: resourceapi.ResourceClaimStatus{
+						Allocation: &resourceapi.AllocationResult{
+							Devices: resourceapi.DeviceAllocationResult{
+								Results: []resourceapi.DeviceRequestAllocationResult{
+									{Driver: DriverName, Device: "gpu-0"},
+									{Driver: DriverName, Device: "mig-0"},
+								},
+							},
+						},
+					},
 					PreparedDevices: PreparedDevices{
 						{
 							Devices: PreparedDeviceList{
@@ -234,6 +245,41 @@ func TestSharingReferenceCountingHelpers(t *testing.T) {
 						},
 					},
 				},
+				"claim-admin": {
+					CheckpointState: ClaimCheckpointStatePrepareCompleted,
+					Status: resourceapi.ResourceClaimStatus{
+						Allocation: &resourceapi.AllocationResult{
+							Devices: resourceapi.DeviceAllocationResult{
+								Results: []resourceapi.DeviceRequestAllocationResult{
+									{Driver: DriverName, Device: "gpu-admin", AdminAccess: ptr.To(true)},
+									{Driver: DriverName, Device: "gpu-non-admin"},
+								},
+							},
+						},
+					},
+					PreparedDevices: PreparedDevices{
+						{
+							Devices: PreparedDeviceList{
+								{
+									Gpu: &PreparedGpu{
+										Info: &GpuInfo{UUID: "GPU-ADMIN"},
+										Device: &CheckpointedDevice{
+											DeviceName: "gpu-admin",
+										},
+									},
+								},
+								{
+									Gpu: &PreparedGpu{
+										Info: &GpuInfo{UUID: "GPU-NON-ADMIN"},
+										Device: &CheckpointedDevice{
+											DeviceName: "gpu-non-admin",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -249,6 +295,9 @@ func TestSharingReferenceCountingHelpers(t *testing.T) {
 	require.True(t, isMigDeviceInUseByOtherClaims(checkpoint, "claim-2", "MIG-2222", "mig-0"))
 	require.False(t, isMigDeviceInUseByOtherClaims(checkpoint, "claim-2", "MIG-9999", "mig-9"))
 	require.False(t, isMigDeviceInUseByOtherClaims(checkpoint, "claim-1", "MIG-2222", "mig-0"))
+
+	require.False(t, isGpuUUIDInUseByOtherClaims(checkpoint, "claim-2", "GPU-ADMIN"))
+	require.True(t, isGpuUUIDInUseByOtherClaims(checkpoint, "claim-2", "GPU-NON-ADMIN"))
 
 	var cpNil *Checkpoint
 	require.False(t, isGpuUUIDInUseByOtherClaims(cpNil, "claim-1", "GPU-1111"))
@@ -384,4 +433,143 @@ func TestDeactivateFabricPartitionRefCounting(t *testing.T) {
 	err = state.deactivateFabricPartition("claim-1", &pc1, checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, []int{1}, fmClient.deactivatedIDs, "FM partition deactivation MUST be called when no active claims remain")
+}
+
+func TestValidateAdminAccessRequest(t *testing.T) {
+	state := &DeviceState{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				"0000:00:00.0": {
+					"gpu-0":  &AllocatableDevice{Gpu: &GpuInfo{minor: 0}},
+					"vfio-0": &AllocatableDevice{Vfio: &VfioDeviceInfo{index: 0}},
+					"mig-0":  &AllocatableDevice{MigStatic: &MigDeviceInfo{}},
+				},
+			},
+		},
+	}
+
+	// driverConfig builds a config for this driver applying to the given requests
+	// (empty requests means it applies to every request in the claim).
+	driverConfig := func(requests ...string) resourceapi.DeviceAllocationConfiguration {
+		return resourceapi.DeviceAllocationConfiguration{
+			Source:   resourceapi.AllocationConfigSourceClaim,
+			Requests: requests,
+			DeviceConfiguration: resourceapi.DeviceConfiguration{
+				Opaque: &resourceapi.OpaqueDeviceConfiguration{Driver: DriverName},
+			},
+		}
+	}
+	otherDriverConfig := func(requests ...string) resourceapi.DeviceAllocationConfiguration {
+		c := driverConfig(requests...)
+		c.Opaque.Driver = "other.driver.com"
+		return c
+	}
+
+	adminGpu := resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Request: "gpu", Device: "gpu-0", AdminAccess: ptr.To(true)}
+	nonAdminGpu := resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Request: "gpu", Device: "gpu-0"}
+	adminVfio := resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Request: "gpu", Device: "vfio-0", AdminAccess: ptr.To(true)}
+	adminMig := resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Request: "gpu", Device: "mig-0", AdminAccess: ptr.To(true)}
+
+	tests := []struct {
+		name    string
+		noAlloc bool
+		results []resourceapi.DeviceRequestAllocationResult
+		configs []resourceapi.DeviceAllocationConfiguration
+		wantErr bool
+	}{
+		{
+			name:    "no allocation",
+			noAlloc: true,
+		},
+		{
+			name:    "vfio without admin access",
+			results: []resourceapi.DeviceRequestAllocationResult{{Driver: DriverName, Request: "gpu", Device: "vfio-0"}},
+		},
+		{
+			name:    "vfio with admin access rejected",
+			results: []resourceapi.DeviceRequestAllocationResult{adminVfio},
+			wantErr: true,
+		},
+		{
+			name:    "gpu with admin access, no config, allowed",
+			results: []resourceapi.DeviceRequestAllocationResult{adminGpu},
+		},
+		{
+			name:    "mig with admin access rejected",
+			results: []resourceapi.DeviceRequestAllocationResult{adminMig},
+			wantErr: true,
+		},
+		{
+			name:    "mixed: gpu plus admin-access vfio rejected",
+			results: []resourceapi.DeviceRequestAllocationResult{nonAdminGpu, adminVfio},
+			wantErr: true,
+		},
+		{
+			name:    "admin-access vfio for other driver ignored",
+			results: []resourceapi.DeviceRequestAllocationResult{{Driver: "other.driver.com", Request: "gpu", Device: "vfio-0", AdminAccess: ptr.To(true)}},
+		},
+		{
+			name:    "gpu admin access with config targeting the request rejected",
+			results: []resourceapi.DeviceRequestAllocationResult{adminGpu},
+			configs: []resourceapi.DeviceAllocationConfiguration{driverConfig("gpu")},
+			wantErr: true,
+		},
+		{
+			name:    "gpu admin access with claim-wide config rejected",
+			results: []resourceapi.DeviceRequestAllocationResult{adminGpu},
+			configs: []resourceapi.DeviceAllocationConfiguration{driverConfig()},
+			wantErr: true,
+		},
+		{
+			name:    "gpu admin access with config for another request allowed",
+			results: []resourceapi.DeviceRequestAllocationResult{adminGpu},
+			configs: []resourceapi.DeviceAllocationConfiguration{driverConfig("other")},
+		},
+		{
+			name:    "non-admin gpu with config allowed",
+			results: []resourceapi.DeviceRequestAllocationResult{nonAdminGpu},
+			configs: []resourceapi.DeviceAllocationConfiguration{driverConfig("gpu")},
+		},
+		{
+			name:    "gpu admin access with config for another driver allowed",
+			results: []resourceapi.DeviceRequestAllocationResult{adminGpu},
+			configs: []resourceapi.DeviceAllocationConfiguration{otherDriverConfig("gpu")},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			claim := &resourceapi.ResourceClaim{}
+			if !tc.noAlloc {
+				claim.Status.Allocation = &resourceapi.AllocationResult{
+					Devices: resourceapi.DeviceAllocationResult{
+						Results: tc.results,
+						Config:  tc.configs,
+					},
+				}
+			}
+			err := state.validateAdminAccessRequest(claim)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsAdminAccessIgnoresOtherDrivers(t *testing.T) {
+	results := []resourceapi.DeviceRequestAllocationResult{
+		{Driver: "other.driver.com", AdminAccess: ptr.To(true)},
+		{Driver: DriverName},
+	}
+
+	require.False(t, isAdminAccess(results))
+
+	results = append(results, resourceapi.DeviceRequestAllocationResult{
+		Driver:      DriverName,
+		AdminAccess: ptr.To(true),
+	})
+
+	require.True(t, isAdminAccess(results))
 }

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -262,6 +262,8 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 			configInterface = castConfig
 		case *nvapi.MigDeviceConfig:
 			configInterface = castConfig
+		case *nvapi.VfioDeviceConfig:
+			configInterface = castConfig
 		case *nvapi.ComputeDomainChannelConfig:
 			configInterface = castConfig
 		case *nvapi.ComputeDomainDaemonConfig:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
Admin-access ResourceClaims are intended for host-side monitoring/management
of full GPUs. This PR:
 
* Skips Fabric Manager partition activate/deactivate for admin-access claims
* Rejects admin access on non-full-GPU devices (MIG, VFIO) at prepare time
* Rejects admin access combined with this driver's device configuration
* Ignores admin-access allocations in consumable-share "in use" reference checks
  so monitors do not block unprepare of workload claims
* Enforces the same full-GPU + no-config constraints in the validating admission
  webhook

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
Admin-access ResourceClaims are limited to full GPUs without device configuration; Fabric Manager partitions are not activated or deactivated for admin-access claims.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
