### PR TITLE
WIP: Match request-scoped opaque configs against prioritized-list subrequests

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	"k8s.io/dynamic-resource-allocation/resourceclaim"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	cperrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
@@ -839,7 +840,7 @@ func (s *DeviceState) getConfigResultsMap(rcs *resourceapi.ResourceClaimStatus, 
 			return nil, fmt.Errorf("requested device is not allocatable: %v", result.Device)
 		}
 		for _, c := range slices.Backward(configs) {
-			if slices.Contains(c.Requests, result.Request) {
+			if configMatchesRequest(c.Requests, result.Request) {
 				if _, ok := c.Config.(*configapi.ComputeDomainChannelConfig); ok && device.Type() != ComputeDomainChannelType {
 					return nil, fmt.Errorf("cannot apply ComputeDomainChannelConfig to request: %v", result.Request)
 				}
@@ -862,6 +863,28 @@ func (s *DeviceState) getConfigResultsMap(rcs *resourceapi.ResourceClaimStatus, 
 		}
 	}
 	return configResultsMap, nil
+}
+
+// configMatchesRequest reports whether a config scoped to the given request
+// names applies to the request reference in an allocation result. For
+// prioritized list allocations (KEP-4816 firstAvailable), the scheduler
+// records the result's request as "<request>/<subrequest>", so a config may
+// reference either the full subrequest reference or just the parent request.
+// This mirrors the matching used by
+// [k8s.io/dynamic-resource-allocation/resourceclaim.ConfigForResult].
+//
+// Matching carries no specificity ranking: getConfigResultsMap applies the
+// last matching config in its precedence-ordered list, so a parent-scoped
+// config with higher precedence shadows a subrequest-scoped one and vice
+// versa. A matched config is still subject to per-device-type validation, so
+// a type-specific config scoped to a parent request whose subrequests span
+// device types fails preparation rather than silently falling back to the
+// default config; scope such configs to the exact subrequest instead.
+func configMatchesRequest(requests []string, requestRef string) bool {
+	if slices.Contains(requests, requestRef) {
+		return true
+	}
+	return slices.Contains(requests, resourceclaim.BaseRequestRef(requestRef))
 }
 
 // assertImexChannelNotAllocated() consults the absolute, node-local source of

--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -198,6 +198,104 @@ func TestGetConfigResultsMap(t *testing.T) {
 		assert.Contains(t, err.Error(), "requested device is not allocatable")
 	})
 
+	t.Run("config scoped to parent request applies to subrequest result", func(t *testing.T) {
+		state := testDeviceState()
+		status := claimStatus(
+			[]resourceapi.DeviceRequestAllocationResult{
+				allocationResult("channel-request/sub-0", DriverName, "channel-0", nil),
+			},
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"channel-request"}, channelConfig("claim-domain")),
+		)
+
+		got, err := state.getConfigResultsMap(&status, configapi.StrictDecoder)
+
+		require.NoError(t, err)
+		assertConfigResultDevices(t, got, ComputeDomainChannelType, "claim-domain", []string{"channel-0"})
+	})
+
+	t.Run("config scoped to exact subrequest applies only to that subrequest", func(t *testing.T) {
+		state := testDeviceState()
+		status := claimStatus(
+			[]resourceapi.DeviceRequestAllocationResult{
+				allocationResult("channel-request/sub-0", DriverName, "channel-0", nil),
+			},
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"channel-request/sub-0"}, channelConfig("sub-domain")),
+		)
+
+		got, err := state.getConfigResultsMap(&status, configapi.StrictDecoder)
+
+		require.NoError(t, err)
+		assertConfigResultDevices(t, got, ComputeDomainChannelType, "sub-domain", []string{"channel-0"})
+	})
+
+	t.Run("config scoped to different subrequest falls back to default", func(t *testing.T) {
+		state := testDeviceState()
+		status := claimStatus(
+			[]resourceapi.DeviceRequestAllocationResult{
+				allocationResult("channel-request/sub-1", DriverName, "channel-0", nil),
+			},
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"channel-request/sub-0"}, channelConfig("sub-domain")),
+		)
+
+		got, err := state.getConfigResultsMap(&status, configapi.StrictDecoder)
+
+		require.NoError(t, err)
+		assertNoConfigResult(t, got, ComputeDomainChannelType, "sub-domain")
+		assertConfigResultDevices(t, got, ComputeDomainChannelType, "", []string{"channel-0"})
+	})
+
+	// Matching carries no specificity ranking: the last matching config in
+	// precedence order wins, whether it names the parent request or the full
+	// subrequest reference.
+	t.Run("subrequest-scoped config listed later shadows parent-scoped config", func(t *testing.T) {
+		state := testDeviceState()
+		status := claimStatus(
+			[]resourceapi.DeviceRequestAllocationResult{
+				allocationResult("channel-request/sub-0", DriverName, "channel-0", nil),
+			},
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"channel-request"}, channelConfig("parent-domain")),
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"channel-request/sub-0"}, channelConfig("sub-domain")),
+		)
+
+		got, err := state.getConfigResultsMap(&status, configapi.StrictDecoder)
+
+		require.NoError(t, err)
+		assertConfigResultDevices(t, got, ComputeDomainChannelType, "sub-domain", []string{"channel-0"})
+		assertNoConfigResult(t, got, ComputeDomainChannelType, "parent-domain")
+	})
+
+	t.Run("parent-scoped config listed later shadows subrequest-scoped config", func(t *testing.T) {
+		state := testDeviceState()
+		status := claimStatus(
+			[]resourceapi.DeviceRequestAllocationResult{
+				allocationResult("channel-request/sub-0", DriverName, "channel-0", nil),
+			},
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"channel-request/sub-0"}, channelConfig("sub-domain")),
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"channel-request"}, channelConfig("parent-domain")),
+		)
+
+		got, err := state.getConfigResultsMap(&status, configapi.StrictDecoder)
+
+		require.NoError(t, err)
+		assertConfigResultDevices(t, got, ComputeDomainChannelType, "parent-domain", []string{"channel-0"})
+		assertNoConfigResult(t, got, ComputeDomainChannelType, "sub-domain")
+	})
+
+	t.Run("rejects parent-scoped config with mismatched device type on subrequest result", func(t *testing.T) {
+		state := testDeviceState()
+		status := claimStatus(
+			[]resourceapi.DeviceRequestAllocationResult{
+				allocationResult("channel-request/sub-0", DriverName, "channel-0", nil),
+			},
+			opaqueConfig(t, resourceapi.AllocationConfigSourceClaim, DriverName, []string{"channel-request"}, daemonConfig("daemon-domain")),
+		)
+
+		_, err := state.getConfigResultsMap(&status, configapi.StrictDecoder)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot apply ComputeDomainDaemonConfig")
+	})
+
 	t.Run("rejects request config with mismatched device type", func(t *testing.T) {
 		state := testDeviceState()
 		status := claimStatus(

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -36,6 +36,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	"k8s.io/dynamic-resource-allocation/resourceclaim"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	cperrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
@@ -1707,7 +1708,7 @@ func (s *DeviceState) getConfigResultsMap(allocation *resourceapi.AllocationResu
 			return nil, fmt.Errorf("allocatable not found for device %q", result.Device)
 		}
 		for _, c := range slices.Backward(configs) {
-			if slices.Contains(c.Requests, result.Request) {
+			if configMatchesRequest(c.Requests, result.Request) {
 				if err := validateDeviceConfigType(c.Config, device, &result); err != nil {
 					return nil, err
 				}
@@ -1753,6 +1754,28 @@ func getDeviceConfigsWithDefaults(rawConfigs []resourceapi.DeviceAllocationConfi
 	}
 
 	return append(defaults, configs...), nil
+}
+
+// configMatchesRequest reports whether a config scoped to the given request
+// names applies to the request reference in an allocation result. For
+// prioritized list allocations (KEP-4816 firstAvailable), the scheduler
+// records the result's request as "<request>/<subrequest>", so a config may
+// reference either the full subrequest reference or just the parent request.
+// This mirrors the matching used by
+// [k8s.io/dynamic-resource-allocation/resourceclaim.ConfigForResult].
+//
+// Matching carries no specificity ranking: getConfigResultsMap applies the
+// last matching config in its precedence-ordered list, so a parent-scoped
+// config with higher precedence shadows a subrequest-scoped one and vice
+// versa. A matched config is still subject to per-device-type validation, so
+// a type-specific config scoped to a parent request whose subrequests span
+// device types fails preparation rather than silently falling back to the
+// default config; scope such configs to the exact subrequest instead.
+func configMatchesRequest(requests []string, requestRef string) bool {
+	if slices.Contains(requests, requestRef) {
+		return true
+	}
+	return slices.Contains(requests, resourceclaim.BaseRequestRef(requestRef))
 }
 
 func validateDeviceConfigType(c runtime.Object, dev *AllocatableDevice, result *resourceapi.DeviceRequestAllocationResult) error {

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
@@ -672,4 +674,202 @@ func TestIsAdminAccessIgnoresOtherDrivers(t *testing.T) {
 	})
 
 	require.True(t, isAdminAccess(results))
+}
+
+func TestGetConfigResultsMap(t *testing.T) {
+	state := &DeviceState{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				"0000:00:00.0": {
+					"gpu-0": &AllocatableDevice{Gpu: &GpuInfo{minor: 0}},
+					"gpu-1": &AllocatableDevice{Gpu: &GpuInfo{minor: 1}},
+				},
+			},
+		},
+	}
+
+	t.Run("config scoped to plain request applies to its result", func(t *testing.T) {
+		allocation := gpuAllocation(
+			[]resourceapi.DeviceRequestAllocationResult{
+				gpuAllocationResult("gpu", "gpu-0"),
+			},
+			gpuOpaqueConfig(t, []string{"gpu"}, timeSlicedGpuConfig()),
+		)
+
+		got, err := state.getConfigResultsMap(allocation)
+
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"gpu-0"}, devicesForConfig(got, isTimeSlicedGpuConfig))
+	})
+
+	t.Run("config scoped to parent request applies to subrequest result", func(t *testing.T) {
+		allocation := gpuAllocation(
+			[]resourceapi.DeviceRequestAllocationResult{
+				gpuAllocationResult("gpu/subreq", "gpu-0"),
+			},
+			gpuOpaqueConfig(t, []string{"gpu"}, timeSlicedGpuConfig()),
+		)
+
+		got, err := state.getConfigResultsMap(allocation)
+
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"gpu-0"}, devicesForConfig(got, isTimeSlicedGpuConfig))
+	})
+
+	t.Run("config scoped to exact subrequest applies only to that subrequest", func(t *testing.T) {
+		allocation := gpuAllocation(
+			[]resourceapi.DeviceRequestAllocationResult{
+				gpuAllocationResult("gpu/subreq-0", "gpu-0"),
+				gpuAllocationResult("gpu/subreq-1", "gpu-1"),
+			},
+			gpuOpaqueConfig(t, []string{"gpu/subreq-0"}, timeSlicedGpuConfig()),
+		)
+
+		got, err := state.getConfigResultsMap(allocation)
+
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"gpu-0"}, devicesForConfig(got, isTimeSlicedGpuConfig))
+		require.ElementsMatch(t, []string{"gpu-1"}, devicesForConfig(got, isDefaultGpuConfig))
+	})
+
+	t.Run("config scoped to unrelated request does not apply to subrequest result", func(t *testing.T) {
+		allocation := gpuAllocation(
+			[]resourceapi.DeviceRequestAllocationResult{
+				gpuAllocationResult("gpu/subreq", "gpu-0"),
+			},
+			gpuOpaqueConfig(t, []string{"other"}, timeSlicedGpuConfig()),
+		)
+
+		got, err := state.getConfigResultsMap(allocation)
+
+		require.NoError(t, err)
+		require.Empty(t, devicesForConfig(got, isTimeSlicedGpuConfig))
+		require.ElementsMatch(t, []string{"gpu-0"}, devicesForConfig(got, isDefaultGpuConfig))
+	})
+
+	// Matching carries no specificity ranking: the last matching config in
+	// precedence order wins, whether it names the parent request or the full
+	// subrequest reference.
+	t.Run("subrequest-scoped config listed later shadows parent-scoped config", func(t *testing.T) {
+		allocation := gpuAllocation(
+			[]resourceapi.DeviceRequestAllocationResult{
+				gpuAllocationResult("gpu/subreq", "gpu-0"),
+			},
+			gpuOpaqueConfig(t, []string{"gpu"}, timeSlicedGpuConfig()),
+			gpuOpaqueConfig(t, []string{"gpu/subreq"}, mpsGpuConfig()),
+		)
+
+		got, err := state.getConfigResultsMap(allocation)
+
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"gpu-0"}, devicesForConfig(got, isMpsGpuConfig))
+		require.Empty(t, devicesForConfig(got, isTimeSlicedGpuConfig))
+	})
+
+	t.Run("parent-scoped config listed later shadows subrequest-scoped config", func(t *testing.T) {
+		allocation := gpuAllocation(
+			[]resourceapi.DeviceRequestAllocationResult{
+				gpuAllocationResult("gpu/subreq", "gpu-0"),
+			},
+			gpuOpaqueConfig(t, []string{"gpu/subreq"}, mpsGpuConfig()),
+			gpuOpaqueConfig(t, []string{"gpu"}, timeSlicedGpuConfig()),
+		)
+
+		got, err := state.getConfigResultsMap(allocation)
+
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"gpu-0"}, devicesForConfig(got, isTimeSlicedGpuConfig))
+		require.Empty(t, devicesForConfig(got, isMpsGpuConfig))
+	})
+
+	t.Run("device type validation enforced for parent-scoped config on subrequest result", func(t *testing.T) {
+		allocation := gpuAllocation(
+			[]resourceapi.DeviceRequestAllocationResult{
+				gpuAllocationResult("gpu/subreq", "gpu-0"),
+			},
+			gpuOpaqueConfig(t, []string{"gpu"}, configapi.DefaultMigDeviceConfig()),
+		)
+
+		_, err := state.getConfigResultsMap(allocation)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot apply MigDeviceConfig")
+	})
+}
+
+func timeSlicedGpuConfig() *configapi.GpuConfig {
+	config := configapi.DefaultGpuConfig()
+	config.Sharing = &configapi.GpuSharing{Strategy: configapi.TimeSlicingStrategy}
+	return config
+}
+
+func mpsGpuConfig() *configapi.GpuConfig {
+	config := configapi.DefaultGpuConfig()
+	config.Sharing = &configapi.GpuSharing{Strategy: configapi.MpsStrategy}
+	return config
+}
+
+func isMpsGpuConfig(obj runtime.Object) bool {
+	config, ok := obj.(*configapi.GpuConfig)
+	return ok && config.Sharing != nil && config.Sharing.Strategy == configapi.MpsStrategy
+}
+
+func isTimeSlicedGpuConfig(obj runtime.Object) bool {
+	config, ok := obj.(*configapi.GpuConfig)
+	return ok && config.Sharing != nil && config.Sharing.Strategy == configapi.TimeSlicingStrategy
+}
+
+func isDefaultGpuConfig(obj runtime.Object) bool {
+	config, ok := obj.(*configapi.GpuConfig)
+	return ok && config.Sharing == nil
+}
+
+func gpuAllocation(results []resourceapi.DeviceRequestAllocationResult, configs ...resourceapi.DeviceAllocationConfiguration) *resourceapi.AllocationResult {
+	return &resourceapi.AllocationResult{
+		Devices: resourceapi.DeviceAllocationResult{
+			Results: results,
+			Config:  configs,
+		},
+	}
+}
+
+func gpuAllocationResult(request, device string) resourceapi.DeviceRequestAllocationResult {
+	return resourceapi.DeviceRequestAllocationResult{
+		Request: request,
+		Driver:  DriverName,
+		Pool:    "pool",
+		Device:  device,
+	}
+}
+
+func gpuOpaqueConfig(t *testing.T, requests []string, obj runtime.Object) resourceapi.DeviceAllocationConfiguration {
+	t.Helper()
+	raw, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	return resourceapi.DeviceAllocationConfiguration{
+		Source:   resourceapi.AllocationConfigSourceClaim,
+		Requests: requests,
+		DeviceConfiguration: resourceapi.DeviceConfiguration{
+			Opaque: &resourceapi.OpaqueDeviceConfiguration{
+				Driver: DriverName,
+				Parameters: runtime.RawExtension{
+					Raw: raw,
+				},
+			},
+		},
+	}
+}
+
+func devicesForConfig(got map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult, match func(runtime.Object) bool) []string {
+	var devices []string
+	for config, results := range got {
+		if !match(config) {
+			continue
+		}
+		for _, result := range results {
+			devices = append(devices, result.Device)
+		}
+	}
+	return devices
 }

--- a/test/e2e/framework/gpu.go
+++ b/test/e2e/framework/gpu.go
@@ -81,8 +81,21 @@ func StripSemverLeadingZeros(v string) string {
 	}
 }
 
-// LowerKebab lowercases and converts '-' to ' ', converting an NFD label
-// value like "Tesla-T4" to the form CEL's lowerAscii() productName returns.
-func LowerKebab(s string) string {
-	return strings.ToLower(strings.ReplaceAll(s, "-", " "))
+// ProductNamePattern converts a ResourceSlice productName (e.g. "Tesla T4",
+// "NVIDIA A100-SXM4-40GB") into a regex fragment that matches the value CEL's
+// lowerAscii() returns for the same attribute. Letters, digits, spaces and
+// hyphens are kept verbatim (none are RE2 metacharacters outside a class);
+// any other rune becomes a single-character wildcard so no escaping is
+// needed inside the CEL string literal.
+func ProductNamePattern(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == ' ', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('.')
+		}
+	}
+	return b.String()
 }

--- a/test/e2e/framework/specs/prioritized-list-config.yaml.tmpl
+++ b/test/e2e/framework/specs/prioritized-list-config.yaml.tmpl
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: gpu-device
+  namespace: {{ .Namespace }}
+spec:
+  devices:
+    requests:
+    - name: gpu
+      firstAvailable:
+      - name: dual
+        deviceClassName: gpu.nvidia.com
+        count: 2
+      - name: single
+        deviceClassName: gpu.nvidia.com
+    config:
+    - requests: ["gpu"]
+      opaque:
+        driver: gpu.nvidia.com
+        parameters:
+          apiVersion: resource.nvidia.com/v1beta1
+          kind: GpuConfig
+          sharing:
+            strategy: TimeSlicing
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-test
+  namespace: {{ .Namespace }}
+spec:
+  replicas: {{ .Replicas }}
+  selector:
+    matchLabels:
+      app: gpu-test
+  template:
+    metadata:
+      labels:
+        app: gpu-test
+    spec:
+      resourceClaims:
+      - name: gpu-device
+        resourceClaimName: gpu-device
+      containers:
+      - name: gpu-container
+        image: nvcr.io/nvidia/cuda:12.2.0-base-ubuntu22.04
+        command: ["bash","-c"]
+        args: ["nvidia-smi -L && echo GPU_OK && sleep 3600"]
+        resources:
+          claims:
+          - name: gpu-device
+            request: gpu
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/test/e2e/gpu_allocation_test.go
+++ b/test/e2e/gpu_allocation_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GPU Allocation", func() {
 	It("[cel/productName] schedules a pod via product-name regex selector", func(ctx SpecContext) {
 		yaml, err := framework.Render("product-type", map[string]any{
 			"Namespace":      ns,
-			"ProductPattern": framework.LowerKebab(gpu.ProductName),
+			"ProductPattern": framework.ProductNamePattern(gpu.ProductName),
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(framework.ApplyYAML(ctx, yaml)).To(Succeed())
@@ -125,6 +125,35 @@ var _ = Describe("GPU Allocation", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rc.Status.Allocation).NotTo(BeNil())
 		Expect(len(rc.Status.ReservedFor)).To(BeEquivalentTo(replicas))
+	})
+
+	It("[prioritized-list] applies request-scoped config to firstAvailable subrequest allocation", func(ctx SpecContext) {
+		const replicas = 2
+		yaml, err := framework.Render("prioritized-list-config", map[string]any{
+			"Namespace": ns,
+			"Replicas":  replicas,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(framework.ApplyYAML(ctx, yaml)).To(Succeed())
+
+		// Smoke test of the prepare path for a prioritized-list allocation
+		// whose TimeSlicing config is scoped to the parent request "gpu". Pod
+		// readiness proves NodePrepareResources succeeded on the "gpu/dual"
+		// or "gpu/single" subrequest result; it does not by itself prove the
+		// config was applied (a non-matching config silently falls back to
+		// the default GpuConfig). Config-matching semantics are pinned by
+		// TestGetConfigResultsMap in cmd/gpu-kubelet-plugin.
+		got, err := framework.WaitForPodsReady(ctx, cs, ns, "app=gpu-test", replicas, 5*time.Minute)
+		Expect(err).NotTo(HaveOccurred(), "only %d/%d pods Ready", got, replicas)
+
+		rc, err := cs.ResourceV1().ResourceClaims(ns).Get(ctx, "gpu-device", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rc.Status.Allocation).NotTo(BeNil())
+		Expect(rc.Status.Allocation.Devices.Results).NotTo(BeEmpty())
+		for _, r := range rc.Status.Allocation.Devices.Results {
+			Expect(r.Request).To(HavePrefix("gpu/"),
+				"expected a prioritized-list subrequest reference, got %q", r.Request)
+		}
 	})
 
 	It("[negative] pod stays Pending when no device matches (h300)", func(ctx SpecContext) {
@@ -248,4 +277,3 @@ func verifyClaimsShareSameDevice(ctx context.Context, ns string) {
 		}
 	}
 }
-


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For prioritized list allocations (KEP-4816 `firstAvailable`) the scheduler sets `AllocationResult.Request` to `"<request>/<subrequest>"`, so a config scoped with `requests: ["gpu"]` never matched the allocated result and was silently ignored. This matches the parent segment before the first `/` as well, in both the GPU and the compute domain kubelet plugin, mirroring `resourceclaim.ConfigForResult`.

Matching carries no specificity ranking: the last matching config in precedence order wins, parent scoped and subrequest scoped alike.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

**This is intentionally a draft, so please don't spend review time on it yet.**

It is part of an experiment in bringing the three DRA drivers (dra-example-driver, dra-driver-nvidia-gpu and dra-driver-google-tpu) closer to feature parity, along with a few bugs found along the way.

**How it was produced:** the implementation was written largely by autonomous coding agents working under my direction, one per feature, each in its own branch. I am not asking you to take that on trust, which is exactly why it opens as a draft.

**Verified so far, unattended:** gofmt, go vet including `-tags e2e`, unit tests for both plugins, and a run on kind v1.36.1 using this repo's mock NVML path, where the driver really discovers devices and real claims are allocated by kube-scheduler and prepared by the plugin. Six scenarios were checked against the plugin's observable behaviour, using the fact that an applied time slicing config makes the plugin invoke `nvidia-smi compute-policy --set-timeslice`: parent scoped config applied to the subrequest result, exactly scoped config applied, sibling scoped config not applied, both precedence orders, and a cross type config now failing prepare. The same scenarios were then run against a binary built from the merge base, which reproduced the bug in each case. The full e2e suite passes at 9 of 9 specs. An automated code review pass ran on top of this, and its findings were applied and retested.

**Not done yet:** my own reading of the full diff, and testing it again by hand under my supervision. That happens before this leaves draft, so no CI approval, `/ok-to-test`, or reviewer attention is needed until then.

I will drop the `WIP:` prefix and mark it ready for review only after that human pass.

Technical notes:

A type specific config scoped to a parent request whose subrequests span device types now fails prepare instead of silently falling back to the default. Scoping to the exact subrequest is the way to opt out. This is a deliberate behaviour change and the reason is documented next to `configMatchesRequest`.

Two cases turn out to be defensive only, which the cluster run surfaced: the API server drops configs for unallocated subrequests before the driver sees them, and it rejects a `requests` entry naming something that is not a request or subrequest in the claim.

This PR also fixes an unrelated pre existing bug in the e2e framework, where `LowerKebab` rewrote hyphens into spaces before matching the ResourceSlice `productName`, so any hyphenated product name such as "NVIDIA A100-SXM4-40GB" could never match. Current CI hardware has no hyphens in its product names, which is why it has not been noticed.

The same fix for dra-example-driver is in https://github.com/kubernetes-sigs/dra-example-driver/pull/257, and the semantics are kept identical.

#### Does this PR introduce a user-facing change?

```release-note
Fixed opaque device configs scoped to a parent request so they now apply to devices allocated through a prioritized list subrequest, where they were previously ignored.
```

#### Additional documentation (design docs, usage docs, etc.):

```docs
NONE
```

#### Checklist

- [x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [x] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
