### PR TITLE
compute-domain: follow-ups to the DomainID validation

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/computedomain_validation_test.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain_validation_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSettingsRejectsUnsafeDomainID(t *testing.T) {
+	m := &ComputeDomainManager{configFilesRoot: t.TempDir()}
+
+	// A UID-like value is accepted and its paths stay under the config root.
+	settings, err := m.NewSettings("d3b07384-d9a7-4e2b-8f1a-2c1e6b5a9f00")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(settings.rootDir, m.configFilesRoot+string(filepath.Separator)))
+
+	// Anything that is not a single path segment is rejected before any path is built.
+	for _, bad := range []string{"", ".", "..", "../..", "../../../driver-root/tmp/evil", "/etc/cron.d/x", "a/b", "a\x00b"} {
+		_, err := m.NewSettings(bad)
+		require.Error(t, err, "NewSettings(%q) should be rejected", bad)
+	}
+}

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -217,6 +217,14 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		return nil, fmt.Errorf("unable to prepare claim %v: %w", claimUID, err)
 	}
 
+	// Decode and validate before checkpointing, so that a claim rejected on its
+	// own contents never leaves an entry behind. Unprepare would have to decode
+	// that entry to clean it up, which is exactly what failed here.
+	plan, err := s.buildPreparePlan(claim)
+	if err != nil {
+		return nil, fmt.Errorf("prepare preflight failed: %w", err)
+	}
+
 	err = s.updateCheckpoint(func(checkpoint *Checkpoint) {
 		checkpoint.V2.PreparedClaims[claimUID] = PreparedClaim{
 			CheckpointState: ClaimCheckpointStatePrepareStarted,
@@ -230,7 +238,7 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	}
 	klog.V(6).Infof("checkpoint updated for claim %v", claimUID)
 
-	preparedDevices, err := s.prepareDevices(ctx, claim)
+	preparedDevices, err := s.applyPreparePlan(ctx, claim, plan)
 	if err != nil {
 		return nil, fmt.Errorf("prepare devices failed: %w", err)
 	}
@@ -517,19 +525,33 @@ func validateConfigs(configResultsMap map[runtime.Object][]*resourceapi.DeviceRe
 	return validated, nil
 }
 
-func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.ResourceClaim) (PreparedDevices, error) {
-	// Generate a mapping of each OpaqueDeviceConfigs to the Device.Results it
-	// applies to. Strict-decode: data is provided by user and may be completely
-	// unvalidated so far (in absence of validating webhook).
+// preparePlan is everything Prepare can work out about a claim without touching
+// anything outside this process.
+type preparePlan struct {
+	configResultsMap map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult
+	validatedConfigs map[runtime.Object]configapi.Interface
+}
+
+// buildPreparePlan decodes and validates the claim's configs. It writes nothing
+// and touches no device, so a claim it rejects leaves no trace for Unprepare to
+// have to undo. Decoding is strict because the config is claim-authored and may
+// not have passed a validating webhook.
+func (s *DeviceState) buildPreparePlan(claim *resourceapi.ResourceClaim) (*preparePlan, error) {
 	configResultsMap, err := s.getConfigResultsMap(&claim.Status, configapi.StrictDecoder)
 	if err != nil {
-		return nil, fmt.Errorf("error generating configResultsMap: %w", err)
+		return nil, permanentError{fmt.Errorf("error generating configResultsMap: %w", err)}
 	}
 
 	validatedConfigs, err := validateConfigs(configResultsMap)
 	if err != nil {
 		return nil, err
 	}
+
+	return &preparePlan{configResultsMap: configResultsMap, validatedConfigs: validatedConfigs}, nil
+}
+
+func (s *DeviceState) applyPreparePlan(ctx context.Context, claim *resourceapi.ResourceClaim, plan *preparePlan) (PreparedDevices, error) {
+	configResultsMap, validatedConfigs := plan.configResultsMap, plan.validatedConfigs
 
 	preparedDeviceGroupConfigState := make(map[runtime.Object]*DeviceConfigState)
 	for c, results := range configResultsMap {

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -487,6 +487,36 @@ func expiredPrepareAbortedClaimEntries(cp *Checkpoint, now time.Time, ttl time.D
 	return expired
 }
 
+// validateConfigs normalizes and validates every config on the claim and returns
+// them keyed as configResultsMap keys them. prepareDevices applies nothing until
+// this returns, so one bad config cannot land after a good one has taken effect.
+func validateConfigs(configResultsMap map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult) (map[runtime.Object]configapi.Interface, error) {
+	validated := make(map[runtime.Object]configapi.Interface, len(configResultsMap))
+	for c := range configResultsMap {
+		var config configapi.Interface
+		switch castConfig := c.(type) {
+		case *configapi.ComputeDomainChannelConfig:
+			config = castConfig
+		case *configapi.ComputeDomainDaemonConfig:
+			config = castConfig
+		default:
+			return nil, permanentError{fmt.Errorf("runtime object is not a recognized configuration")}
+		}
+
+		// These failures are deterministic, so spending the prepare deadline on
+		// retries cannot help.
+		if err := config.Normalize(); err != nil {
+			return nil, permanentError{fmt.Errorf("error normalizing config: %w", err)}
+		}
+		if err := config.Validate(); err != nil {
+			return nil, permanentError{fmt.Errorf("error validating config: %w", err)}
+		}
+
+		validated[c] = config
+	}
+	return validated, nil
+}
+
 func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.ResourceClaim) (PreparedDevices, error) {
 	// Generate a mapping of each OpaqueDeviceConfigs to the Device.Results it
 	// applies to. Strict-decode: data is provided by user and may be completely
@@ -496,39 +526,17 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 		return nil, fmt.Errorf("error generating configResultsMap: %w", err)
 	}
 
-	// Normalize, validate, and apply all configs associated with devices that
-	// need to be prepared. Track device group configs generated from applying the
-	// config to the set of device allocation results.
+	validatedConfigs, err := validateConfigs(configResultsMap)
+	if err != nil {
+		return nil, err
+	}
+
 	preparedDeviceGroupConfigState := make(map[runtime.Object]*DeviceConfigState)
 	for c, results := range configResultsMap {
-		// Cast the opaque config to a configapi.Interface type
-		var config configapi.Interface
-		switch castConfig := c.(type) {
-		case *configapi.ComputeDomainChannelConfig:
-			config = castConfig
-		case *configapi.ComputeDomainDaemonConfig:
-			config = castConfig
-		default:
-			return nil, fmt.Errorf("runtime object is not a recognized configuration")
-		}
-
-		// Normalize the config to set any implied defaults.
-		if err := config.Normalize(); err != nil {
-			return nil, fmt.Errorf("error normalizing config: %w", err)
-		}
-
-		// Validate the config to ensure its integrity.
-		if err := config.Validate(); err != nil {
-			return nil, fmt.Errorf("error validating config: %w", err)
-		}
-
-		// Apply the config to the list of results associated with it.
-		configState, err := s.applyConfig(ctx, config, claim, results)
+		configState, err := s.applyConfig(ctx, validatedConfigs[c], claim, results)
 		if err != nil {
 			return nil, fmt.Errorf("error applying config: %w", err)
 		}
-
-		// Capture the prepared device group config in the map.
 		preparedDeviceGroupConfigState[c] = configState
 	}
 

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -602,10 +602,13 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, cs *resourceapi.Reso
 				return fmt.Errorf("error removing Node label for ComputeDomain: %w", err)
 			}
 		case *configapi.ComputeDomainDaemonConfig:
-			// If a daemon type, unprepare the new ComputeDomain daemon.
+			// An old checkpoint can hold a DomainID this now rejects. Failing here
+			// would strand the claim, and cleaning up would mean deleting whatever
+			// the unvalidated path resolves to, so skip it.
 			computeDomainDaemonSettings, err := s.computeDomainManager.NewSettings(config.DomainID)
 			if err != nil {
-				return fmt.Errorf("error creating ComputeDomain daemon settings: %w", err)
+				klog.Warningf("skipping ComputeDomain daemon unprepare: %v", err)
+				continue
 			}
 			if err := computeDomainDaemonSettings.Unprepare(ctx); err != nil {
 				return fmt.Errorf("error unpreparing ComputeDomain daemon settings: %w", err)

--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/utils/ptr"
+	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -212,6 +213,47 @@ func TestGetConfigResultsMap(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot apply ComputeDomainDaemonConfig")
 	})
+}
+
+// A ResourceClaim can be authored directly and the chart ships the validating
+// webhook off by default, so a hand-written compute-domain config reaches the
+// plugin. Prepare checkpoints the claim before it validates that config, so the
+// entry it leaves behind is one Unprepare has to be able to clear.
+func TestUnprepareClearsAClaimCheckpointedBeforeItsConfigWasRejected(t *testing.T) {
+	claim := &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim-uid", Namespace: "default", UID: types.UID("claim-uid")},
+		Status: claimStatus(
+			[]resourceapi.DeviceRequestAllocationResult{
+				allocationResult("daemon-request", DriverName, "daemon-0", nil),
+			},
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"daemon-request"}, daemonConfig("../x")),
+		),
+	}
+
+	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(t.TempDir()), cdiapi.WithAutoRefresh(false))
+	require.NoError(t, err)
+
+	state := testDeviceState()
+	state.checkpointManager = &fakeCheckpointManager{checkpoint: checkpointWithClaims(map[string]PreparedClaim{})}
+	state.computeDomainManager = &ComputeDomainManager{configFilesRoot: t.TempDir()}
+	state.cdi = &CDIHandler{cache: cache, vendor: cdiVendor, claimClass: cdiClaimClass}
+	state.config = &Config{flags: &Flags{nodeName: "test-node"}}
+
+	// Prepare rejects the config, but only after checkpointing the claim.
+	_, err = state.Prepare(context.Background(), claim)
+	require.Error(t, err)
+	require.Equal(t, ClaimCheckpointStatePrepareStarted,
+		requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims["claim-uid"].CheckpointState)
+
+	claimRef := kubeletplugin.NamespacedObject{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "claim-uid"},
+		UID:            types.UID("claim-uid"),
+	}
+	require.NoError(t, state.Unprepare(context.Background(), claimRef))
+
+	pc := requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims["claim-uid"]
+	require.Equal(t, ClaimCheckpointStatePrepareAborted, pc.CheckpointState)
+	require.NotNil(t, pc.AbortedAt)
 }
 
 func TestRequestedNonAdminDevices(t *testing.T) {

--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -215,67 +215,63 @@ func TestGetConfigResultsMap(t *testing.T) {
 	})
 }
 
-// A ResourceClaim can be authored directly and the chart ships the validating
-// webhook off by default, so a hand-written compute-domain config reaches the
-// plugin. Prepare checkpoints the claim before it validates that config, so the
-// entry it leaves behind is one Unprepare has to be able to clear.
-func TestUnprepareClearsAClaimCheckpointedBeforeItsConfigWasRejected(t *testing.T) {
-	claim := &resourceapi.ResourceClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "claim-uid", Namespace: "default", UID: types.UID("claim-uid")},
-		Status: claimStatus(
-			[]resourceapi.DeviceRequestAllocationResult{
-				allocationResult("daemon-request", DriverName, "daemon-0", nil),
-			},
-			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"daemon-request"}, daemonConfig("../x")),
-		),
+// v0.5.0 checkpointed a claim before it validated the config, so an entry whose
+// daemon DomainID this build rejects can already be on disk. Unprepare has to be
+// able to clear it from either state without touching the unvalidated path.
+func TestUnprepareClearsALegacyCheckpointWithARejectedDomainID(t *testing.T) {
+	status := claimStatus(
+		[]resourceapi.DeviceRequestAllocationResult{
+			allocationResult("daemon-request", DriverName, "daemon-0", nil),
+		},
+		opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"daemon-request"}, daemonConfig("../x")),
+	)
+
+	cases := map[string]struct {
+		state       ClaimCheckpointState
+		wantCleared bool
+	}{
+		"left mid-prepare":  {state: ClaimCheckpointStatePrepareStarted},
+		"already completed": {state: ClaimCheckpointStatePrepareCompleted, wantCleared: true},
 	}
 
-	cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(t.TempDir()), cdiapi.WithAutoRefresh(false))
-	require.NoError(t, err)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cache, err := cdiapi.NewCache(cdiapi.WithSpecDirs(t.TempDir()), cdiapi.WithAutoRefresh(false))
+			require.NoError(t, err)
 
-	state := testDeviceState()
-	state.checkpointManager = &fakeCheckpointManager{checkpoint: checkpointWithClaims(map[string]PreparedClaim{})}
-	state.computeDomainManager = &ComputeDomainManager{configFilesRoot: t.TempDir()}
-	state.cdi = &CDIHandler{cache: cache, vendor: cdiVendor, claimClass: cdiClaimClass}
-	state.config = &Config{flags: &Flags{nodeName: "test-node"}}
+			state := testDeviceState()
+			state.checkpointManager = &fakeCheckpointManager{checkpoint: checkpointWithClaims(map[string]PreparedClaim{
+				"claim-uid": {
+					CheckpointState: tc.state,
+					Status:          status,
+					Name:            "claim-uid",
+					Namespace:       "default",
+				},
+			})}
+			state.computeDomainManager = &ComputeDomainManager{configFilesRoot: t.TempDir()}
+			state.cdi = &CDIHandler{cache: cache, vendor: cdiVendor, claimClass: cdiClaimClass}
+			state.config = &Config{flags: &Flags{nodeName: "test-node"}}
 
-	// Prepare rejects the config, but only after checkpointing the claim.
-	_, err = state.Prepare(context.Background(), claim)
-	require.Error(t, err)
-	require.Equal(t, ClaimCheckpointStatePrepareStarted,
-		requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims["claim-uid"].CheckpointState)
+			claimRef := kubeletplugin.NamespacedObject{
+				NamespacedName: types.NamespacedName{Namespace: "default", Name: "claim-uid"},
+				UID:            types.UID("claim-uid"),
+			}
+			require.NoError(t, state.Unprepare(context.Background(), claimRef))
 
-	claimRef := kubeletplugin.NamespacedObject{
-		NamespacedName: types.NamespacedName{Namespace: "default", Name: "claim-uid"},
-		UID:            types.UID("claim-uid"),
+			pc, stillThere := requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims["claim-uid"]
+			if tc.wantCleared {
+				require.False(t, stillThere, "a completed claim should be dropped from the checkpoint")
+				return
+			}
+			require.True(t, stillThere)
+			require.Equal(t, ClaimCheckpointStatePrepareAborted, pc.CheckpointState)
+			require.NotNil(t, pc.AbortedAt)
+		})
 	}
-	require.NoError(t, state.Unprepare(context.Background(), claimRef))
-
-	pc := requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims["claim-uid"]
-	require.Equal(t, ClaimCheckpointStatePrepareAborted, pc.CheckpointState)
-	require.NotNil(t, pc.AbortedAt)
 }
 
-func TestPrepareDevicesReturnsPermanentErrorForInvalidConfig(t *testing.T) {
-	// An invalid config can never become valid on a retry, so prepareDevices must
-	// return a permanent error rather than one the driver retries for the deadline.
-	state := testDeviceState()
-	claim := &resourceapi.ResourceClaim{
-		Status: claimStatus(
-			[]resourceapi.DeviceRequestAllocationResult{
-				allocationResult("daemon-request", DriverName, "daemon-0", nil),
-			},
-			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"daemon-request"}, daemonConfig("../x")),
-		),
-	}
-
-	_, err := state.prepareDevices(context.Background(), claim)
-	require.Error(t, err)
-	require.True(t, isPermanentError(err), "an invalid config must be a permanent error, got %v", err)
-}
-
-// validateConfigs is the whole of the first pass, so a claim carrying one good
-// and one bad config has to come back with nothing for prepareDevices to apply,
+// validateConfigs is the whole of the second half of the preflight, so a claim
+// carrying one good and one bad config has to come back with nothing to apply,
 // whichever order the map hands them over in.
 func TestValidateConfigsReturnsNothingWhenAnyConfigIsInvalid(t *testing.T) {
 	good := daemonConfig("d3b07384-d9a7-4e2b-8f1a-2c1e6b5a9f00")
@@ -291,11 +287,47 @@ func TestValidateConfigsReturnsNothingWhenAnyConfigIsInvalid(t *testing.T) {
 	require.Nil(t, validated, "returning the configs it did accept would let the caller apply them")
 }
 
-// The first pass is only worth anything if prepareDevices still runs it before
-// it applies anything, so keep a case on the caller as well: with a good and a
-// bad config, the error has to be the deterministic one from validation rather
-// than whatever applying the good one first would have produced.
-func TestPrepareDevicesRejectsAMixedClaimBeforeApplying(t *testing.T) {
+// A claim the plugin turns down on its own contents must not reach the
+// checkpoint: Unprepare would have to decode that entry to clear it, which is
+// the very thing that just failed.
+func TestPrepareLeavesNoCheckpointForARejectedClaim(t *testing.T) {
+	daemonRequest := allocationResult("daemon-request", DriverName, "daemon-0", nil)
+
+	cases := map[string]resourceapi.DeviceAllocationConfiguration{
+		"a kind this build does not know": rawOpaqueConfig([]string{"daemon-request"},
+			`{"apiVersion":"resource.nvidia.com/v1beta1","kind":"FutureComputeDomainDaemonConfig","domainID":"d3b07384-d9a7-4e2b-8f1a-2c1e6b5a9f00"}`),
+		"a field of the wrong type": rawOpaqueConfig([]string{"daemon-request"},
+			`{"apiVersion":"resource.nvidia.com/v1beta1","kind":"ComputeDomainDaemonConfig","domainID":123}`),
+		"a domainID that is not a path segment": rawOpaqueConfig([]string{"daemon-request"},
+			`{"apiVersion":"resource.nvidia.com/v1beta1","kind":"ComputeDomainDaemonConfig","domainID":"../x"}`),
+	}
+
+	for name, config := range cases {
+		t.Run(name, func(t *testing.T) {
+			claim := &resourceapi.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim-uid", Namespace: "default", UID: types.UID("claim-uid")},
+				Status:     claimStatus([]resourceapi.DeviceRequestAllocationResult{daemonRequest}, config),
+			}
+			state := testDeviceState()
+			state.checkpointManager = &fakeCheckpointManager{checkpoint: checkpointWithClaims(map[string]PreparedClaim{})}
+			state.computeDomainManager = &ComputeDomainManager{configFilesRoot: t.TempDir()}
+			state.config = &Config{flags: &Flags{nodeName: "test-node"}}
+
+			_, err := state.Prepare(context.Background(), claim)
+
+			require.Error(t, err)
+			require.True(t, isPermanentError(err), "a claim rejected on its contents cannot become valid on a retry, got %v", err)
+			_, exists := requireFakeCheckpointManager(t, state).checkpoint.V2.PreparedClaims["claim-uid"]
+			require.False(t, exists, "the claim was checkpointed even though nothing was applied for it")
+		})
+	}
+}
+
+// The preflight is only worth anything if Prepare still runs all of it before
+// applying, so keep a case on the caller: with a good and a bad config the error
+// has to be the deterministic one from validation rather than whatever applying
+// the good one first would have produced.
+func TestPrepareRejectsAMixedClaimBeforeApplying(t *testing.T) {
 	state := testDeviceState()
 	state.config = &Config{flags: &Flags{nodeName: "test-node"}}
 	state.computeDomainManager = &ComputeDomainManager{configFilesRoot: t.TempDir()}
@@ -314,11 +346,26 @@ func TestPrepareDevicesRejectsAMixedClaimBeforeApplying(t *testing.T) {
 	// repeat: the error has to come from validation every time, never from
 	// applying the good one.
 	for i := 0; i < 10; i++ {
-		_, err := state.prepareDevices(context.Background(), claim)
+		_, err := state.buildPreparePlan(claim)
 
 		require.Error(t, err)
 		require.True(t, isPermanentError(err), "applying before validating would surface an apply error instead, got %v", err)
 		require.Contains(t, err.Error(), "error validating config")
+	}
+}
+
+// rawOpaqueConfig carries JSON the plugin has to decode itself, which is how a
+// hand-written claim reaches it.
+func rawOpaqueConfig(requests []string, raw string) resourceapi.DeviceAllocationConfiguration {
+	return resourceapi.DeviceAllocationConfiguration{
+		Source:   resourceapi.AllocationConfigSourceClaim,
+		Requests: requests,
+		DeviceConfiguration: resourceapi.DeviceConfiguration{
+			Opaque: &resourceapi.OpaqueDeviceConfiguration{
+				Driver:     DriverName,
+				Parameters: runtime.RawExtension{Raw: []byte(raw)},
+			},
+		},
 	}
 }
 

--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -256,6 +256,72 @@ func TestUnprepareClearsAClaimCheckpointedBeforeItsConfigWasRejected(t *testing.
 	require.NotNil(t, pc.AbortedAt)
 }
 
+func TestPrepareDevicesReturnsPermanentErrorForInvalidConfig(t *testing.T) {
+	// An invalid config can never become valid on a retry, so prepareDevices must
+	// return a permanent error rather than one the driver retries for the deadline.
+	state := testDeviceState()
+	claim := &resourceapi.ResourceClaim{
+		Status: claimStatus(
+			[]resourceapi.DeviceRequestAllocationResult{
+				allocationResult("daemon-request", DriverName, "daemon-0", nil),
+			},
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"daemon-request"}, daemonConfig("../x")),
+		),
+	}
+
+	_, err := state.prepareDevices(context.Background(), claim)
+	require.Error(t, err)
+	require.True(t, isPermanentError(err), "an invalid config must be a permanent error, got %v", err)
+}
+
+// validateConfigs is the whole of the first pass, so a claim carrying one good
+// and one bad config has to come back with nothing for prepareDevices to apply,
+// whichever order the map hands them over in.
+func TestValidateConfigsReturnsNothingWhenAnyConfigIsInvalid(t *testing.T) {
+	good := daemonConfig("d3b07384-d9a7-4e2b-8f1a-2c1e6b5a9f00")
+	bad := channelConfig("../x")
+
+	validated, err := validateConfigs(map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult{
+		good: nil,
+		bad:  nil,
+	})
+
+	require.Error(t, err)
+	require.True(t, isPermanentError(err), "an invalid config cannot become valid on a retry, got %v", err)
+	require.Nil(t, validated, "returning the configs it did accept would let the caller apply them")
+}
+
+// The first pass is only worth anything if prepareDevices still runs it before
+// it applies anything, so keep a case on the caller as well: with a good and a
+// bad config, the error has to be the deterministic one from validation rather
+// than whatever applying the good one first would have produced.
+func TestPrepareDevicesRejectsAMixedClaimBeforeApplying(t *testing.T) {
+	state := testDeviceState()
+	state.config = &Config{flags: &Flags{nodeName: "test-node"}}
+	state.computeDomainManager = &ComputeDomainManager{configFilesRoot: t.TempDir()}
+	claim := &resourceapi.ResourceClaim{
+		Status: claimStatus(
+			[]resourceapi.DeviceRequestAllocationResult{
+				allocationResult("daemon-request", DriverName, "daemon-0", nil),
+				allocationResult("channel-request", DriverName, "channel-0", nil),
+			},
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"daemon-request"}, daemonConfig("d3b07384-d9a7-4e2b-8f1a-2c1e6b5a9f00")),
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"channel-request"}, channelConfig("../x")),
+		),
+	}
+
+	// Map order decides which config a single-pass caller would reach first, so
+	// repeat: the error has to come from validation every time, never from
+	// applying the good one.
+	for i := 0; i < 10; i++ {
+		_, err := state.prepareDevices(context.Background(), claim)
+
+		require.Error(t, err)
+		require.True(t, isPermanentError(err), "applying before validating would surface an apply error instead, got %v", err)
+		require.Contains(t, err.Error(), "error validating config")
+	}
+}
+
 func TestRequestedNonAdminDevices(t *testing.T) {
 	state := &DeviceState{}
 	claim := claimWithResults(


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Follow-ups to the DomainID validation that landed in #1368, which this PR originally carried.

`ValidateDomainID` is new, so three spots in the compute-domain kubelet plugin now behave differently from what they were written for.

**1. A claim whose config the plugin rejects can be left in the checkpoint with no way out.** The controller always sets `DomainID` from `cd.UID`, so nothing here comes from an ordinary ComputeDomain. A ResourceClaim can be written by hand though, and the chart ships `webhook.enabled: false`, so a hand-written compute-domain config reaches the plugin. `Prepare()` checkpoints the claim as `PrepareStarted` before `prepareDevices` validates its config, so a `domainID` the validation rejects is on disk by the time it is rejected. Every later `Unprepare` then fails at `NewSettings`, which means neither `deleteClaimFromCheckpoint` nor `markClaimPrepareAbortedInCheckpoint` runs and the entry stays put:

```
unprepare devices failed: error creating ComputeDomain daemon settings: invalid domainID: domainID "../x" is not a valid single path component: may not contain '/'
```

The fix logs and skips that daemon unprepare. Cleaning up after such an entry would mean deleting whatever the unvalidated path resolves to, which is the traversal the validation is there to prevent.

I described this as an upgrade problem earlier, which was too broad; @varunrsekar is right that the controller-generated path never produces such a value.

**2. `prepareDevices` can apply one config before rejecting another.** It normalizes, validates and applies in a single pass over `configResultsMap`. Map iteration order is unspecified, so a claim with one good and one bad config can have the good one's node label and daemon directory in place by the time the bad one aborts the prepare. Everything validates before anything is applied now.

**3. A rejected config is retried for the whole prepare deadline.** Normalize failures, validate failures and an unrecognized config type are all deterministic, so they're permanent errors now. The same goes for `getConfigResultsMap`: it fails on a config this build cannot decode, on a request naming a device that is not in this node's allocatable set, and on a config whose type does not match the device it would apply to. That set is fixed when the plugin starts, so none of those can turn into a success within the prepare deadline.

Commit 1 stands alone if it's worth a backport to `release-0.5`. Commits 2 and 3 are hardening and can ride whenever suits you. If hand-written compute-domain configs are out of scope, say so and I will drop commit 1 and keep the other two.

#### Which issue(s) this PR is related to:

N/A. Follows #1368.

#### Special notes for your reviewer:

The two halves are tested from opposite ends. Commit 4's case calls `Prepare` with a hand-written config and requires that nothing reaches the checkpoint, for an unknown kind, a field of the wrong type and a `domainID` that is not a path segment. Commit 1's case builds the checkpoint entry by hand, because with commit 4 in place no code path here can still produce one: what it stands in for is an entry a released v0.5.x already wrote. It covers both states such an entry can be in, and restoring the pre-fix `return` makes both fail with the error quoted above.

`cmd/gpu-kubelet-plugin/device_state.go` has the same validate-and-apply-in-one-pass shape in its own `prepareDevices`. I left it alone to keep this small, and because that prepare path carries FM and VFIO work I haven't exercised.

Commit 3 is coverage for `NewSettings` as it already landed, so it passes either way. The ordering case in commit 2 repeats because map order decides whether a single run sees the bug.

Rebased onto current main; the four commits applied without conflict. `golangci-lint run ./...` (0 issues), `go vet` and `go test -race ./...` are clean, and every commit builds and tests on its own. `go.mod`, `go.sum` and `vendor` are untouched.

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the compute-domain kubelet plugin being unable to unprepare a ResourceClaim whose hand-written domainID fails validation, which previously left the claim in the plugin's checkpoint permanently.
```

#### Additional documentation (design docs, usage docs, etc.):

```docs

```

#### Checklist

- [ ] `make check test` passes locally (see notes above)
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed

