### PR TITLE
compute-domain: write daemon config files through os.Root

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/computedomain.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain.go
@@ -80,6 +80,10 @@ type ComputeDomainDaemonSettings struct {
 	rootDir         string
 	configTmplPath  string
 	nodesConfigPath string
+
+	// templateSourcePath is where the daemon config template is read from. It is
+	// only ever the path below outside of tests.
+	templateSourcePath string
 }
 
 func NewComputeDomainManager(config *Config, getCliqueIDFunc func() (string, error)) (*ComputeDomainManager, error) {
@@ -194,11 +198,12 @@ func (m *ComputeDomainManager) NewSettings(domainID string) (*ComputeDomainDaemo
 		return nil, fmt.Errorf("invalid domainID: %w", err)
 	}
 	return &ComputeDomainDaemonSettings{
-		manager:         m,
-		domainID:        domainID,
-		rootDir:         filepath.Join(m.configFilesRoot, domainID),
-		configTmplPath:  filepath.Join(m.configFilesRoot, domainID, "imexd.cfg.tmpl"),
-		nodesConfigPath: filepath.Join(m.configFilesRoot, domainID, "nodes.cfg"),
+		manager:            m,
+		domainID:           domainID,
+		rootDir:            filepath.Join(m.configFilesRoot, domainID),
+		configTmplPath:     filepath.Join(m.configFilesRoot, domainID, "imexd.cfg.tmpl"),
+		nodesConfigPath:    filepath.Join(m.configFilesRoot, domainID, "nodes.cfg"),
+		templateSourcePath: ComputeDomainDaemonConfigTemplatePath,
 	}, nil
 }
 
@@ -259,10 +264,6 @@ func (s *ComputeDomainDaemonSettings) GetCDIContainerEditsForImex(ctx context.Co
 }
 
 func (s *ComputeDomainDaemonSettings) Prepare(ctx context.Context) error {
-	if err := os.MkdirAll(s.rootDir, 0755); err != nil {
-		return fmt.Errorf("error creating directory %v: %w", s.rootDir, err)
-	}
-
 	if err := s.WriteConfigFile(ctx); err != nil {
 		return fmt.Errorf("error writing config file %v: %w", s.configTmplPath, err)
 	}
@@ -286,12 +287,36 @@ func (s *ComputeDomainDaemonSettings) Unprepare(ctx context.Context) error {
 }
 
 func (s *ComputeDomainDaemonSettings) WriteConfigFile(ctx context.Context) error {
-	configBytes, err := os.ReadFile(ComputeDomainDaemonConfigTemplatePath)
+	configBytes, err := os.ReadFile(s.templateSourcePath)
 	if err != nil {
 		return fmt.Errorf("error reading template file: %w", err)
 	}
 
-	if err := os.WriteFile(s.configTmplPath, configBytes, 0644); err != nil {
+	// The per-domain directory is bind-mounted read-write into the daemon container, so write
+	// through an os.Root scoped to that directory: a symlink there can't redirect the write to
+	// another domain's directory or outside the config root. This assumes the config root and
+	// the per-domain directory entry itself stay ours; the daemon is given the contents of its
+	// own directory, not the entry in the parent. os.Root is not a filesystem sandbox and says
+	// nothing about mounts already in place underneath it.
+	if err := os.MkdirAll(s.manager.configFilesRoot, 0755); err != nil {
+		return fmt.Errorf("error creating config root %v: %w", s.manager.configFilesRoot, err)
+	}
+	configRoot, err := os.OpenRoot(s.manager.configFilesRoot)
+	if err != nil {
+		return fmt.Errorf("error opening config root %v: %w", s.manager.configFilesRoot, err)
+	}
+	defer configRoot.Close()
+
+	if err := configRoot.MkdirAll(s.domainID, 0755); err != nil {
+		return fmt.Errorf("error creating ComputeDomain daemon directory: %w", err)
+	}
+	domainRoot, err := configRoot.OpenRoot(s.domainID)
+	if err != nil {
+		return fmt.Errorf("error opening ComputeDomain daemon directory: %w", err)
+	}
+	defer domainRoot.Close()
+
+	if err := domainRoot.WriteFile("imexd.cfg.tmpl", configBytes, 0644); err != nil {
 		return fmt.Errorf("error writing config file %v: %w", s.configTmplPath, err)
 	}
 

--- a/cmd/compute-domain-kubelet-plugin/computedomain_symlink_test.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain_symlink_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteConfigFileDoesNotFollowSymlink(t *testing.T) {
+	template := filepath.Join(t.TempDir(), "template.cfg")
+	require.NoError(t, os.WriteFile(template, []byte("template contents"), 0644))
+
+	const domainID = "d3b07384-d9a7-4e2b-8f1a-2c1e6b5a9f00"
+
+	// Plant a symlink where the plugin writes imexd.cfg.tmpl (as a compromised daemon
+	// container with the read-write /imexd mount could) and assert the write does not
+	// follow it out of the per-domain directory.
+	check := func(t *testing.T, configRoot, victim, linkTarget string) {
+		require.NoError(t, os.WriteFile(victim, []byte("original"), 0644))
+		require.NoError(t, os.Symlink(linkTarget, filepath.Join(configRoot, domainID, "imexd.cfg.tmpl")))
+
+		settings, err := (&ComputeDomainManager{configFilesRoot: configRoot}).NewSettings(domainID)
+		require.NoError(t, err)
+		settings.templateSourcePath = template
+		require.Error(t, settings.WriteConfigFile(context.Background()))
+
+		got, err := os.ReadFile(victim)
+		require.NoError(t, err)
+		require.Equal(t, "original", string(got), "write followed the symlink and clobbered %s", victim)
+	}
+
+	t.Run("target outside the config root", func(t *testing.T) {
+		configRoot := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(configRoot, domainID), 0755))
+		victim := filepath.Join(t.TempDir(), "victim")
+		check(t, configRoot, victim, victim)
+	})
+
+	t.Run("target in another domain under the config root", func(t *testing.T) {
+		configRoot := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(configRoot, domainID), 0755))
+		other := filepath.Join(configRoot, "other-domain")
+		require.NoError(t, os.MkdirAll(other, 0755))
+		check(t, configRoot, filepath.Join(other, "victim"), "../other-domain/victim")
+	})
+}
+
+// WriteConfigFile owns creating the per-domain directory now that Prepare no
+// longer does, so the ordinary path is worth pinning too.
+func TestWriteConfigFileCreatesTheDomainDirectory(t *testing.T) {
+	template := filepath.Join(t.TempDir(), "template.cfg")
+	require.NoError(t, os.WriteFile(template, []byte("template contents"), 0644))
+
+	configRoot := t.TempDir()
+	const domainID = "d3b07384-d9a7-4e2b-8f1a-2c1e6b5a9f00"
+
+	// A neighbour that must come through untouched.
+	const otherDomainID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+	require.NoError(t, os.MkdirAll(filepath.Join(configRoot, otherDomainID), 0755))
+	other := filepath.Join(configRoot, otherDomainID, "imexd.cfg.tmpl")
+	require.NoError(t, os.WriteFile(other, []byte("someone else"), 0644))
+
+	settings, err := (&ComputeDomainManager{configFilesRoot: configRoot}).NewSettings(domainID)
+	require.NoError(t, err)
+	settings.templateSourcePath = template
+
+	// The domain directory does not exist yet.
+	require.NoError(t, settings.WriteConfigFile(context.Background()))
+
+	written := filepath.Join(configRoot, domainID, "imexd.cfg.tmpl")
+	got, err := os.ReadFile(written)
+	require.NoError(t, err)
+	require.Equal(t, "template contents", string(got))
+
+	info, err := os.Stat(written)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0644), info.Mode().Perm())
+
+	untouched, err := os.ReadFile(other)
+	require.NoError(t, err)
+	require.Equal(t, "someone else", string(untouched))
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The compute-domain daemon config write follows symlinks, so a symlink inside the writable, container-mounted config directory can redirect it outside that directory. This hardens the write with `os.Root`.

For each daemon, the plugin writes an IMEX config template into `domains/<domainID>/imexd.cfg.tmpl` under its config root, and that per-domain directory is bind-mounted read-write into the daemon container:

```go
ContainerPath: "/imexd",
HostPath:      s.rootDir,
Options:       []string{"rw", "nosuid", "nodev", "bind"},
```

The write itself used `os.WriteFile`:

```go
os.WriteFile(s.configTmplPath, configBytes, 0644)
```

`os.WriteFile` follows symlinks, so if `imexd.cfg.tmpl` is replaced with a symlink pointing elsewhere (something a process with the read-write `/imexd` mount can do), the next prepare writes through it, for example onto another domain's directory or the plugin's own `checkpoint.json`. This is a containment gap in the write, separate from validating the `DomainID` value (#1346); it holds even for a valid `DomainID`.

This PR creates the per-domain directory and writes the template through an [`os.Root`](https://pkg.go.dev/os#Root) scoped to that directory: it opens a root on the driver-owned config root, then opens a nested root on the per-domain directory and writes within it. `os.Root` refuses to traverse a symlink that leaves its root, so a symlink at `imexd.cfg.tmpl` can no longer redirect the write to a sibling domain (a relative symlink that stays under the config root) or outside the config root. `os.MkdirAll(s.rootDir)` in `Prepare` is dropped because `WriteConfigFile` now creates the directory through the root.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`os.Root`/`OpenRoot` are Go 1.24, and the `Root.MkdirAll`/`Root.WriteFile` methods used here are Go 1.25; `go.mod` asks for 1.26.0 and `hack/golang-version.sh` resolves CI to 1.26.6, both past the `os.Root` symlink fix in GO-2026-4970.

The new test plants a symlink at `imexd.cfg.tmpl` and asserts that `WriteConfigFile` does not follow it, for a target outside the config root and for a relative target in a sibling domain under the config root. The sibling-domain case is the one that a single root on the whole config root would still follow; it passes only with the per-domain root. The template path moved onto `ComputeDomainDaemonSettings` as `templateSourcePath`, filled in by `NewSettings`, so a case points its own settings at a temporary template instead of the package holding mutable state that a parallel case could trip over.

There is a case for the ordinary path too, since `WriteConfigFile` owns creating the per-domain directory now that `Prepare` no longer does: it starts with no domain directory, and checks the file is created with the template's contents and mode while a neighbouring domain is left alone.

Rebased onto main. #1368 changed `NewSettings` to return an error, so the case here needed updating for that, and the test file is `computedomain_symlink_test.go` rather than `computedomain_test.go` so it does not collide with the file #1346 adds.

What this does not cover: the write is still a truncate in place rather than a temporary file and a rename, so a daemon reading its config while a prepare rewrites it can still see a partial file. That is existing behaviour and I would rather do it separately.

This complements #1346 (which validates the `DomainID` value) and the daemon-claim namespace check discussed in #1222: this PR is only about keeping the config write inside its directory.

#### Does this PR introduce a user-facing change?

```release-note
The compute-domain kubelet plugin now writes daemon configuration files through an os.Root so a symlink in the config directory cannot redirect the write outside it.
```

