### PR TITLE
WIP: gpu-kubelet-plugin: publish device status to ResourceClaims (KEP-4817)

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -88,6 +88,13 @@ type DeviceState struct {
 
 	// Checkpoint read/write lock, file-based for multi-process synchronization.
 	cplock *flock.Flock
+
+	// Claim UIDs whose device statuses (KEP-4817) were successfully
+	// published, so that repeated Prepare() calls for a claim skip the API
+	// round-trip. In-memory only: after a plugin restart, the first Prepare()
+	// per claim re-checks (and no-ops when the status is already in place).
+	// Guarded by the DeviceState lock.
+	statusPublishedClaims map[string]bool
 }
 
 // newFabricManager opens a Fabric Manager connection when the
@@ -225,6 +232,8 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		checkpointManager: checkpointManager,
 		fmManager:         fmManager,
 		cplock:            flock.NewFlock(cpLockPath),
+
+		statusPublishedClaims: make(map[string]bool),
 	}
 	state.checkpointCleanupManager = NewCheckpointCleanupManager(state, config.clientsets.Resource)
 
@@ -319,6 +328,11 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 		// Prepare() must be idempotent, as it may be invoked more than once per
 		// claim (and actual device preparation must happen at most once).
 		klog.V(4).Infof("Skip prepare: claim already in PrepareCompleted state: %s", ResourceClaimToString(claim))
+		// Re-assert the device statuses: this heals a status write that
+		// failed during the original preparation. Free in steady state: once
+		// a publish succeeded for this claim, this returns without an API
+		// call (see publishDeviceStatuses).
+		s.publishDeviceStatuses(ctx, claim, preparedClaim.PreparedDevices)
 		return preparedClaim.PreparedDevices.GetDevices(), nil
 	}
 
@@ -398,6 +412,12 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	}
 	klog.V(6).Infof("checkpoint updated for claim %v", claimUID)
 	klog.V(7).Infof("t_prep_ucp2 %.3f s", time.Since(tucp20).Seconds())
+
+	// KEP-4817: publish per-device status to the ResourceClaim. Best-effort
+	// (see publishDeviceStatuses); do this only after the claim reached
+	// PrepareCompleted so the status never describes a preparation that may
+	// still be rolled back.
+	s.publishDeviceStatuses(ctx, claim, preparedDevices)
 
 	return preparedDevices.GetDevices(), nil
 }
@@ -571,6 +591,12 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 			return false, fmt.Errorf("error deactivating fabric partition: %w", err)
 		}
 	}
+
+	// KEP-4817: remove this driver's entries from the claim's device statuses
+	// so the claim does not keep advertising devices that are no longer
+	// prepared. Best-effort; the claim is typically already deleted, in which
+	// case this is a cheap noop.
+	s.clearDeviceStatuses(ctx, claimRef)
 
 	// TODOMIG: we delete per-claim CDI spec files here in the happy path. In
 	// regular operation, that means we don't leak files. However, upon program

--- a/cmd/gpu-kubelet-plugin/devicestatus.go
+++ b/cmd/gpu-kubelet-plugin/devicestatus.go
@@ -1,0 +1,349 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	resourceapi "k8s.io/api/resource/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+// The status write is best-effort and must never wedge the prepare/unprepare
+// path (it runs while the DeviceState lock and the node-global prep/unprep
+// flock are held): bound each publish attempt, mirroring the 20s bound on the
+// claim GET in cleanup.go.
+const deviceStatusUpdateTimeout = 10 * time.Second
+
+// DeviceStatusData is the driver-specific payload published as
+// ResourceClaim.status.devices[].data (KEP-4817). It records which concrete
+// device backed an allocation: unlike ResourceSlice contents, it remains
+// available after the device disappears from the slice (e.g. when a MIG
+// device is torn down or a GPU becomes unhealthy), so past allocations can
+// still be correlated with later health or scheduling issues.
+type DeviceStatusData struct {
+	Type          string `json:"type"`
+	UUID          string `json:"uuid,omitempty"`
+	ProductName   string `json:"productName,omitempty"`
+	DriverVersion string `json:"driverVersion,omitempty"`
+	// For MIG devices, the PCI bus ID is that of the parent GPU.
+	PCIBusID string `json:"pciBusID,omitempty"`
+	// MIG devices only.
+	MigProfile string `json:"migProfile,omitempty"`
+	ParentUUID string `json:"parentUUID,omitempty"`
+}
+
+// publishDeviceStatuses writes one AllocatedDeviceStatus per device prepared
+// for the claim into ResourceClaim.status.devices. Failure to publish is
+// non-fatal for Prepare(): the devices are prepared either way and the claim
+// status is simply missing the data; the write is retried on the next
+// (idempotent) Prepare() call for the claim. A successful publish is recorded
+// in memory so that repeated Prepare() calls for the claim (one per pod
+// referencing it, plus the replay after a kubelet or plugin restart) skip the
+// API round-trip.
+//
+// Must be called with the DeviceState lock held (it serializes access to
+// statusPublishedClaims and the allocatable device map).
+func (s *DeviceState) publishDeviceStatuses(ctx context.Context, claim *resourceapi.ResourceClaim, preparedDevices PreparedDevices) {
+	if !featuregates.Enabled(featuregates.ResourceClaimDeviceStatus) {
+		return
+	}
+	claimUID := string(claim.UID)
+	if s.statusPublishedClaims[claimUID] {
+		return
+	}
+
+	statuses := s.buildDeviceStatuses(claim, preparedDevices)
+	if len(statuses) == 0 {
+		return
+	}
+
+	written, err := s.updateDeviceStatuses(ctx, claim, statuses)
+	if err != nil {
+		klog.Errorf("Failed to publish device statuses to claim %s: %s", ResourceClaimToString(claim), err)
+		return
+	}
+	if s.statusPublishedClaims == nil {
+		s.statusPublishedClaims = make(map[string]bool)
+	}
+	s.statusPublishedClaims[claimUID] = true
+	if written {
+		klog.V(4).Infof("Published %d device status(es) to claim %s", len(statuses), ResourceClaimToString(claim))
+	} else {
+		klog.V(4).Infof("Device status(es) for claim %s already up to date", ResourceClaimToString(claim))
+	}
+}
+
+// clearDeviceStatuses removes this driver's entries from
+// ResourceClaim.status.devices. Called during Unprepare so that a claim that
+// outlives its preparation (e.g. a user-created claim, or one shared by
+// several pods) does not keep advertising devices that are no longer
+// prepared. Best-effort: an error only means the stale entries linger until
+// the claim is deallocated, at which point the API server drops them.
+//
+// Must be called with the DeviceState lock held.
+func (s *DeviceState) clearDeviceStatuses(ctx context.Context, claimRef kubeletplugin.NamespacedObject) {
+	if !featuregates.Enabled(featuregates.ResourceClaimDeviceStatus) {
+		return
+	}
+	delete(s.statusPublishedClaims, string(claimRef.UID))
+
+	ctx, cancel := context.WithTimeout(ctx, deviceStatusUpdateTimeout)
+	defer cancel()
+
+	rc := s.config.clientsets.Resource.ResourceClaims(claimRef.Namespace)
+	cleared := 0
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := rc.Get(ctx, claimRef.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if current.UID != claimRef.UID {
+			// The claim was deleted and recreated: nothing of ours to clear.
+			return nil
+		}
+		merged := mergeDeviceStatuses(current.Status.Devices, nil)
+		cleared = len(current.Status.Devices) - len(merged)
+		if cleared == 0 {
+			return nil
+		}
+		updated := current.DeepCopy()
+		updated.Status.Devices = merged
+		_, err = rc.UpdateStatus(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+	switch {
+	case apierrors.IsNotFound(err):
+		klog.V(4).Infof("Clear device statuses: claim %s already gone", claimRef.String())
+	case err != nil:
+		klog.Errorf("Failed to clear device statuses on claim %s: %s", claimRef.String(), err)
+	case cleared > 0:
+		klog.V(4).Infof("Cleared %d device status(es) from claim %s", cleared, claimRef.String())
+	default:
+		klog.V(4).Infof("Clear device statuses: no entries of ours on claim %s", claimRef.String())
+	}
+}
+
+// buildDeviceStatuses constructs one AllocatedDeviceStatus per allocation
+// result owned by this driver, with a DeviceStatusData payload describing the
+// concrete prepared device. Device properties are resolved from the current
+// device discovery data (not from the checkpointed PreparedDevices, which
+// only round-trip a subset of fields through JSON).
+func (s *DeviceState) buildDeviceStatuses(claim *resourceapi.ResourceClaim, preparedDevices PreparedDevices) []resourceapi.AllocatedDeviceStatus {
+	if claim.Status.Allocation == nil {
+		return nil
+	}
+
+	preparedByName := make(map[DeviceName]*PreparedDevice)
+	for _, group := range preparedDevices {
+		for i := range group.Devices {
+			device := &group.Devices[i]
+			if name, ok := preparedDeviceName(device); ok {
+				preparedByName[name] = device
+			}
+		}
+	}
+
+	var statuses []resourceapi.AllocatedDeviceStatus
+	// status.devices is validated by the API server as a set keyed by
+	// (driver, pool, device, shareID): a duplicate key (e.g. two allocation
+	// results for the same device without a ShareID, as produced by
+	// adminAccess requests) would make the whole update be rejected.
+	seen := make(map[string]bool)
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		if result.Driver != DriverName {
+			continue
+		}
+		device, exists := preparedByName[result.Device]
+		if !exists {
+			continue
+		}
+		key := result.Pool + "/" + result.Device
+		if result.ShareID != nil {
+			key += "/" + string(*result.ShareID)
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		data, err := json.Marshal(s.buildDeviceStatusData(device))
+		if err != nil {
+			// Not expected (plain struct); skip the entry rather than
+			// publishing an empty payload.
+			klog.Errorf("Failed to marshal device status data for device %s: %s", result.Device, err)
+			continue
+		}
+
+		statuses = append(statuses, resourceapi.AllocatedDeviceStatus{
+			Driver: result.Driver,
+			Pool:   result.Pool,
+			Device: result.Device,
+			// With ConsumableShares, the same device may appear in more than
+			// one result; the ShareID distinguishes the entries.
+			ShareID: (*string)(result.ShareID),
+			Data:    &runtime.RawExtension{Raw: data},
+		})
+	}
+	return statuses
+}
+
+// preparedDeviceName returns the announced device name for a prepared device.
+// Unlike PreparedDevice.CanonicalName() it does not panic on malformed
+// (e.g. checkpoint-restored) entries.
+func preparedDeviceName(device *PreparedDevice) (DeviceName, bool) {
+	switch device.Type() {
+	case GpuDeviceType:
+		if device.Gpu.Device != nil {
+			return device.Gpu.Device.DeviceName, true
+		}
+	case PreparedMigDeviceType:
+		if device.Mig.Device != nil {
+			return device.Mig.Device.DeviceName, true
+		}
+	case VfioDeviceType:
+		if device.Vfio.Device != nil {
+			return device.Vfio.Device.DeviceName, true
+		}
+	}
+	return "", false
+}
+
+func (s *DeviceState) buildDeviceStatusData(device *PreparedDevice) DeviceStatusData {
+	switch device.Type() {
+	case GpuDeviceType:
+		data := DeviceStatusData{
+			Type: GpuDeviceType,
+			UUID: device.Gpu.Info.UUID,
+		}
+		if gpu := s.nvdevlib.gpuInfosByUUID[device.Gpu.Info.UUID]; gpu != nil {
+			data.ProductName = gpu.productName
+			data.DriverVersion = gpu.driverVersion
+			data.PCIBusID = gpu.pciBusID
+		}
+		return data
+	case PreparedMigDeviceType:
+		data := DeviceStatusData{
+			Type: PreparedMigDeviceType,
+		}
+		if device.Mig.Concrete != nil {
+			data.UUID = device.Mig.Concrete.MigUUID
+			data.ParentUUID = device.Mig.Concrete.ParentUUID
+			if parent := s.nvdevlib.gpuInfosByUUID[device.Mig.Concrete.ParentUUID]; parent != nil {
+				data.ProductName = parent.productName
+				data.DriverVersion = parent.driverVersion
+				data.PCIBusID = parent.pciBusID
+			}
+		}
+		if allocatable := s.perGPUAllocatable.GetAllocatableDevice(device.Mig.Device.DeviceName); allocatable != nil {
+			switch {
+			case allocatable.MigStatic != nil:
+				data.MigProfile = allocatable.MigStatic.Profile
+			case allocatable.MigDynamic != nil:
+				data.MigProfile = allocatable.MigDynamic.Profile.String()
+			}
+		}
+		return data
+	case VfioDeviceType:
+		data := DeviceStatusData{
+			Type:     VfioDeviceType,
+			UUID:     device.Vfio.Info.UUID,
+			PCIBusID: device.Vfio.Info.PciBusID,
+		}
+		if allocatable := s.perGPUAllocatable.GetAllocatableDevice(device.Vfio.Device.DeviceName); allocatable != nil && allocatable.Vfio != nil {
+			data.ProductName = allocatable.Vfio.productName
+			if data.PCIBusID == "" {
+				data.PCIBusID = allocatable.Vfio.PciBusID
+			}
+		}
+		return data
+	}
+	return DeviceStatusData{Type: UnknownDeviceType}
+}
+
+// updateDeviceStatuses updates ResourceClaim.status.devices with the given
+// entries, replacing only entries owned by this driver. Entries written by
+// other drivers (a claim can carry allocations from several drivers) are
+// preserved -- deliberately stricter than dra-example-driver, which
+// overwrites status.devices wholesale. Returns whether an update was
+// written (false when the claim already carried identical entries).
+func (s *DeviceState) updateDeviceStatuses(ctx context.Context, claim *resourceapi.ResourceClaim, statuses []resourceapi.AllocatedDeviceStatus) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, deviceStatusUpdateTimeout)
+	defer cancel()
+
+	rc := s.config.clientsets.Resource.ResourceClaims(claim.Namespace)
+
+	written := false
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := rc.Get(ctx, claim.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if current.UID != claim.UID {
+			return fmt.Errorf("claim UID changed (prepared %s, found %s): not writing device status", claim.UID, current.UID)
+		}
+
+		merged := mergeDeviceStatuses(current.Status.Devices, statuses)
+		if apiequality.Semantic.DeepEqual(current.Status.Devices, merged) {
+			// Nothing to do; common on idempotent Prepare() retries.
+			return nil
+		}
+
+		updated := current.DeepCopy()
+		updated.Status.Devices = merged
+		result, err := rc.UpdateStatus(ctx, updated, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		written = true
+		if len(result.Status.Devices) == 0 {
+			// The API server accepted the write but dropped the field: the
+			// cluster-side DRAResourceClaimDeviceStatus feature gate is
+			// disabled. Warn (the driver-side gate was enabled explicitly)
+			// but report success so the write is not retried forever.
+			klog.Warningf("Device statuses for claim %s were dropped by the API server; "+
+				"the DRAResourceClaimDeviceStatus Kubernetes feature gate appears to be disabled on this cluster",
+				ResourceClaimToString(claim))
+		}
+		return nil
+	})
+	return written, err
+}
+
+// mergeDeviceStatuses returns the entries of `existing` not owned by this
+// driver, followed by `ours` (the full replacement set for this driver's
+// entries; nil removes them all).
+func mergeDeviceStatuses(existing, ours []resourceapi.AllocatedDeviceStatus) []resourceapi.AllocatedDeviceStatus {
+	var merged []resourceapi.AllocatedDeviceStatus
+	for _, status := range existing {
+		if status.Driver != DriverName {
+			merged = append(merged, status)
+		}
+	}
+	return append(merged, ours...)
+}

--- a/cmd/gpu-kubelet-plugin/devicestatus_test.go
+++ b/cmd/gpu-kubelet-plugin/devicestatus_test.go
@@ -1,0 +1,317 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+func deviceStatusTestState() *DeviceState {
+	gpu0 := &GpuInfo{
+		UUID:          "GPU-0000",
+		minor:         0,
+		productName:   "NVIDIA H100 80GB HBM3",
+		driverVersion: "565.57.01",
+		pciBusID:      "0000:01:00.0",
+	}
+	gpu1 := &GpuInfo{
+		UUID:          "GPU-1111",
+		minor:         1,
+		productName:   "NVIDIA A100-SXM4-40GB",
+		driverVersion: "565.57.01",
+		pciBusID:      "0000:02:00.0",
+	}
+	return &DeviceState{
+		nvdevlib: &deviceLib{
+			gpuInfosByUUID: map[string]*GpuInfo{
+				gpu0.UUID: gpu0,
+				gpu1.UUID: gpu1,
+			},
+		},
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				"0000:01:00.0": {
+					"gpu-0": &AllocatableDevice{Gpu: gpu0},
+				},
+				"0000:02:00.0": {
+					"gpu-1-mig-1g5gb-19-0": &AllocatableDevice{
+						MigStatic: &MigDeviceInfo{
+							UUID:       "MIG-2222",
+							Profile:    "1g.5gb",
+							ParentUUID: gpu1.UUID,
+						},
+					},
+				},
+				"0000:03:00.0": {
+					"gpu-vfio-0": &AllocatableDevice{
+						Vfio: &VfioDeviceInfo{
+							UUID:        "GPU-3333",
+							index:       0,
+							productName: "NVIDIA H100 80GB HBM3",
+							PciBusID:    "0000:03:00.0",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func claimWithResults(results ...resourceapi.DeviceRequestAllocationResult) *resourceapi.ResourceClaim {
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "claim-1",
+			Namespace: "default",
+			UID:       types.UID("uid-1"),
+		},
+		Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{
+					Results: results,
+				},
+			},
+		},
+	}
+}
+
+func decodeStatusData(t *testing.T, status resourceapi.AllocatedDeviceStatus) DeviceStatusData {
+	t.Helper()
+	require.NotNil(t, status.Data)
+	var data DeviceStatusData
+	require.NoError(t, json.Unmarshal(status.Data.Raw, &data))
+	return data
+}
+
+func TestBuildDeviceStatuses(t *testing.T) {
+	state := deviceStatusTestState()
+
+	claim := claimWithResults(
+		resourceapi.DeviceRequestAllocationResult{
+			Request: "req-gpu", Driver: DriverName, Pool: "node-1", Device: "gpu-0",
+		},
+		resourceapi.DeviceRequestAllocationResult{
+			Request: "req-mig", Driver: DriverName, Pool: "node-1", Device: "gpu-1-mig-1g5gb-19-0",
+		},
+		resourceapi.DeviceRequestAllocationResult{
+			Request: "req-vfio", Driver: DriverName, Pool: "node-1", Device: "gpu-vfio-0",
+		},
+		// Allocation result owned by another driver: must be ignored.
+		resourceapi.DeviceRequestAllocationResult{
+			Request: "req-other", Driver: "other.example.com", Pool: "node-1", Device: "gpu-0",
+		},
+	)
+
+	preparedDevices := PreparedDevices{
+		&PreparedDeviceGroup{
+			Devices: PreparedDeviceList{
+				{
+					Gpu: &PreparedGpu{
+						Info:   &GpuInfo{UUID: "GPU-0000"},
+						Device: &CheckpointedDevice{DeviceName: "gpu-0", PoolName: "node-1"},
+					},
+				},
+				{
+					Mig: &PreparedMigDevice{
+						Concrete: &MigLiveTuple{MigUUID: "MIG-2222", ParentUUID: "GPU-1111"},
+						Device:   &CheckpointedDevice{DeviceName: "gpu-1-mig-1g5gb-19-0", PoolName: "node-1"},
+					},
+				},
+				{
+					Vfio: &PreparedVfioDevice{
+						Info:   &VfioDeviceInfo{UUID: "GPU-3333"},
+						Device: &CheckpointedDevice{DeviceName: "gpu-vfio-0", PoolName: "node-1"},
+					},
+				},
+			},
+		},
+	}
+
+	statuses := state.buildDeviceStatuses(claim, preparedDevices)
+	require.Len(t, statuses, 3)
+
+	require.Equal(t, DriverName, statuses[0].Driver)
+	require.Equal(t, "node-1", statuses[0].Pool)
+	require.Equal(t, "gpu-0", statuses[0].Device)
+	require.Nil(t, statuses[0].ShareID)
+	require.Equal(t, DeviceStatusData{
+		Type:          GpuDeviceType,
+		UUID:          "GPU-0000",
+		ProductName:   "NVIDIA H100 80GB HBM3",
+		DriverVersion: "565.57.01",
+		PCIBusID:      "0000:01:00.0",
+	}, decodeStatusData(t, statuses[0]))
+
+	require.Equal(t, "gpu-1-mig-1g5gb-19-0", statuses[1].Device)
+	require.Equal(t, DeviceStatusData{
+		Type:          PreparedMigDeviceType,
+		UUID:          "MIG-2222",
+		ParentUUID:    "GPU-1111",
+		ProductName:   "NVIDIA A100-SXM4-40GB",
+		DriverVersion: "565.57.01",
+		PCIBusID:      "0000:02:00.0",
+		MigProfile:    "1g.5gb",
+	}, decodeStatusData(t, statuses[1]))
+
+	require.Equal(t, "gpu-vfio-0", statuses[2].Device)
+	require.Equal(t, DeviceStatusData{
+		Type:        VfioDeviceType,
+		UUID:        "GPU-3333",
+		ProductName: "NVIDIA H100 80GB HBM3",
+		PCIBusID:    "0000:03:00.0",
+	}, decodeStatusData(t, statuses[2]))
+}
+
+// A GPU prepared before a plugin restart is restored from the checkpoint,
+// which round-trips only the UUID of the GpuInfo. The status data must still
+// be complete, resolved from current device discovery data.
+func TestBuildDeviceStatusesFromRestoredCheckpoint(t *testing.T) {
+	state := deviceStatusTestState()
+
+	claim := claimWithResults(resourceapi.DeviceRequestAllocationResult{
+		Request: "req-gpu", Driver: DriverName, Pool: "node-1", Device: "gpu-0",
+	})
+
+	preparedDevices := PreparedDevices{
+		&PreparedDeviceGroup{
+			Devices: PreparedDeviceList{
+				{
+					Gpu: &PreparedGpu{
+						// As deserialized from the checkpoint: unexported
+						// GpuInfo fields (productName, ...) are all empty.
+						Info:   &GpuInfo{UUID: "GPU-0000"},
+						Device: &CheckpointedDevice{DeviceName: "gpu-0", PoolName: "node-1"},
+					},
+				},
+			},
+		},
+	}
+
+	statuses := state.buildDeviceStatuses(claim, preparedDevices)
+	require.Len(t, statuses, 1)
+	data := decodeStatusData(t, statuses[0])
+	require.Equal(t, "NVIDIA H100 80GB HBM3", data.ProductName)
+	require.Equal(t, "565.57.01", data.DriverVersion)
+}
+
+func TestBuildDeviceStatusesConsumableShares(t *testing.T) {
+	state := deviceStatusTestState()
+
+	shareA := types.UID("11111111-1111-1111-1111-111111111111")
+	shareB := types.UID("22222222-2222-2222-2222-222222222222")
+	claim := claimWithResults(
+		resourceapi.DeviceRequestAllocationResult{
+			Request: "req-a", Driver: DriverName, Pool: "node-1", Device: "gpu-0", ShareID: &shareA,
+		},
+		resourceapi.DeviceRequestAllocationResult{
+			Request: "req-b", Driver: DriverName, Pool: "node-1", Device: "gpu-0", ShareID: &shareB,
+		},
+	)
+
+	preparedDevices := PreparedDevices{
+		&PreparedDeviceGroup{
+			Devices: PreparedDeviceList{
+				{
+					Gpu: &PreparedGpu{
+						Info:   &GpuInfo{UUID: "GPU-0000"},
+						Device: &CheckpointedDevice{DeviceName: "gpu-0", PoolName: "node-1"},
+					},
+				},
+			},
+		},
+	}
+
+	statuses := state.buildDeviceStatuses(claim, preparedDevices)
+	require.Len(t, statuses, 2)
+	require.Equal(t, ptr.To(string(shareA)), statuses[0].ShareID)
+	require.Equal(t, ptr.To(string(shareB)), statuses[1].ShareID)
+}
+
+// Two allocation results for the same device without a ShareID (e.g. from
+// adminAccess requests) must not produce duplicate (driver, pool, device,
+// shareID) keys: status.devices is validated as a set and the whole update
+// would be rejected.
+func TestBuildDeviceStatusesDeduplicatesResults(t *testing.T) {
+	state := deviceStatusTestState()
+
+	claim := claimWithResults(
+		resourceapi.DeviceRequestAllocationResult{
+			Request: "req-a", Driver: DriverName, Pool: "node-1", Device: "gpu-0",
+		},
+		resourceapi.DeviceRequestAllocationResult{
+			Request: "req-b", Driver: DriverName, Pool: "node-1", Device: "gpu-0",
+		},
+	)
+
+	preparedDevices := PreparedDevices{
+		&PreparedDeviceGroup{
+			Devices: PreparedDeviceList{
+				{
+					Gpu: &PreparedGpu{
+						Info:   &GpuInfo{UUID: "GPU-0000"},
+						Device: &CheckpointedDevice{DeviceName: "gpu-0", PoolName: "node-1"},
+					},
+				},
+			},
+		},
+	}
+
+	statuses := state.buildDeviceStatuses(claim, preparedDevices)
+	require.Len(t, statuses, 1)
+}
+
+func TestBuildDeviceStatusesNoAllocation(t *testing.T) {
+	state := deviceStatusTestState()
+	claim := claimWithResults()
+	claim.Status.Allocation = nil
+	require.Empty(t, state.buildDeviceStatuses(claim, PreparedDevices{}))
+}
+
+func TestMergeDeviceStatuses(t *testing.T) {
+	otherDriverStatus := resourceapi.AllocatedDeviceStatus{
+		Driver: "other.example.com", Pool: "pool-x", Device: "dev-x",
+	}
+	staleOwnStatus := resourceapi.AllocatedDeviceStatus{
+		Driver: DriverName, Pool: "node-1", Device: "gpu-9",
+	}
+	ownStatus := resourceapi.AllocatedDeviceStatus{
+		Driver: DriverName, Pool: "node-1", Device: "gpu-0",
+	}
+
+	// Entries of other drivers are preserved; all entries owned by this
+	// driver are replaced with the new set.
+	merged := mergeDeviceStatuses(
+		[]resourceapi.AllocatedDeviceStatus{otherDriverStatus, staleOwnStatus},
+		[]resourceapi.AllocatedDeviceStatus{ownStatus},
+	)
+	require.Equal(t, []resourceapi.AllocatedDeviceStatus{otherDriverStatus, ownStatus}, merged)
+
+	// No prior entries.
+	merged = mergeDeviceStatuses(nil, []resourceapi.AllocatedDeviceStatus{ownStatus})
+	require.Equal(t, []resourceapi.AllocatedDeviceStatus{ownStatus}, merged)
+
+	// A nil replacement set (the Unprepare path) removes all of this
+	// driver's entries and keeps everyone else's.
+	merged = mergeDeviceStatuses([]resourceapi.AllocatedDeviceStatus{otherDriverStatus, ownStatus}, nil)
+	require.Equal(t, []resourceapi.AllocatedDeviceStatus{otherDriverStatus}, merged)
+}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml
@@ -11,6 +11,24 @@ rules:
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceclaims"]
   verbs: ["get", "list", "watch"]
+{{- if (and $.Values.resources.gpus.enabled (and $.Values.featureGates (and (hasKey $.Values.featureGates "ResourceClaimDeviceStatus") $.Values.featureGates.ResourceClaimDeviceStatus))) }}
+# Required for publishing per-device status (KEP-4817) into
+# ResourceClaim.status.devices when the ResourceClaimDeviceStatus driver
+# feature gate is enabled.
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/status"]
+  verbs: ["update"]
+# Kubernetes 1.36+ enforces granular authorization for ResourceClaim status
+# writes via the DRAResourceClaimGranularStatusAuthorization feature gate. As a
+# node-local driver, we need the "associated-node" verbs on
+# "resourceclaims/driver" for our own driver name. This rule is inert on older
+# clusters that have not yet enabled the feature gate.
+# See https://github.com/kubernetes/kubernetes/issues/138149
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/driver"]
+  verbs: ["associated-node:update", "associated-node:patch"]
+  resourceNames: ["gpu.nvidia.com"]
+{{- end }}
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceslices"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -118,6 +118,8 @@ resources:
 #   HostManagedIMEXDaemon: false       # Gate allowing resources.computeDomains.imex.mode=hostManaged
 #   DRAListTypeAttributes: false       # Publish list-valued DRA device attributes
 #   ConsumableShares: false            # Publish consumable capacity and multi-allocation support for devices
+#   ResourceClaimDeviceStatus: false   # Publish per-device status (KEP-4817) into ResourceClaim.status.devices
+#                                      # (requires the DRAResourceClaimDeviceStatus Kubernetes feature gate)
 featureGates: {}
 
 # Log verbosity for all components. Zero or greater, higher number means higher

--- a/hack/ci/lambda/e2e-test.sh
+++ b/hack/ci/lambda/e2e-test.sh
@@ -41,6 +41,10 @@ fi
 # These Alpha feature gates must be explicitly enabled on k8s 1.35+:
 #   DRAExtendedResource: allows nvidia.com/gpu in resources.limits (test_gpu_extres.bats)
 #   DRAPartitionableDevices: allows SharedCounters/ConsumesCounters in ResourceSlices (DynamicMIG)
+# DRAResourceClaimDeviceStatus lets the driver publish per-device status
+# (KEP-4817) into ResourceClaim.status.devices (test_gpu_device_status.bats).
+# Known since 1.32 and beta default-on since 1.33, so enabling it explicitly
+# is safe on all supported versions.
 if [ -n "${K8S_VERSION}" ]; then
   RESOLVED_K8S_VERSION="${K8S_VERSION}"
 else
@@ -49,8 +53,8 @@ fi
 K8S_MINOR=$(echo "${RESOLVED_K8S_VERSION}" | sed 's/v1\.\([0-9]*\)\..*/\1/')
 KUBEADM_FEATURE_GATES=""
 if [ "${K8S_MINOR}" -ge 35 ]; then
-  KUBEADM_FEATURE_GATES="DRAExtendedResource=true,DRAPartitionableDevices=true"
-  echo "K8s >= 1.35 (${RESOLVED_K8S_VERSION}): enabling DRAExtendedResource,DRAPartitionableDevices"
+  KUBEADM_FEATURE_GATES="DRAExtendedResource=true,DRAPartitionableDevices=true,DRAResourceClaimDeviceStatus=true"
+  echo "K8s >= 1.35 (${RESOLVED_K8S_VERSION}): enabling DRAExtendedResource,DRAPartitionableDevices,DRAResourceClaimDeviceStatus"
 fi
 
 # --- Compute git metadata before transfer ---

--- a/hack/ci/mock-nvml/e2e-test.sh
+++ b/hack/ci/mock-nvml/e2e-test.sh
@@ -256,8 +256,12 @@ KINDEOF
 
 # Inject additional feature gates for k8s 1.35+
 if [ -n "${FEATURE_GATES}" ]; then
-  # Add DRA-specific feature gates to the Kind config
-  sed -i '/DynamicResourceAllocation: true/a\  DRAExtendedResource: true\n  DRAPartitionableDevices: true' "${KIND_CONFIG}"
+  # Add DRA-specific feature gates to the Kind config.
+  # DRAResourceClaimDeviceStatus lets the driver publish per-device status
+  # (KEP-4817) into ResourceClaim.status.devices (test_gpu_device_status.bats).
+  # Known since 1.32, beta default-on since 1.33, so setting it explicitly is
+  # safe on all supported versions.
+  sed -i '/DynamicResourceAllocation: true/a\  DRAExtendedResource: true\n  DRAPartitionableDevices: true\n  DRAResourceClaimDeviceStatus: true' "${KIND_CONFIG}"
 fi
 if [ "${TEST_DRA_LIST_TYPE_ATTRIBUTES}" = "true" ]; then
   sed -i '/DynamicResourceAllocation: true/a\  DRAListTypeAttributes: true' "${KIND_CONFIG}"

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -103,6 +103,17 @@ const (
 	// via --consumable-shares. Note: MPS sharing is not supported when consumable
 	// shares is enabled.
 	ConsumableShares featuregate.Feature = "ConsumableShares"
+
+	// ResourceClaimDeviceStatus enables the kubelet plugin to publish
+	// per-device status (KEP-4817) into ResourceClaim.status.devices upon
+	// claim preparation: which physical GPU / MIG device a claim got (UUID,
+	// product name, driver version, MIG profile/parent). This gives a durable
+	// pod->device mapping that survives device removal from ResourceSlices.
+	// The cluster must have the Kubernetes feature gate
+	// DRAResourceClaimDeviceStatus enabled, and RBAC must allow the plugin to
+	// update resourceclaims/status (see the Helm chart, which grants this
+	// automatically when the gate is enabled via .Values.featureGates).
+	ResourceClaimDeviceStatus featuregate.Feature = "ResourceClaimDeviceStatus"
 )
 
 // Feature gate Version fields use driver SemVer major.minor.
@@ -199,6 +210,13 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 		},
 	},
 	ConsumableShares: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(0, 5),
+		},
+	},
+	ResourceClaimDeviceStatus: {
 		{
 			Default:    false,
 			PreRelease: featuregate.Alpha,

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -146,6 +146,7 @@ func TestDefaultFeatureGates(t *testing.T) {
 		// Test that real features have expected defaults
 		require.False(t, fg.Enabled(TimeSlicingSettings), "TimeSlicingSettings should be disabled by default (alpha)")
 		require.False(t, fg.Enabled(HostManagedIMEXDaemon), "HostManagedIMEXDaemon should be disabled by default (alpha)")
+		require.False(t, fg.Enabled(ResourceClaimDeviceStatus), "ResourceClaimDeviceStatus should be disabled by default (alpha)")
 	})
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,7 +1,7 @@
 # test/e2e
 
-End-to-end suite for `dra-driver-nvidia-gpu` using Go + Ginkgo v2. Covers eight
-DRA allocation scenarios driven by CEL selectors and embedded YAML templates.
+End-to-end suite for `dra-driver-nvidia-gpu` using Go + Ginkgo v2. Covers nine
+DRA scenarios driven by CEL selectors and embedded YAML templates.
 
 ## Coverage
 
@@ -15,6 +15,7 @@ DRA allocation scenarios driven by CEL selectors and embedded YAML templates.
 | 6 | `[negative]` | Unmatchable selector leaves the pod Pending with no allocation. |
 | 7 | `[consumable-shares/unlimited]` | Multiple pods share the same GPU concurrently with `--consumable-shares=unlimited`. |
 | 8 | `[consumable-shares/memory]` | Multiple pods with explicit fractional memory requests share the same GPU with `--consumable-shares=memory`. |
+| 9 | `[device-status]` | KEP-4817: `ResourceClaim.status.devices` is published on prepare (uuid matches the ResourceSlice), untouched by a second consumer, and pruned after the last consumer goes away. Skipped unless the driver runs with `featureGates.ResourceClaimDeviceStatus=true`. |
 
 The suite detects GPU product / driver / memory from the published
 `ResourceSlice` at `BeforeSuite`, so it adapts to whatever hardware the CI
@@ -46,6 +47,7 @@ test/e2e/
 ├── README.md
 ├── suite_test.go              # Ginkgo bootstrap + GPU detection
 ├── gpu_allocation_test.go     # 8 It() specs
+├── device_status_test.go      # [device-status] spec (KEP-4817)
 └── framework/
     ├── client.go              # k8s client factory
     ├── gpu.go                 # ResourceSlice -> GPUDetails
@@ -54,6 +56,7 @@ test/e2e/
     └── specs/                 # embedded YAML templates
         ├── consumable-shares-memory.yaml.tmpl
         ├── consumable-shares-unlimited.yaml.tmpl
+        ├── device-status.yaml.tmpl
         ├── driver-version.yaml.tmpl
         ├── error-handling.yaml.tmpl
         ├── memory-size.yaml.tmpl

--- a/test/e2e/device_status_test.go
+++ b/test/e2e/device_status_test.go
@@ -1,0 +1,181 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/test/e2e/framework"
+)
+
+const (
+	driverNamespace   = "dra-driver-nvidia-gpu"
+	kubeletPluginDS   = "dra-driver-nvidia-gpu-kubelet-plugin"
+	deviceStatusClaim = "device-status-claim"
+)
+
+// deviceStatusData mirrors the JSON payload the kubelet plugin publishes into
+// ResourceClaim.status.devices[].data (see cmd/gpu-kubelet-plugin/devicestatus.go).
+type deviceStatusData struct {
+	Type          string `json:"type"`
+	UUID          string `json:"uuid"`
+	ProductName   string `json:"productName"`
+	DriverVersion string `json:"driverVersion"`
+	PCIBusID      string `json:"pciBusID"`
+	MigProfile    string `json:"migProfile"`
+	ParentUUID    string `json:"parentUUID"`
+}
+
+// KEP-4817: the kubelet plugin publishes per-device status into
+// ResourceClaim.status.devices when the ResourceClaimDeviceStatus driver
+// feature gate is enabled.
+var _ = Describe("Device Status", func() {
+	var ns string
+
+	BeforeEach(func() {
+		ns = fmt.Sprintf("gpu-e2e-%d", time.Now().UnixNano()%1_000_000)
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		_ = cs.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+	})
+
+	It("[device-status] publishes, keeps and prunes ResourceClaim.status.devices across the claim lifecycle", func(ctx SpecContext) {
+		requireDeviceStatus(ctx)
+
+		// Prepare: one pod on a standalone claim.
+		yaml, err := framework.Render("device-status", map[string]any{"Namespace": ns, "PodName": "pod1"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(framework.ApplyYAML(ctx, yaml)).To(Succeed())
+
+		phase, err := framework.WaitForPodPhase(ctx, cs, ns, "pod1",
+			[]corev1.PodPhase{corev1.PodRunning, corev1.PodSucceeded}, 3*time.Minute)
+		Expect(err).NotTo(HaveOccurred(), "pod1 never reached Running/Succeeded (phase=%s)", phase)
+
+		claim := waitForDeviceStatus(ctx, ns, 1, 2*time.Minute)
+		Expect(claim.Status.Allocation).NotTo(BeNil())
+		Expect(claim.Status.Allocation.Devices.Results).To(HaveLen(1))
+		result := claim.Status.Allocation.Devices.Results[0]
+
+		status := claim.Status.Devices[0]
+		Expect(status.Driver).To(Equal("gpu.nvidia.com"))
+		Expect(status.Pool).To(Equal(result.Pool))
+		Expect(status.Device).To(Equal(result.Device))
+		Expect(status.Data).NotTo(BeNil(), "status.devices[0].data must be set")
+
+		var data deviceStatusData
+		Expect(json.Unmarshal(status.Data.Raw, &data)).To(Succeed())
+		Expect(data.Type).To(Equal("gpu"))
+		Expect(data.UUID).To(HavePrefix("GPU-"))
+		Expect(data.ProductName).To(Equal(gpu.ProductName))
+		Expect(data.DriverVersion).NotTo(BeEmpty())
+		Expect(data.PCIBusID).NotTo(BeEmpty())
+
+		// The payload must describe the very device that was allocated,
+		// as advertised in the ResourceSlice.
+		Expect(data.UUID).To(Equal(publishedUUID(ctx, result.Pool, result.Device)),
+			"status.devices[0].data.uuid must match the ResourceSlice uuid attribute of the allocated device")
+
+		// A second consumer of the same claim must not disturb the entry.
+		yaml, err = framework.Render("device-status", map[string]any{"Namespace": ns, "PodName": "pod2"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(framework.ApplyYAML(ctx, yaml)).To(Succeed())
+		phase, err = framework.WaitForPodPhase(ctx, cs, ns, "pod2",
+			[]corev1.PodPhase{corev1.PodRunning, corev1.PodSucceeded}, 3*time.Minute)
+		Expect(err).NotTo(HaveOccurred(), "pod2 never reached Running/Succeeded (phase=%s)", phase)
+
+		claim, err = cs.ResourceV1().ResourceClaims(ns).Get(ctx, deviceStatusClaim, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(claim.Status.Devices).To(HaveLen(1))
+		Expect(claim.Status.Devices[0].Data.Raw).To(MatchJSON(status.Data.Raw))
+
+		// Unprepare: once the last consumer is gone the entry is pruned,
+		// either by the plugin (Unprepare) or by the API server when the
+		// claim is deallocated.
+		Expect(cs.CoreV1().Pods(ns).DeleteCollection(ctx, metav1.DeleteOptions{},
+			metav1.ListOptions{LabelSelector: "app=device-status"})).To(Succeed())
+		Eventually(func(g Gomega) {
+			c, err := cs.ResourceV1().ResourceClaims(ns).Get(ctx, deviceStatusClaim, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(c.Status.Devices).To(BeEmpty(), "status.devices must be pruned after unprepare/deallocation")
+		}).WithContext(ctx).WithTimeout(3 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+	})
+})
+
+// requireDeviceStatus skips the spec unless the deployed kubelet plugin runs
+// with the ResourceClaimDeviceStatus driver feature gate enabled (as rendered
+// into the FEATURE_GATES env var by the Helm chart).
+func requireDeviceStatus(ctx context.Context) {
+	ds, err := cs.AppsV1().DaemonSets(driverNamespace).Get(ctx, kubeletPluginDS, metav1.GetOptions{})
+	if err != nil {
+		Skip(fmt.Sprintf("cannot inspect kubelet plugin DaemonSet %s/%s: %v", driverNamespace, kubeletPluginDS, err))
+	}
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.Name == "FEATURE_GATES" && strings.Contains(e.Value, "ResourceClaimDeviceStatus=true") {
+				return
+			}
+		}
+	}
+	Skip("ResourceClaimDeviceStatus feature is not enabled on the deployed cluster driver")
+}
+
+// waitForDeviceStatus polls until the claim carries at least n status.devices
+// entries owned by gpu.nvidia.com and returns the claim.
+func waitForDeviceStatus(ctx context.Context, ns string, n int, timeout time.Duration) *resourceapi.ResourceClaim {
+	var claim *resourceapi.ResourceClaim
+	Eventually(func(g Gomega) {
+		c, err := cs.ResourceV1().ResourceClaims(ns).Get(ctx, deviceStatusClaim, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		count := 0
+		for _, d := range c.Status.Devices {
+			if d.Driver == "gpu.nvidia.com" {
+				count++
+			}
+		}
+		g.Expect(count).To(BeNumerically(">=", n), "claim %s has %d gpu.nvidia.com status entries", c.Name, count)
+		claim = c
+	}).WithContext(ctx).WithTimeout(timeout).WithPolling(2 * time.Second).Should(Succeed())
+	return claim
+}
+
+// publishedUUID returns the uuid attribute of the named device in the
+// gpu.nvidia.com ResourceSlice for the given pool.
+func publishedUUID(ctx context.Context, pool, device string) string {
+	slices, err := cs.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	for _, s := range slices.Items {
+		if s.Spec.Driver != "gpu.nvidia.com" || s.Spec.Pool.Name != pool {
+			continue
+		}
+		for _, d := range s.Spec.Devices {
+			if d.Name != device {
+				continue
+			}
+			if attr, ok := d.Attributes["uuid"]; ok && attr.StringValue != nil {
+				return *attr.StringValue
+			}
+		}
+	}
+	Fail(fmt.Sprintf("device %s/%s not found in any gpu.nvidia.com ResourceSlice", pool, device))
+	return ""
+}

--- a/test/e2e/framework/specs/device-status.yaml.tmpl
+++ b/test/e2e/framework/specs/device-status.yaml.tmpl
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}
+---
+# A standalone (non-template) claim so it outlives its consumer pods and the
+# lifecycle of status.devices across prepare / unprepare can be observed.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: device-status-claim
+  namespace: {{ .Namespace }}
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        count: 1
+        deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: {{ .Namespace }}
+  name: {{ .PodName }}
+  labels:
+    app: device-status
+spec:
+  restartPolicy: Never
+  containers:
+  - name: ctr
+    image: ubuntu:22.04
+    command: ["bash","-c"]
+    args: ["trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: device-status-claim
+  tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -190,6 +190,7 @@ tests-mock-nvml: runner-image
 	$(call RUN_BATS, \
 		tests/bats/test_gpu_basic.bats \
 		tests/bats/test_gpu_cuda_workloads.bats \
+		tests/bats/test_gpu_device_status.bats \
 		tests/bats/test_gpu_sharing.bats \
 		tests/bats/test_gpu_robustness.bats \
 		tests/bats/test_gpu_extres.bats \
@@ -207,6 +208,7 @@ tests-gpu-single: runner-image
 	$(call RUN_BATS, \
 		tests/bats/test_gpu_basic.bats \
 		tests/bats/test_gpu_cuda_workloads.bats \
+		tests/bats/test_gpu_device_status.bats \
 		tests/bats/test_gpu_dynmig.bats \
 		tests/bats/test_gpu_sharing.bats \
 		tests/bats/test_gpu_robustness.bats \
@@ -218,6 +220,7 @@ tests-gpu-a10: runner-image
 	$(call RUN_BATS, \
 		tests/bats/test_gpu_basic.bats \
 		tests/bats/test_gpu_cuda_workloads.bats \
+		tests/bats/test_gpu_device_status.bats \
 		tests/bats/test_gpu_sharing.bats \
 		tests/bats/test_gpu_robustness.bats \
 		tests/bats/test_gpu_extres.bats)
@@ -232,6 +235,7 @@ tests-gpu: runner-image
 	$(call RUN_BATS, \
 		tests/bats/test_basics.bats \
 		tests/bats/test_gpu_basic.bats \
+		tests/bats/test_gpu_device_status.bats \
 		tests/bats/test_gpu_extres.bats \
 		tests/bats/test_gpu_dynmig.bats \
 		tests/bats/test_gpu_mig.bats \
@@ -255,6 +259,7 @@ tests: runner-image
 	$(call RUN_BATS, \
 		tests/bats/test_basics.bats \
 		tests/bats/test_gpu_basic.bats \
+		tests/bats/test_gpu_device_status.bats \
 		tests/bats/test_gpu_extres.bats \
 		tests/bats/test_gpu_stress.bats \
 		tests/bats/test_gpu_dynmig.bats \

--- a/tests/bats/specs/gpu-device-status-pod2.yaml
+++ b/tests/bats/specs/gpu-device-status-pod2.yaml
@@ -1,0 +1,22 @@
+# Second consumer of the shared rc-device-status claim (see
+# gpu-device-status.yaml). Applied after the first pod is running to verify
+# that a repeated (idempotent) prepare leaves ResourceClaim.status.devices
+# untouched.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-device-status-2
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: rc-device-status

--- a/tests/bats/specs/gpu-device-status.yaml
+++ b/tests/bats/specs/gpu-device-status.yaml
@@ -1,0 +1,35 @@
+# Standalone (non-template) claim for the KEP-4817 device status test.
+# The claim outlives its consumer pods so the lifecycle of
+# ResourceClaim.status.devices across prepare / unprepare can be observed.
+# Mirrors test/e2e/framework/specs/device-status.yaml.tmpl.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: rc-device-status
+  labels:
+    env: batssuite
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-device-status-1
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: rc-device-status

--- a/tests/bats/test_gpu_device_status.bats
+++ b/tests/bats/test_gpu_device_status.bats
@@ -1,0 +1,194 @@
+# shellcheck disable=SC2148
+# shellcheck disable=SC2329
+
+# Tests for KEP-4817 ResourceClaim device status publishing by the GPU
+# kubelet plugin: after a successful prepare the plugin writes one entry per
+# prepared device into ResourceClaim.status.devices, and removes its entries
+# on unprepare. Requires the ResourceClaimDeviceStatus driver feature gate
+# (enabled via setup_file below) and the cluster-side
+# DRAResourceClaimDeviceStatus gate (beta default-on since Kubernetes 1.33,
+# GA locked since 1.37). Works on any GPU type, including mock NVML: no CUDA
+# compute is required.
+
+setup_file() {
+  load 'helpers.sh'
+  _common_setup
+  local _iargs=("--set" "logVerbosity=6"
+    "--set" "featureGates.ResourceClaimDeviceStatus=true")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+}
+
+setup() {
+  load 'helpers.sh'
+  _common_setup
+  log_objects
+}
+
+bats::on_failure() {
+  echo -e "\n\nFAILURE HOOK START"
+  log_objects
+  show_kubelet_plugin_error_logs
+  show_gpu_plugin_log_tails
+  echo -e "FAILURE HOOK END\n\n"
+}
+
+# Skip unless the deployed kubelet plugin runs with the
+# ResourceClaimDeviceStatus driver feature gate enabled (rendered into the
+# FEATURE_GATES env var by the Helm chart).
+require_device_status_driver_gate() {
+  local gates
+  gates=$(kubectl get daemonset -n dra-driver-nvidia-gpu \
+    dra-driver-nvidia-gpu-kubelet-plugin -o json 2>/dev/null | \
+    jq -r '.spec.template.spec.containers[].env[]? | select(.name=="FEATURE_GATES") | .value')
+  if ! echo "${gates}" | grep -q "ResourceClaimDeviceStatus=true"; then
+    skip "ResourceClaimDeviceStatus driver feature gate is not enabled on the deployed driver"
+  fi
+}
+
+# Skip unless the API server serves the status.devices field (i.e. the
+# cluster-side DRAResourceClaimDeviceStatus gate is enabled).
+require_device_status_cluster_gate() {
+  if ! kubectl explain resourceclaim.status.devices >/dev/null 2>&1; then
+    skip "cluster does not expose resourceclaim.status.devices (DRAResourceClaimDeviceStatus not enabled)"
+  fi
+}
+
+# Skip when the plugin's status write was dropped by the API server, which
+# happens when the cluster-side DRAResourceClaimDeviceStatus gate is disabled
+# despite the field being served. The plugin logs a warning in that case (see
+# cmd/gpu-kubelet-plugin/devicestatus.go).
+skip_if_status_write_dropped() {
+  local pod
+  for pod in $(kubectl get pods -n dra-driver-nvidia-gpu \
+      -l dra-driver-nvidia-gpu-component=kubelet-plugin \
+      -o jsonpath='{.items[*].metadata.name}'); do
+    if kubectl logs -n dra-driver-nvidia-gpu "${pod}" -c gpus \
+        --tail=500 2>/dev/null | grep -q "were dropped by the API server"; then
+      skip "DRAResourceClaimDeviceStatus is not enabled on the API server (status write dropped)"
+    fi
+  done
+}
+
+# Poll up to $1 seconds for at least one gpu.nvidia.com entry in
+# .status.devices of claim $2. Emits the claim JSON to stdout on success.
+wait_for_device_status() {
+  local timeout="$1"
+  local claim="$2"
+  local start=$SECONDS
+  while (( SECONDS - start < timeout )); do
+    local count
+    count=$(kubectl get resourceclaim "${claim}" -o json 2>/dev/null | \
+      jq '[.status.devices[]? | select(.driver=="gpu.nvidia.com")] | length')
+    if [ -n "${count}" ] && [ "${count}" -ge 1 ]; then
+      kubectl get resourceclaim "${claim}" -o json
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+# Poll up to $1 seconds until .status.devices of claim $2 is empty.
+wait_for_device_status_pruned() {
+  local timeout="$1"
+  local claim="$2"
+  local start=$SECONDS
+  while (( SECONDS - start < timeout )); do
+    local count
+    count=$(kubectl get resourceclaim "${claim}" -o json 2>/dev/null | \
+      jq '.status.devices // [] | length')
+    if [ -n "${count}" ] && [ "${count}" -eq 0 ]; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+
+# bats test_tags=fastfeedback,device-status
+@test "GPUs: publish, keep and prune ResourceClaim.status.devices across the claim lifecycle" {
+  require_device_status_driver_gate
+  require_device_status_cluster_gate
+
+  local _claim="rc-device-status"
+  local _pod1="pod-device-status-1"
+  local _pod2="pod-device-status-2"
+
+  # Prepare: one pod on a standalone claim.
+  kubectl apply -f tests/bats/specs/gpu-device-status.yaml
+  kubectl wait --for=condition=READY pods "${_pod1}" --timeout=60s
+
+  local claim_json
+  if ! claim_json=$(wait_for_device_status 120 "${_claim}"); then
+    skip_if_status_write_dropped
+    echo "timed out waiting for status.devices on claim ${_claim}"
+    kubectl get resourceclaim "${_claim}" -o yaml
+    return 1
+  fi
+
+  # The entry must describe the allocated device ...
+  local pool device
+  pool=$(echo "${claim_json}" | jq -r '.status.allocation.devices.results[0].pool')
+  device=$(echo "${claim_json}" | jq -r '.status.allocation.devices.results[0].device')
+  [ -n "${pool}" ] && [ "${pool}" != "null" ] || fail "claim has no allocated pool"
+  [ -n "${device}" ] && [ "${device}" != "null" ] || fail "claim has no allocated device"
+
+  run jq -e --arg pool "${pool}" --arg device "${device}" \
+    '.status.devices[] | select(.driver=="gpu.nvidia.com" and .pool==$pool and .device==$device and .data != null)' <<<"${claim_json}"
+  assert_success
+
+  # ... with a full-GPU payload ...
+  local dtype uuid product_name driver_version pci_bus_id
+  dtype=$(echo "${claim_json}" | jq -r '[.status.devices[] | select(.driver=="gpu.nvidia.com")][0].data.type')
+  assert_equal "${dtype}" "gpu"
+
+  uuid=$(echo "${claim_json}" | jq -r '[.status.devices[] | select(.driver=="gpu.nvidia.com")][0].data.uuid')
+  [[ "${uuid}" == GPU-* ]] || fail "expected data.uuid with GPU- prefix, got: ${uuid}"
+
+  product_name=$(echo "${claim_json}" | jq -r '[.status.devices[] | select(.driver=="gpu.nvidia.com")][0].data.productName')
+  [ -n "${product_name}" ] && [ "${product_name}" != "null" ] || fail "data.productName is empty"
+
+  driver_version=$(echo "${claim_json}" | jq -r '[.status.devices[] | select(.driver=="gpu.nvidia.com")][0].data.driverVersion')
+  [ -n "${driver_version}" ] && [ "${driver_version}" != "null" ] || fail "data.driverVersion is empty"
+
+  pci_bus_id=$(echo "${claim_json}" | jq -r '[.status.devices[] | select(.driver=="gpu.nvidia.com")][0].data.pciBusID')
+  [ -n "${pci_bus_id}" ] && [ "${pci_bus_id}" != "null" ] || fail "data.pciBusID is empty"
+
+  # ... and the UUID must match the ResourceSlice attribute of the allocated
+  # device.
+  local slice_uuid
+  slice_uuid=$(kubectl get resourceslices.resource.k8s.io -o json | jq -r \
+    --arg pool "${pool}" --arg device "${device}" \
+    '[.items[] | select(.spec.driver=="gpu.nvidia.com" and .spec.pool.name==$pool) | .spec.devices[]? | select(.name==$device) | .attributes.uuid.string] | .[0]')
+  assert_equal "${uuid}" "${slice_uuid}"
+
+  # A second consumer of the same claim must not disturb the entry
+  # (idempotent prepare).
+  local before
+  before=$(echo "${claim_json}" | jq -c -S '.status.devices')
+
+  kubectl apply -f tests/bats/specs/gpu-device-status-pod2.yaml
+  kubectl wait --for=condition=READY pods "${_pod2}" --timeout=60s
+
+  local after
+  after=$(kubectl get resourceclaim "${_claim}" -o json | jq -c -S '.status.devices')
+  assert_equal "${after}" "${before}"
+
+  # Unprepare: once the last consumer is gone the entry is pruned, either by
+  # the plugin (Unprepare) or by the API server when the claim is deallocated.
+  kubectl delete pods "${_pod1}" "${_pod2}"
+  kubectl wait --for=delete pods "${_pod1}" --timeout=60s
+  kubectl wait --for=delete pods "${_pod2}" --timeout=60s
+  if ! wait_for_device_status_pruned 180 "${_claim}"; then
+    echo "status.devices was not pruned after unprepare/deallocation"
+    kubectl get resourceclaim "${_claim}" -o yaml
+    return 1
+  fi
+
+  # The pods are already gone; only the standalone claim is left.
+  kubectl delete resourceclaim "${_claim}"
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implements KEP-4817 device status reporting in the GPU kubelet plugin. After a successful prepare the plugin publishes per device status (`{type, uuid, productName, driverVersion, pciBusID}`, with MIG and VFIO variants) to `resourceclaim.status.devices`, and clears its own entries on unprepare. It is gated by the `ResourceClaimDeviceStatus` feature gate, which also gates the `resourceclaims/status` and `resourceclaims/driver` RBAC rules.

#### Which issue(s) this PR is related to:

KEP: kubernetes/enhancements#4817

#### Special notes for your reviewer:

**This is intentionally a draft, so please don't spend review time on it yet.**

It is part of an experiment in bringing the three DRA drivers (dra-example-driver, dra-driver-nvidia-gpu and dra-driver-google-tpu) closer to feature parity, along with a few bugs found along the way.

**How it was produced:** the implementation was written largely by autonomous coding agents working under my direction, one per feature, each in its own branch. I am not asking you to take that on trust, which is exactly why it opens as a draft.

**Verified so far, unattended:** gofmt, go vet, unit tests in a Linux container, and a run on kind built from v1.37.0-rc.0 using this repo's mock NVML path with a second real DRA driver installed alongside, so that multi driver claims are genuine. Verified there: status published with the uuid matching the ResourceSlice attribute and the write attributed to the plugin in managedFields, another driver's entries preserved across a further prepare, no redundant writes across repeated prepares, a plugin restart and a forced kubelet state replay, entries cleared on unprepare and pruned on deallocation, and RBAC present only when the gate is on, checked with SubjectAccessReviews. The e2e suite passes at 7 of 7 specs with 2 skipped for unrelated modes. An automated code review pass ran on top of this, and its findings were applied and retested.

**Not done yet:** my own reading of the full diff, and testing it again by hand under my supervision. That happens before this leaves draft, so no CI approval, `/ok-to-test`, or reviewer attention is needed until then.

I will drop the `WIP:` prefix and mark it ready for review only after that human pass.

Technical notes:

The MIG and VFIO payload variants are unit tested but not exercised end to end, since mock NVML reports MIG mode as unsupported. Those need MIG capable silicon and a GPU bindable to vfio-pci respectively.

The warning path for an API server that drops `status.devices` is unreachable on 1.37, where the gate is locked on, so it is covered by unit tests only.

The same feature for dra-driver-google-tpu is in https://github.com/kubernetes-sigs/dra-driver-google-tpu/pull/37, and the payload shape and semantics are kept aligned.

#### Does this PR introduce a user-facing change?

```release-note
The GPU kubelet plugin can publish per device status to ResourceClaims (KEP-4817) when the ResourceClaimDeviceStatus feature gate is enabled.
```

#### Additional documentation (design docs, usage docs, etc.):

```docs
NONE
```

#### Checklist

- [x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [x] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
