### PR TITLE
Fix ComputeDomain node index conflicts

### DIFF
--- a/api/nvidia.com/resource/v1beta1/computedomain.go
+++ b/api/nvidia.com/resource/v1beta1/computedomain.go
@@ -127,8 +127,9 @@ type ComputeDomainNode struct {
 	// mapping across all machines within an IMEX domain. Each node's index
 	// directly determines its DNS name within a given NVLink partition
 	// (i.e. clique). In other words, the 2-tuple of (CliqueID, Index) will
-	// always be unique. This field is marked as optional (but not
-	// omitempty) in order to support downgrades and avoid an API bump.
+	// always be unique. Nodes without a clique receive a stable synthetic index
+	// which is not used for DNS mapping. This field is marked as optional (but
+	// not omitempty) in order to support downgrades and avoid an API bump.
 	// +kubebuilder:validation:Optional
 	Index int `json:"index"`
 	// The Status field tracks the readiness of the IMEX daemon running on

--- a/cmd/compute-domain-controller/cdstatus.go
+++ b/cmd/compute-domain-controller/cdstatus.go
@@ -211,12 +211,12 @@ func (m *ComputeDomainStatusManager) syncCD(ctx context.Context, cd *nvapi.Compu
 	if m.cliqueManager != nil {
 		// Feature gate enabled: build from cliques + non-fabric pods
 		fabricNodes = m.buildNodesFromCliques(cliques)
-		nonFabricNodes = m.buildNodesFromPods(nonFabricPods)
+		nonFabricNodes = m.buildNodesFromPods(nonFabricPods, cd.Status.Nodes)
 		newNodes = slices.Concat(fabricNodes, nonFabricNodes)
 	} else {
 		// Feature gate disabled: filter stale fabric nodes + rebuild non-fabric nodes
 		fabricNodes = m.getNonStaleFabricNodes(cd.Status.Nodes, fabricPods)
-		nonFabricNodes = m.buildNodesFromPods(nonFabricPods)
+		nonFabricNodes = m.buildNodesFromPods(nonFabricPods, cd.Status.Nodes)
 		newNodes = slices.Concat(fabricNodes, nonFabricNodes)
 	}
 
@@ -256,12 +256,66 @@ func (m *ComputeDomainStatusManager) buildNodesFromCliques(cliques []*nvapi.Comp
 }
 
 // buildNodesFromPods builds ComputeDomainNode entries from non-fabric-attached pods.
-func (m *ComputeDomainStatusManager) buildNodesFromPods(pods []*corev1.Pod) []*nvapi.ComputeDomainNode {
-	var nodes []*nvapi.ComputeDomainNode
+func (m *ComputeDomainStatusManager) buildNodesFromPods(pods []*corev1.Pod, existingNodes []*nvapi.ComputeDomainNode) []*nvapi.ComputeDomainNode {
+	podsByNode := make(map[string]*corev1.Pod)
 	for _, pod := range pods {
 		if pod.Spec.NodeName == "" || pod.Status.PodIP == "" {
 			continue
 		}
+		existingPod, exists := podsByNode[pod.Spec.NodeName]
+		if !exists || preferNonFabricPod(pod, existingPod) {
+			podsByNode[pod.Spec.NodeName] = pod
+		}
+	}
+
+	nodeNames := make([]string, 0, len(podsByNode))
+	for nodeName := range podsByNode {
+		nodeNames = append(nodeNames, nodeName)
+	}
+	slices.Sort(nodeNames)
+
+	// Preserve valid indices for surviving nodes. Count first so that legacy
+	// duplicate indices are repaired instead of arbitrarily preserving one.
+	indexCounts := make(map[int]int)
+	nodeCounts := make(map[string]int)
+	existingIndices := make(map[string]int)
+	for _, node := range existingNodes {
+		if node.CliqueID != "" || node.Index < 0 {
+			continue
+		}
+		if _, exists := podsByNode[node.Name]; !exists {
+			continue
+		}
+		indexCounts[node.Index]++
+		nodeCounts[node.Name]++
+		existingIndices[node.Name] = node.Index
+	}
+
+	assignedIndices := make(map[string]int, len(nodeNames))
+	usedIndices := make(map[int]bool, len(nodeNames))
+	for _, nodeName := range nodeNames {
+		index, exists := existingIndices[nodeName]
+		if exists && nodeCounts[nodeName] == 1 && indexCounts[index] == 1 {
+			assignedIndices[nodeName] = index
+			usedIndices[index] = true
+		}
+	}
+
+	nextIndex := 0
+	for _, nodeName := range nodeNames {
+		if _, exists := assignedIndices[nodeName]; exists {
+			continue
+		}
+		for usedIndices[nextIndex] {
+			nextIndex++
+		}
+		assignedIndices[nodeName] = nextIndex
+		usedIndices[nextIndex] = true
+	}
+
+	nodes := make([]*nvapi.ComputeDomainNode, 0, len(nodeNames))
+	for _, nodeName := range nodeNames {
+		pod := podsByNode[nodeName]
 
 		status := nvapi.ComputeDomainStatusNotReady
 		for _, condition := range pod.Status.Conditions {
@@ -272,14 +326,39 @@ func (m *ComputeDomainStatusManager) buildNodesFromPods(pods []*corev1.Pod) []*n
 		}
 
 		nodes = append(nodes, &nvapi.ComputeDomainNode{
-			Name:      pod.Spec.NodeName,
+			Name:      nodeName,
 			IPAddress: pod.Status.PodIP,
 			CliqueID:  "",
-			Index:     -1,
+			Index:     assignedIndices[nodeName],
 			Status:    status,
 		})
 	}
 	return nodes
+}
+
+// preferNonFabricPod deterministically selects the active pod when a rollout
+// temporarily leaves more than one daemon pod on the same node.
+func preferNonFabricPod(candidate, current *corev1.Pod) bool {
+	if (candidate.DeletionTimestamp == nil) != (current.DeletionTimestamp == nil) {
+		return candidate.DeletionTimestamp == nil
+	}
+
+	candidateTerminal := candidate.Status.Phase == corev1.PodSucceeded || candidate.Status.Phase == corev1.PodFailed
+	currentTerminal := current.Status.Phase == corev1.PodSucceeded || current.Status.Phase == corev1.PodFailed
+	if candidateTerminal != currentTerminal {
+		return !candidateTerminal
+	}
+
+	if !candidate.CreationTimestamp.Equal(&current.CreationTimestamp) {
+		return candidate.CreationTimestamp.After(current.CreationTimestamp.Time)
+	}
+	if candidate.Name != current.Name {
+		return candidate.Name > current.Name
+	}
+	if candidate.UID != current.UID {
+		return candidate.UID > current.UID
+	}
+	return candidate.Status.PodIP > current.Status.PodIP
 }
 
 // cleanupClique removes stale daemon entries from a single clique.

--- a/cmd/compute-domain-controller/cdstatus_test.go
+++ b/cmd/compute-domain-controller/cdstatus_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	nvapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+)
+
+func TestBuildNodesFromPodsAssignsUniqueIndices(t *testing.T) {
+	m := &ComputeDomainStatusManager{}
+	pods := []*corev1.Pod{
+		nonFabricPod("node-b", "10.0.0.2", false),
+		nonFabricPod("node-a", "10.0.0.1", true),
+	}
+
+	nodes := m.buildNodesFromPods(pods, nil)
+
+	require.Equal(t, []*nvapi.ComputeDomainNode{
+		{Name: "node-a", IPAddress: "10.0.0.1", CliqueID: "", Index: 0, Status: nvapi.ComputeDomainStatusReady},
+		{Name: "node-b", IPAddress: "10.0.0.2", CliqueID: "", Index: 1, Status: nvapi.ComputeDomainStatusNotReady},
+	}, nodes)
+}
+
+func TestBuildNodesFromPodsPreservesExistingIndices(t *testing.T) {
+	m := &ComputeDomainStatusManager{}
+	existingNodes := []*nvapi.ComputeDomainNode{
+		{Name: "node-a", CliqueID: "", Index: 4},
+		{Name: "node-b", CliqueID: "", Index: 7},
+		{Name: "stale-node", CliqueID: "", Index: 0},
+	}
+	pods := []*corev1.Pod{
+		nonFabricPod("node-c", "10.0.0.3", false),
+		nonFabricPod("node-b", "10.0.1.2", false),
+		nonFabricPod("node-a", "10.0.1.1", false),
+	}
+
+	nodes := m.buildNodesFromPods(pods, existingNodes)
+
+	require.Equal(t, 4, nodes[0].Index)
+	require.Equal(t, 7, nodes[1].Index)
+	require.Equal(t, 0, nodes[2].Index)
+}
+
+func TestBuildNodesFromPodsRepairsInvalidIndices(t *testing.T) {
+	m := &ComputeDomainStatusManager{}
+	existingNodes := []*nvapi.ComputeDomainNode{
+		{Name: "node-a", CliqueID: "", Index: -1},
+		{Name: "node-b", CliqueID: "", Index: 2},
+		{Name: "node-c", CliqueID: "", Index: 2},
+		{Name: "node-d", CliqueID: "", Index: 5},
+	}
+	pods := []*corev1.Pod{
+		nonFabricPod("node-d", "10.0.0.4", false),
+		nonFabricPod("node-c", "10.0.0.3", false),
+		nonFabricPod("node-b", "10.0.0.2", false),
+		nonFabricPod("node-a", "10.0.0.1", false),
+	}
+
+	nodes := m.buildNodesFromPods(pods, existingNodes)
+
+	require.Equal(t, []int{0, 1, 2, 5}, []int{nodes[0].Index, nodes[1].Index, nodes[2].Index, nodes[3].Index})
+}
+
+func TestBuildNodesFromPodsFiltersInvalidPodsAndDuplicateNodes(t *testing.T) {
+	m := &ComputeDomainStatusManager{}
+	pods := []*corev1.Pod{
+		nonFabricPod("", "10.0.0.1", false),
+		nonFabricPod("node-no-ip", "", false),
+		nonFabricPod("node-a", "10.0.0.2", false),
+		nonFabricPod("node-a", "10.0.0.3", true),
+	}
+
+	nodes := m.buildNodesFromPods(pods, nil)
+
+	require.Len(t, nodes, 1)
+	require.Equal(t, "node-a", nodes[0].Name)
+	require.Equal(t, "10.0.0.3", nodes[0].IPAddress)
+	require.Equal(t, 0, nodes[0].Index)
+	require.Equal(t, nvapi.ComputeDomainStatusReady, nodes[0].Status)
+}
+
+func TestSyncCDMigratesLegacyIndicesOnce(t *testing.T) {
+	cd := &nvapi.ComputeDomain{}
+	cd.Status.Nodes = []*nvapi.ComputeDomainNode{
+		{Name: "fabric-node", IPAddress: "10.0.0.10", CliqueID: "clique-a", Index: 3},
+		{Name: "node-a", IPAddress: "10.0.0.1", CliqueID: "", Index: -1},
+		{Name: "node-b", IPAddress: "10.0.0.2", CliqueID: "", Index: -1},
+	}
+	fabricPods := []*corev1.Pod{nonFabricPod("fabric-node", "10.0.0.10", true)}
+	nonFabricPods := []*corev1.Pod{
+		nonFabricPod("node-b", "10.0.0.2", true),
+		nonFabricPod("node-a", "10.0.0.1", true),
+	}
+
+	var updated *nvapi.ComputeDomain
+	m := &ComputeDomainStatusManager{
+		updateComputeDomainStatus: func(_ context.Context, newCD *nvapi.ComputeDomain) (*nvapi.ComputeDomain, error) {
+			updated = newCD
+			return newCD, nil
+		},
+	}
+
+	m.syncCD(context.Background(), cd, nil, fabricPods, nonFabricPods)
+
+	require.NotNil(t, updated)
+	require.Equal(t, []*nvapi.ComputeDomainNode{
+		{Name: "fabric-node", IPAddress: "10.0.0.10", CliqueID: "clique-a", Index: 3},
+		{Name: "node-a", IPAddress: "10.0.0.1", CliqueID: "", Index: 0, Status: nvapi.ComputeDomainStatusReady},
+		{Name: "node-b", IPAddress: "10.0.0.2", CliqueID: "", Index: 1, Status: nvapi.ComputeDomainStatusReady},
+	}, updated.Status.Nodes)
+
+	cd = updated
+	updated = nil
+	m.syncCD(context.Background(), cd, nil, fabricPods, nonFabricPods)
+	require.Nil(t, updated)
+}
+
+func nonFabricPod(nodeName, podIP string, ready bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{NodeName: nodeName},
+		Status: corev1.PodStatus{
+			PodIP: podIP,
+		},
+	}
+	if ready {
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+		}}
+	}
+	return pod
+}

--- a/deployments/helm/dra-driver-nvidia-gpu/crds/resource.nvidia.com_computedomains.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/crds/resource.nvidia.com_computedomains.yaml
@@ -119,8 +119,9 @@ spec:
                         mapping across all machines within an IMEX domain. Each node's index
                         directly determines its DNS name within a given NVLink partition
                         (i.e. clique). In other words, the 2-tuple of (CliqueID, Index) will
-                        always be unique. This field is marked as optional (but not
-                        omitempty) in order to support downgrades and avoid an API bump.
+                        always be unique. Nodes without a clique receive a stable synthetic index
+                        which is not used for DNS mapping. This field is marked as optional (but
+                        not omitempty) in order to support downgrades and avoid an API bump.
                       type: integer
                     ipAddress:
                       type: string

--- a/site/content/docs/reference/api.md
+++ b/site/content/docs/reference/api.md
@@ -151,7 +151,7 @@ spec:
 | `status.nodes[].name` | string | Node name. |
 | `status.nodes[].ipAddress` | string | Node IP used by the IMEX daemon. |
 | `status.nodes[].cliqueID` | string | NVLink clique identifier for the node. |
-| `status.nodes[].index` | integer | Deterministic index for the node within its clique. Used to map IPs to DNS names. |
+| `status.nodes[].index` | integer | Deterministic index for the node within its clique. Used to map IPs to DNS names for fabric-attached nodes; nodes without a clique receive a stable synthetic index that is not used for DNS mapping. |
 | `status.nodes[].status` | string | Per-node daemon readiness: `Ready` or `NotReady`. |
 
 {{% alert title="Note" %}}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Assigns stable, unique synthetic indices to non-fabric nodes in ComputeDomain status instead of assigning every node index -1. Existing valid indices are preserved, while negative or duplicate legacy indices are repaired deterministically during reconciliation.

The controller also deterministically selects the active pod during overlapping DaemonSet pods, preventing status flapping during rollout.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Synthetic indices for nodes without a clique are status identities only. They are not consumed by IMEX DNS or /etc/hosts management.

#### Does this PR introduce a user-facing change?
```release-note
ComputeDomain status now reports stable, unique indices for nodes without an NVLink clique.
```

#### Additional documentation (design docs, usage docs, etc.):
```docs
Updated the ComputeDomain API reference and generated CRD field description.
```

#### Checklist
- [ ] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed

Additional validation: `go test ./...`, `go test -race ./cmd/compute-domain-controller`, and `golangci-lint run ./...` pass.