### PR TITLE
WIP: kubelet plugins: support seamless upgrades via SeamlessUpgrades feature gate

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/computedomain.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain.go
@@ -179,10 +179,21 @@ func (m *ComputeDomainManager) Stop() error {
 	m.waitGroup.Wait()
 
 	if m.config.flags.gpuCliqueLabelEnabled {
-		rmCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := m.RemoveGPUCliqueLabel(rmCtx); err != nil {
-			klog.Errorf("error removing %s node label: %v", gpuCliqueLabelKey, err)
+		if featuregates.Enabled(featuregates.SeamlessUpgrades) {
+			// During a seamless rolling update, the replacement plugin instance
+			// has typically already set the label by the time this (old)
+			// instance shuts down; removing it here would leave the node
+			// unlabeled until the next periodic refresh (up to
+			// gpuCliqueLabelRefreshInterval). Leave the label in place: on
+			// actual driver teardown it goes stale, which matches the
+			// pre-existing behavior for any non-graceful shutdown.
+			klog.Infof("SeamlessUpgrades enabled: leaving %s node label in place on shutdown", gpuCliqueLabelKey)
+		} else {
+			rmCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := m.RemoveGPUCliqueLabel(rmCtx); err != nil {
+				klog.Errorf("error removing %s node label: %v", gpuCliqueLabelKey, err)
+			}
 		}
 	}
 

--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -45,7 +47,11 @@ import (
 // never valid in that mode (see applyComputeDomainDaemonConfig).
 func computeDomainPublishedDevices(allocatable AllocatableDevices, hostManaged bool) []resourceapi.Device {
 	var devices []resourceapi.Device
-	for _, device := range allocatable {
+	// Iterate in a stable (sorted) order so that the published device order is
+	// deterministic across plugin processes (see the gpu plugin's
+	// publishResources for the rationale).
+	for _, name := range slices.Sorted(maps.Keys(allocatable)) {
+		device := allocatable[name]
 		if device.Type() == ComputeDomainChannelType && device.Channel.ID != 0 {
 			continue
 		}
@@ -101,9 +107,7 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		pulock: flock.NewFlock(puLockPath),
 	}
 
-	helper, err := kubeletplugin.Start(
-		ctx,
-		driver,
+	opts := []kubeletplugin.Option{
 		kubeletplugin.KubeClient(driver.client),
 		kubeletplugin.NodeName(config.flags.nodeName),
 		kubeletplugin.DriverName(DriverName),
@@ -116,7 +120,16 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.Serialize(false),
 		kubeletplugin.RegistrarDirectoryPath(config.flags.kubeletRegistrarDirectoryPath),
 		kubeletplugin.PluginDataDirectoryPath(config.DriverPluginPath()),
-	)
+	}
+	// With the SeamlessUpgrades feature gate enabled, derive unique (pod
+	// UID-suffixed) socket names so that an old and a new plugin instance can
+	// serve concurrently during a DaemonSet rolling update. Cross-instance
+	// serialization of prepare/unprepare is provided by the node-global
+	// file-based pu.lock; kubeletplugin.Serialize stays disabled.
+	if podUID := config.RollingUpdatePodUID(); podUID != "" {
+		opts = append(opts, kubeletplugin.RollingUpdate(types.UID(podUID)))
+	}
+	helper, err := kubeletplugin.Start(ctx, driver, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -159,20 +172,26 @@ func (d *driver) Shutdown() error {
 		return nil
 	}
 
+	var errs []error
 	if err := d.state.computeDomainManager.Stop(); err != nil {
-		return fmt.Errorf("error stopping ComputeDomainManager: %w", err)
+		errs = append(errs, fmt.Errorf("error stopping ComputeDomainManager: %w", err))
 	}
 
 	if err := d.state.checkpointCleanupManager.Stop(); err != nil {
-		return fmt.Errorf("error stopping CheckpointCleanupManager: %w", err)
+		errs = append(errs, fmt.Errorf("error stopping CheckpointCleanupManager: %w", err))
 	}
 
 	if d.healthcheck != nil {
 		d.healthcheck.Stop()
 	}
 
+	// Always stop the plugin helper, even if earlier shutdown steps failed: it
+	// removes this instance's registration and DRA sockets. With rolling
+	// updates enabled, socket names are unique per pod, and a socket leaked
+	// here can never be cleaned up by a later instance.
 	d.pluginhelper.Stop()
-	return nil
+
+	return errors.Join(errs...)
 }
 
 func (d *driver) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {

--- a/cmd/compute-domain-kubelet-plugin/health.go
+++ b/cmd/compute-domain-kubelet-plugin/health.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"path"
 	"strconv"
 	"sync"
 
@@ -33,6 +32,8 @@ import (
 	"k8s.io/klog/v2"
 	drapb "k8s.io/kubelet/pkg/apis/dra/v1beta1"
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/internal/common"
 )
 
 type healthcheck struct {
@@ -58,11 +59,11 @@ func setupHealthcheckPrimitives(ctx context.Context, config *Config) (*healthche
 		return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
 
+	rollingUpdatePodUID := config.RollingUpdatePodUID()
+
 	regSockPath := (&url.URL{
 		Scheme: "unix",
-		// TODO: this needs to adapt when seamless upgrades
-		// are enabled and the filename includes a uid.
-		Path: path.Join(config.flags.kubeletRegistrarDirectoryPath, DriverName+"-reg.sock"),
+		Path:   common.RegistrarSocketPath(config.flags.kubeletRegistrarDirectoryPath, DriverName, rollingUpdatePodUID),
 	}).String()
 
 	klog.V(6).Infof("Connect to registration socket at %s", regSockPath)
@@ -76,7 +77,7 @@ func setupHealthcheckPrimitives(ctx context.Context, config *Config) (*healthche
 
 	draSockPath := (&url.URL{
 		Scheme: "unix",
-		Path:   path.Join(config.DriverPluginPath(), "dra.sock"),
+		Path:   common.DRASocketPath(config.DriverPluginPath(), rollingUpdatePodUID),
 	}).String()
 
 	klog.V(6).Infof("Connect to plugin socket at %s", draSockPath)

--- a/cmd/compute-domain-kubelet-plugin/main.go
+++ b/cmd/compute-domain-kubelet-plugin/main.go
@@ -65,6 +65,7 @@ type Flags struct {
 	nvidiaCDIHookPath             string
 	kubeletRegistrarDirectoryPath string
 	kubeletPluginsDirectoryPath   string
+	podUID                        string
 	healthcheckPort               int
 	klogVerbosity                 int
 	gpuCliqueLabelEnabled         bool
@@ -81,6 +82,16 @@ type Config struct {
 
 func (c Config) DriverPluginPath() string {
 	return filepath.Join(c.flags.kubeletPluginsDirectoryPath, DriverName)
+}
+
+// RollingUpdatePodUID returns the pod UID to use for deriving unique
+// (rolling-update-compatible) socket names, or the empty string when seamless
+// upgrades are disabled.
+func (c Config) RollingUpdatePodUID() string {
+	if featuregates.Enabled(featuregates.SeamlessUpgrades) {
+		return c.flags.podUID
+	}
+	return ""
 }
 
 func main() {
@@ -165,6 +176,12 @@ func newApp() *cli.App {
 			Destination: &flags.kubeletPluginsDirectoryPath,
 			EnvVars:     []string{"KUBELET_PLUGINS_DIRECTORY_PATH"},
 		},
+		&cli.StringFlag{
+			Name:        "pod-uid",
+			Usage:       "The UID of this plugin pod. Used to derive unique socket names for seamless upgrades (SeamlessUpgrades feature gate).",
+			Destination: &flags.podUID,
+			EnvVars:     []string{"POD_UID"},
+		},
 		&cli.IntFlag{
 			Name:        "healthcheck-port",
 			Usage:       "Port to start a gRPC healthcheck service. When positive, a literal port number. When zero, a random port is allocated. When negative, the healthcheck service is disabled.",
@@ -229,6 +246,10 @@ func newApp() *cli.App {
 			// Validate feature gate dependencies
 			if err := featuregates.ValidateFeatureGates(); err != nil {
 				return fmt.Errorf("feature gate validation failed: %w", err)
+			}
+
+			if featuregates.Enabled(featuregates.SeamlessUpgrades) && flags.podUID == "" {
+				return fmt.Errorf("feature gate %s requires the pod UID to be set via --pod-uid / POD_UID", featuregates.SeamlessUpgrades)
 			}
 
 			imexConfig := imex.Config{Mode: imex.Mode(flags.imexMode), Isolation: imex.Isolation(flags.imexIsolation)}
@@ -350,7 +371,10 @@ func (c Config) setNvidiaCDIHookPath() error {
 		return fmt.Errorf("error reading nvidia-cdi-hook: %w", err)
 	}
 
-	if err := os.WriteFile(targetPath, input, 0755); err != nil {
+	// Write atomically: the target path is in a shared, node-global directory
+	// and another plugin instance (e.g. during a rolling update) may
+	// concurrently execute or rewrite the binary.
+	if err := common.AtomicWriteFile(targetPath, input, 0755); err != nil {
 		return fmt.Errorf("error copying nvidia-cdi-hook: %w", err)
 	}
 

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -75,6 +75,9 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		return nil, err
 	}
 
+	puLockPath := filepath.Join(config.DriverPluginPath(), DriverPrepUprepFlockFileName)
+	pulock := flock.NewFlock(puLockPath)
+
 	useSplitSlices := false
 
 	if featuregates.Enabled(featuregates.DynamicMIG) {
@@ -109,7 +112,27 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 			// completely prepared claims can stay; assuming that the central
 			// scheduler state is equivalent. TODO: review if this logic is correct;
 			// or if it potentially is too invasive for certain edge cases.
-			state.DestroyUnknownMIGDevices(ctx)
+			//
+			// Hold the node-global prepare/unprepare lock during the teardown:
+			// another plugin instance may be running on this node (e.g., during a
+			// rolling update with maxSurge) and must not be mid-Prepare() while we
+			// decide which incarnated MIG devices are unaccounted for -- a MIG
+			// device created after our checkpoint read would otherwise be
+			// mistaken for stale and destroyed.
+			//
+			// This cleanup has always been best-effort: if the lock cannot be
+			// acquired (e.g., another instance is stuck holding it), skip the
+			// teardown instead of failing startup -- skipping is strictly safer
+			// than tearing down MIG devices without the lock. Note that while we
+			// hold the lock, prepare/unprepare calls served by a concurrently
+			// running instance can transiently time out (10 s acquire timeout);
+			// the kubelet retries those.
+			if release, err := pulock.Acquire(ctx, flock.WithTimeout(60*time.Second)); err != nil {
+				klog.Errorf("Skipping unknown MIG device cleanup: error acquiring prep/unprep lock: %v", err)
+			} else {
+				state.DestroyUnknownMIGDevices(ctx)
+				release()
+			}
 
 			// Read Kubernetes API server version to determine which ResourceSlice
 			// model to use.
@@ -121,12 +144,10 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		}
 	}
 
-	puLockPath := filepath.Join(config.DriverPluginPath(), DriverPrepUprepFlockFileName)
-
 	driver := &driver{
 		client:                 config.clientsets.Core,
 		state:                  state,
-		pulock:                 flock.NewFlock(puLockPath),
+		pulock:                 pulock,
 		useSplitResourceSlices: useSplitSlices,
 	}
 
@@ -137,6 +158,14 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.Serialize(false),
 		kubeletplugin.RegistrarDirectoryPath(config.flags.kubeletRegistrarDirectoryPath),
 		kubeletplugin.PluginDataDirectoryPath(config.DriverPluginPath()),
+	}
+	// With the SeamlessUpgrades feature gate enabled, derive unique (pod
+	// UID-suffixed) socket names so that an old and a new plugin instance can
+	// serve concurrently during a DaemonSet rolling update. Cross-instance
+	// serialization of prepare/unprepare is provided by the node-global
+	// file-based pu.lock (see above); kubeletplugin.Serialize stays disabled.
+	if podUID := config.RollingUpdatePodUID(); podUID != "" {
+		opts = append(opts, kubeletplugin.RollingUpdate(types.UID(podUID)))
 	}
 	// KEP-5304: Enable Device Metadata support for the kubelet plugin implementation.
 	// See: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5304-dra-attributes-downward-api
@@ -337,11 +366,17 @@ func (d *driver) Shutdown() error {
 
 	d.wg.Wait()
 
-	if err := d.state.checkpointCleanupManager.Stop(); err != nil {
-		return fmt.Errorf("error stopping CheckpointCleanupManager: %w", err)
-	}
+	cleanupErr := d.state.checkpointCleanupManager.Stop()
 
+	// Always stop the plugin helper, even if earlier shutdown steps failed: it
+	// removes this instance's registration and DRA sockets. With rolling
+	// updates enabled, socket names are unique per pod, and a socket leaked
+	// here can never be cleaned up by a later instance.
 	d.pluginhelper.Stop()
+
+	if cleanupErr != nil {
+		return fmt.Errorf("error stopping CheckpointCleanupManager: %w", cleanupErr)
+	}
 	return nil
 }
 
@@ -485,10 +520,17 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 		return nil
 	}
 
-	// Enumerate the set of GPU, MIG and VFIO devices and publish them
+	// Enumerate the set of GPU, MIG and VFIO devices and publish them.
+	// Iterate in a stable (sorted) order: the published device order must be
+	// deterministic across plugin processes, otherwise every (re)start -- and,
+	// during a rolling update, every one of the two concurrently running
+	// instances -- rewrites the ResourceSlice with the same devices in a
+	// different order, causing needless API churn.
 	var resourceSlice resourceslice.Slice
-	for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
-		for _, device := range devices {
+	for _, pciBusID := range slices.Sorted(maps.Keys(d.state.perGPUAllocatable.allocatablesMap)) {
+		devices := d.state.perGPUAllocatable.allocatablesMap[pciBusID]
+		for _, devname := range slices.Sorted(maps.Keys(devices)) {
+			device := devices[devname]
 			klog.V(4).Infof("About to announce device %s", device.GetDevice(config).Name)
 			resourceSlice.Devices = append(resourceSlice.Devices, device.GetDevice(config))
 		}
@@ -535,8 +577,10 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
 			}
 
 			var resourceSlice resourceslice.Slice
-			for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
-				for _, dev := range devices {
+			for _, pciBusID := range slices.Sorted(maps.Keys(d.state.perGPUAllocatable.allocatablesMap)) {
+				devices := d.state.perGPUAllocatable.allocatablesMap[pciBusID]
+				for _, devname := range slices.Sorted(maps.Keys(devices)) {
+					dev := devices[devname]
 					d := dev.GetDevice(d.state.config)
 
 					taints := dev.Taints()

--- a/cmd/gpu-kubelet-plugin/health.go
+++ b/cmd/gpu-kubelet-plugin/health.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"path"
 	"strconv"
 	"sync"
 
@@ -34,6 +33,8 @@ import (
 	"k8s.io/klog/v2"
 	drapb "k8s.io/kubelet/pkg/apis/dra/v1beta1"
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/internal/common"
 )
 
 type healthcheck struct {
@@ -60,11 +61,11 @@ func startHealthcheck(ctx context.Context, config *Config, helper *kubeletplugin
 		return nil, fmt.Errorf("failed to listen for healthcheck service at %s: %w", addr, err)
 	}
 
+	rollingUpdatePodUID := config.RollingUpdatePodUID()
+
 	regSockPath := (&url.URL{
 		Scheme: "unix",
-		// TODO: this needs to adapt when seamless upgrades
-		// are enabled and the filename includes a uid.
-		Path: path.Join(config.flags.kubeletRegistrarDirectoryPath, DriverName+"-reg.sock"),
+		Path:   common.RegistrarSocketPath(config.flags.kubeletRegistrarDirectoryPath, DriverName, rollingUpdatePodUID),
 	}).String()
 	klog.V(6).Infof("connecting to registration socket path=%s", regSockPath)
 	regConn, err := grpc.NewClient(
@@ -77,7 +78,7 @@ func startHealthcheck(ctx context.Context, config *Config, helper *kubeletplugin
 
 	draSockPath := (&url.URL{
 		Scheme: "unix",
-		Path:   path.Join(config.DriverPluginPath(), "dra.sock"),
+		Path:   common.DRASocketPath(config.DriverPluginPath(), rollingUpdatePodUID),
 	}).String()
 	klog.V(6).Infof("connecting to DRA socket path=%s", draSockPath)
 	draConn, err := grpc.NewClient(

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -64,6 +64,7 @@ type Flags struct {
 	serviceAccountName            string
 	kubeletRegistrarDirectoryPath string
 	kubeletPluginsDirectoryPath   string
+	podUID                        string
 	healthcheckPort               int
 	klogVerbosity                 int
 	additionalXidsToIgnore        string
@@ -79,6 +80,16 @@ type Config struct {
 
 func (c Config) DriverPluginPath() string {
 	return filepath.Join(c.flags.kubeletPluginsDirectoryPath, DriverName)
+}
+
+// RollingUpdatePodUID returns the pod UID to use for deriving unique
+// (rolling-update-compatible) socket names, or the empty string when seamless
+// upgrades are disabled.
+func (c Config) RollingUpdatePodUID() string {
+	if featuregates.Enabled(featuregates.SeamlessUpgrades) {
+		return c.flags.podUID
+	}
+	return ""
 }
 
 func main() {
@@ -181,6 +192,12 @@ func newApp() *cli.App {
 			Value:       kubeletplugin.KubeletPluginsDir,
 			Destination: &flags.kubeletPluginsDirectoryPath,
 			EnvVars:     []string{"KUBELET_PLUGINS_DIRECTORY_PATH"},
+		},
+		&cli.StringFlag{
+			Name:        "pod-uid",
+			Usage:       "The UID of this plugin pod. Used to derive unique socket names for seamless upgrades (SeamlessUpgrades feature gate).",
+			Destination: &flags.podUID,
+			EnvVars:     []string{"POD_UID"},
 		},
 		&cli.IntFlag{
 			Name:        "healthcheck-port",
@@ -303,6 +320,10 @@ func validateCLIFlags(flags *Flags) error {
 		}
 	}
 
+	if featuregates.Enabled(featuregates.SeamlessUpgrades) && flags.podUID == "" {
+		return fmt.Errorf("feature gate %s requires the pod UID to be set via --pod-uid / POD_UID", featuregates.SeamlessUpgrades)
+	}
+
 	if flags.consumableShares != "disabled" && !featuregates.Enabled(featuregates.ConsumableShares) {
 		return fmt.Errorf("--consumable-shares requires feature gate %s to be enabled", featuregates.ConsumableShares)
 	}
@@ -398,7 +419,10 @@ func (c Config) setNvidiaCDIHookPath() error {
 		return fmt.Errorf("error reading nvidia-cdi-hook: %w", err)
 	}
 
-	if err := os.WriteFile(targetPath, input, 0755); err != nil {
+	// Write atomically: the target path is in a shared, node-global directory
+	// and another plugin instance (e.g. during a rolling update) may
+	// concurrently execute or rewrite the binary.
+	if err := common.AtomicWriteFile(targetPath, input, 0755); err != nil {
 		return fmt.Errorf("error copying nvidia-cdi-hook: %w", err)
 	}
 

--- a/cmd/gpu-kubelet-plugin/main_test.go
+++ b/cmd/gpu-kubelet-plugin/main_test.go
@@ -100,3 +100,62 @@ func TestValidateCLIFlagsConsumableShares(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCLIFlagsSeamlessUpgrades(t *testing.T) {
+	tests := []struct {
+		name        string
+		featureGate bool
+		podUID      string
+		expectErr   bool
+	}{
+		{
+			name:        "feature gate enabled with pod UID succeeds",
+			featureGate: true,
+			podUID:      "08a5f01c-b566-45ea-abb9-6522b1bcbc22",
+			expectErr:   false,
+		},
+		{
+			name:        "feature gate enabled without pod UID fails",
+			featureGate: true,
+			podUID:      "",
+			expectErr:   true,
+		},
+		{
+			name:        "feature gate disabled without pod UID succeeds",
+			featureGate: false,
+			podUID:      "",
+			expectErr:   false,
+		},
+		{
+			name:        "feature gate disabled with pod UID succeeds",
+			featureGate: false,
+			podUID:      "08a5f01c-b566-45ea-abb9-6522b1bcbc22",
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+				string(featuregates.SeamlessUpgrades): tc.featureGate,
+			}))
+			t.Cleanup(func() {
+				require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+					string(featuregates.SeamlessUpgrades): false,
+				}))
+			})
+
+			flags := &Flags{
+				consumableShares: "disabled",
+				podUID:           tc.podUID,
+			}
+
+			err := validateCLIFlags(flags)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -162,6 +162,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # POD_UID is used to derive unique socket names so that two plugin
+        # instances can run concurrently during a rolling update (only acted
+        # upon with the SeamlessUpgrades feature gate enabled).
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         {{- if .Values.nvidiaCDIHookPath }}
         - name: NVIDIA_CDI_HOOK_PATH
           value: "{{ .Values.nvidiaCDIHookPath }}"
@@ -287,6 +294,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # POD_UID is used to derive unique socket names so that two plugin
+        # instances can run concurrently during a rolling update (only acted
+        # upon with the SeamlessUpgrades feature gate enabled).
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: SERVICE_ACCOUNT_NAME
           valueFrom:
             fieldRef:

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/validation.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/validation.yaml
@@ -128,3 +128,20 @@
 {{- $error = printf "%s\nPlease ensure your cluster supports Dynamic Resource Allocation (DRA) with one of these API versions." $error }}
 {{- fail $error }}
 {{- end }}
+
+{{- with .Values.kubeletPlugin.updateStrategy }}
+{{- with .rollingUpdate }}
+{{- $maxSurge := "0" }}
+{{- if hasKey . "maxSurge" }}{{- $maxSurge = toString .maxSurge }}{{- end }}
+{{- $maxUnavailable := "100%" }}
+{{- if hasKey . "maxUnavailable" }}{{- $maxUnavailable = toString .maxUnavailable }}{{- end }}
+{{- if and (ne $maxSurge "0") (and (ne $maxUnavailable "0") (ne $maxUnavailable "0%")) }}
+{{- $error := "" }}
+{{- $error = printf "%s\nInvalid kubeletPlugin.updateStrategy: maxSurge is set to %s but maxUnavailable is %s." $error $maxSurge $maxUnavailable }}
+{{- $error = printf "%s\nThe Kubernetes API server rejects a DaemonSet with maxSurge and a non-zero maxUnavailable." $error }}
+{{- $error = printf "%s\nSet kubeletPlugin.updateStrategy.rollingUpdate.maxUnavailable=0 together with maxSurge" $error }}
+{{- $error = printf "%s\n(the chart default for maxUnavailable is \"100%%\", which Helm merges with a partial override)." $error }}
+{{- fail $error }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -280,6 +280,24 @@ kubeletPlugin:
     computeDomainHttpEndpoint: ":8081"
     metricsPath: "/metrics"
   priorityClassName: "system-node-critical"
+  # For seamless (zero-downtime) upgrades, enable the SeamlessUpgrades feature
+  # gate (featureGates.SeamlessUpgrades=true) and use a surge-based update
+  # strategy so that the new plugin instance starts before the old one stops:
+  #
+  #   updateStrategy:
+  #     type: RollingUpdate
+  #     rollingUpdate:
+  #       maxSurge: 1
+  #       maxUnavailable: 0
+  #
+  # IMPORTANT: maxUnavailable must be explicitly set to 0 together with
+  # maxSurge. Setting only maxSurge (e.g. via a single --set flag) merges with
+  # the default maxUnavailable of "100%" below, and the Kubernetes API server
+  # rejects a DaemonSet with maxSurge and a non-zero maxUnavailable.
+  #
+  # This requires a kubelet with support for multiple registrations of the
+  # same DRA driver (Kubernetes >= 1.33). See:
+  # https://pkg.go.dev/k8s.io/dynamic-resource-allocation/kubeletplugin#RollingUpdate
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/internal/common/upgrade.go
+++ b/internal/common/upgrade.go
@@ -1,0 +1,97 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+)
+
+// RegistrarSocketPath returns the path of the registration socket that the
+// kubelet plugin helper listens on. With a non-empty rolling update pod UID,
+// that is a UID-suffixed socket name unique to one plugin instance (see
+// [kubeletplugin.RollingUpdateRegistrarSocketFile]); otherwise the plain
+// per-driver socket name.
+func RegistrarSocketPath(registrarDir, driverName, rollingUpdatePodUID string) string {
+	if rollingUpdatePodUID != "" {
+		return path.Join(registrarDir, kubeletplugin.RollingUpdateRegistrarSocketFile(registrarDir, driverName, types.UID(rollingUpdatePodUID)))
+	}
+	return path.Join(registrarDir, driverName+"-reg.sock")
+}
+
+// DRASocketPath returns the path of the DRA gRPC socket that the kubelet
+// plugin helper listens on. The library does not export its naming logic for
+// this socket (and documents [kubeletplugin.PluginSocket] as test-only), so
+// this mirrors the name construction in [kubeletplugin.Start]: "dra.sock",
+// or "dra-<pod UID>.sock" when rolling updates are enabled. Keep in sync
+// with the vendored k8s.io/dynamic-resource-allocation/kubeletplugin.
+func DRASocketPath(pluginDir, rollingUpdatePodUID string) string {
+	if rollingUpdatePodUID != "" {
+		return path.Join(pluginDir, "dra-"+rollingUpdatePodUID+".sock")
+	}
+	return path.Join(pluginDir, "dra.sock")
+}
+
+// AtomicWriteFile writes data to a temporary file in the target's directory
+// and renames it into place, fsyncing both the file and the directory. Use
+// this for files in directories shared with other processes (e.g. another
+// plugin instance during a rolling update): the target path is never observed
+// in a truncated or partially written state, and a crash mid-write cannot
+// leave a corrupt file at the target path.
+func AtomicWriteFile(targetPath string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(targetPath)
+
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(targetPath)+".tmp*")
+	if err != nil {
+		return fmt.Errorf("error creating temporary file for %s: %w", targetPath, err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("error writing %s: %w", tmpFile.Name(), err)
+	}
+	if err := tmpFile.Chmod(mode); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("error setting permissions on %s: %w", tmpFile.Name(), err)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("error syncing %s: %w", tmpFile.Name(), err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("error closing %s: %w", tmpFile.Name(), err)
+	}
+
+	if err := os.Rename(tmpFile.Name(), targetPath); err != nil {
+		return fmt.Errorf("error renaming %s to %s: %w", tmpFile.Name(), targetPath, err)
+	}
+
+	// Fsync the directory so the rename itself survives a crash. Best-effort:
+	// a failure here does not undo an otherwise successful write.
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+
+	return nil
+}

--- a/internal/common/upgrade_test.go
+++ b/internal/common/upgrade_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistrarSocketPath(t *testing.T) {
+	registrarDir := "/var/lib/kubelet/plugins_registry"
+	uid := "08a5f01c-b566-45ea-abb9-6522b1bcbc22"
+
+	t.Run("without rolling update pod UID", func(t *testing.T) {
+		require.Equal(t,
+			"/var/lib/kubelet/plugins_registry/gpu.nvidia.com-reg.sock",
+			RegistrarSocketPath(registrarDir, "gpu.nvidia.com", ""),
+		)
+		require.Equal(t,
+			"/var/lib/kubelet/plugins_registry/compute-domain.nvidia.com-reg.sock",
+			RegistrarSocketPath(registrarDir, "compute-domain.nvidia.com", ""),
+		)
+	})
+
+	t.Run("with rolling update pod UID", func(t *testing.T) {
+		require.Equal(t,
+			"/var/lib/kubelet/plugins_registry/gpu.nvidia.com-08a5f01c-b566-45ea-abb9-6522b1bcbc22-reg.sock",
+			RegistrarSocketPath(registrarDir, "gpu.nvidia.com", uid),
+		)
+		require.Equal(t,
+			"/var/lib/kubelet/plugins_registry/compute-domain.nvidia.com-08a5f01c-b566-45ea-abb9-6522b1bcbc22-reg.sock",
+			RegistrarSocketPath(registrarDir, "compute-domain.nvidia.com", uid),
+		)
+	})
+}
+
+func TestDRASocketPath(t *testing.T) {
+	uid := "08a5f01c-b566-45ea-abb9-6522b1bcbc22"
+
+	t.Run("without rolling update pod UID", func(t *testing.T) {
+		require.Equal(t,
+			"/var/lib/kubelet/plugins/gpu.nvidia.com/dra.sock",
+			DRASocketPath("/var/lib/kubelet/plugins/gpu.nvidia.com", ""),
+		)
+	})
+
+	t.Run("with rolling update pod UID", func(t *testing.T) {
+		require.Equal(t,
+			"/var/lib/kubelet/plugins/gpu.nvidia.com/dra-08a5f01c-b566-45ea-abb9-6522b1bcbc22.sock",
+			DRASocketPath("/var/lib/kubelet/plugins/gpu.nvidia.com", uid),
+		)
+	})
+}
+
+func TestAtomicWriteFile(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "binary")
+
+	require.NoError(t, AtomicWriteFile(target, []byte("v1"), 0755))
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "v1", string(content))
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0755), info.Mode().Perm())
+
+	// Overwriting an existing target must succeed and leave no temp files.
+	require.NoError(t, AtomicWriteFile(target, []byte("v2"), 0755))
+	content, err = os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "v2", string(content))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+}

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -103,6 +103,15 @@ const (
 	// via --consumable-shares. Note: MPS sharing is not supported when consumable
 	// shares is enabled.
 	ConsumableShares featuregate.Feature = "ConsumableShares"
+
+	// SeamlessUpgrades enables rolling-update support in the kubelet plugins:
+	// each plugin instance derives unique (pod UID-suffixed) registration and
+	// DRA socket names so that an old and a new plugin instance can run
+	// concurrently on a node during a DaemonSet rolling update with maxSurge
+	// (no time window without a registered driver). Requires the pod UID to be
+	// passed via --pod-uid / POD_UID (downward API) and a kubelet with support
+	// for multiple registrations of the same driver (Kubernetes >= 1.33).
+	SeamlessUpgrades featuregate.Feature = "SeamlessUpgrades"
 )
 
 // Feature gate Version fields use driver SemVer major.minor.
@@ -205,6 +214,13 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 			Version:    version.MajorMinor(0, 5),
 		},
 	},
+	SeamlessUpgrades: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(0, 5),
+		},
+	},
 }
 
 var (
@@ -273,6 +289,21 @@ func ValidateFeatureGates() error {
 
 	if Enabled(DeviceMetadata) && !Enabled(PassthroughSupport) {
 		return fmt.Errorf("feature gate %s requires %s to also be enabled", DeviceMetadata, PassthroughSupport)
+	}
+
+	// SeamlessUpgrades allows two plugin instances to run (and hence publish
+	// ResourceSlices) concurrently during a rolling update. That is only safe
+	// when both instances derive identical slice content. NVMLDeviceHealthCheck
+	// (device taints) and PassthroughSupport (sibling-device removal on
+	// prepare/unprepare) publish from instance-local in-memory state that is
+	// not shared via the checkpoint, so the two publishers would overwrite
+	// each other's slices for the duration of the overlap.
+	if Enabled(SeamlessUpgrades) && Enabled(NVMLDeviceHealthCheck) {
+		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", SeamlessUpgrades, NVMLDeviceHealthCheck)
+	}
+
+	if Enabled(SeamlessUpgrades) && Enabled(PassthroughSupport) {
+		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", SeamlessUpgrades, PassthroughSupport)
 	}
 
 	return nil

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -522,6 +522,32 @@ func TestValidateFeatureGates(t *testing.T) {
 			expectError: false,
 			description: "should be valid when both FabricManagerPartitioning and PassthroughSupport are enabled",
 		},
+		{
+			name:         "SeamlessUpgrades enabled with NVMLDeviceHealthCheck",
+			fgMap:        map[featuregate.Feature]bool{SeamlessUpgrades: true, NVMLDeviceHealthCheck: true},
+			expectError:  true,
+			errorMessage: "feature gate SeamlessUpgrades is currently mutually exclusive with NVMLDeviceHealthCheck",
+			description:  "should fail when both SeamlessUpgrades and NVMLDeviceHealthCheck are enabled",
+		},
+		{
+			name:         "SeamlessUpgrades enabled with PassthroughSupport",
+			fgMap:        map[featuregate.Feature]bool{SeamlessUpgrades: true, PassthroughSupport: true},
+			expectError:  true,
+			errorMessage: "feature gate SeamlessUpgrades is currently mutually exclusive with PassthroughSupport",
+			description:  "should fail when both SeamlessUpgrades and PassthroughSupport are enabled",
+		},
+		{
+			name:        "Only SeamlessUpgrades enabled",
+			fgMap:       map[featuregate.Feature]bool{SeamlessUpgrades: true, NVMLDeviceHealthCheck: false, PassthroughSupport: false},
+			expectError: false,
+			description: "should be valid when only SeamlessUpgrades is enabled",
+		},
+		{
+			name:        "SeamlessUpgrades enabled with DynamicMIG",
+			fgMap:       map[featuregate.Feature]bool{SeamlessUpgrades: true, DynamicMIG: true},
+			expectError: false,
+			description: "should be valid when SeamlessUpgrades and DynamicMIG are both enabled",
+		},
 	}
 
 	for _, tt := range tests {

--- a/site/content/docs/reference/feature-gates.md
+++ b/site/content/docs/reference/feature-gates.md
@@ -40,6 +40,7 @@ helm install dra-driver-nvidia-gpu oci://registry.k8s.io/dra-driver-nvidia/chart
 | `CrashOnNVLinkFabricErrors` | Beta | `true` | Causes the kubelet plugin to crash rather than fall back to non-fabric mode when NVLink fabric errors are detected. |
 | `DeviceMetadata` | Alpha | `false` | Enables IOMMU API device exposure (`/dev/iommu` or `/dev/vfio/vfio`) for VFIO workloads via `VfioDeviceConfig`. Requires `PassthroughSupport`. |
 | `FabricManagerPartitioning` | Alpha | `false` | Enables Fabric Manager (NVSwitch) partition management in single-node NVL systems for full-GPU (`gpu.nvidia.com`) devices and Passthrough VFIO devices. Requires Fabric Manager running with `FABRIC_MODE=1`. When combined with `PassthroughSupport`, both device types are partitioned; otherwise only full-GPU devices. **Prepare requires the allocated physical-GPU set to match an FM partition exactly**; non-matching claims (including ordinary multi-GPU full-GPU workloads without a `matchAttribute` on `gpu.nvidia.com/partitionN`) fail Prepare. Do not enable on nodes that still run unconstrained full-GPU claims. |
+| `SeamlessUpgrades` | Alpha | `false` | Enables seamless (zero-downtime) rolling updates of the kubelet plugin DaemonSet: each plugin instance derives unique, pod-UID-suffixed kubelet registration and DRA socket names, so that an old and a new instance can serve concurrently during a surge-based rolling update. Use together with a `kubeletPlugin.updateStrategy` of `maxSurge: 1`, `maxUnavailable: 0` (both must be set: partially overriding only `maxSurge` merges with the default `maxUnavailable: "100%"` and is rejected). Requires a kubelet with support for multiple registrations of the same DRA driver (Kubernetes v1.33 and later). |
 
 ## Constraints
 
@@ -52,6 +53,8 @@ The following feature gate combinations are mutually exclusive and cannot be ena
 | `DynamicMIG` + `MPSSupport` | Mutually exclusive |
 | `PassthroughSupport` + `NVMLDeviceHealthCheck` | Mutually exclusive |
 | `MPSSupport` + `NVMLDeviceHealthCheck` | Mutually exclusive |
+| `SeamlessUpgrades` + `NVMLDeviceHealthCheck` | Mutually exclusive: device taints are instance-local in-memory state, and two concurrently publishing plugin instances would overwrite each other's ResourceSlices |
+| `SeamlessUpgrades` + `PassthroughSupport` | Mutually exclusive: sibling-device removal on prepare/unprepare is instance-local in-memory state, and two concurrently publishing plugin instances would overwrite each other's ResourceSlices |
 
 The feature gates below have the following dependencies:
 

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -195,6 +195,7 @@ tests-mock-nvml: runner-image
 		tests/bats/test_gpu_extres.bats \
 		tests/bats/test_gpu_stress.bats \
 		tests/bats/test_gpu_updowngrade.bats \
+		tests/bats/test_gpu_seamless_upgrades.bats \
 		tests/bats/test_cd_imex_chan_inject.bats \
 		tests/bats/test_cd_misc.bats \
 		tests/bats/test_cd_logging.bats \
@@ -236,6 +237,7 @@ tests-gpu: runner-image
 		tests/bats/test_gpu_dynmig.bats \
 		tests/bats/test_gpu_mig.bats \
 		tests/bats/test_gpu_updowngrade.bats \
+		tests/bats/test_gpu_seamless_upgrades.bats \
 		tests/bats/test_gpu_stress.bats)
 
 # Run a subset covering mainly the CD plugin
@@ -260,6 +262,7 @@ tests: runner-image
 		tests/bats/test_gpu_dynmig.bats \
 		tests/bats/test_gpu_mig.bats \
 		tests/bats/test_gpu_updowngrade.bats \
+		tests/bats/test_gpu_seamless_upgrades.bats \
 		tests/bats/test_cd_imex_chan_inject.bats \
 		tests/bats/test_cd_mnnvl_workload.bats \
 		tests/bats/test_cd_misc.bats \

--- a/tests/bats/test_gpu_seamless_upgrades.bats
+++ b/tests/bats/test_gpu_seamless_upgrades.bats
@@ -1,0 +1,216 @@
+# shellcheck disable=SC2148
+# shellcheck disable=SC2329
+
+# Seamless (zero-downtime) rolling updates of the kubelet plugin DaemonSet:
+# SeamlessUpgrades feature gate + maxSurge=1/maxUnavailable=0. Verifies that
+#
+#  - each plugin instance uses pod-UID-suffixed registration and DRA sockets,
+#  - during a rollout the old and the new instance run (and are registered)
+#    concurrently and a claim can be prepared in that window,
+#  - the two instances do not fight over the ResourceSlice (no writes during
+#    the overlap window),
+#  - the old instance's sockets are removed when it exits,
+#  - a rollout to a bad image leaves the old instance serving, and rolling
+#    back does not disturb it.
+#
+# The socket assertions look at the node's kubelet directories through the
+# plugin container (which bind-mounts them). This test is device-independent
+# and runs against mock NVML as well as real GPUs.
+
+setup_file() {
+  load 'helpers.sh'
+  local _iargs=(
+    "--set" "logVerbosity=6"
+    "--set" "featureGates.SeamlessUpgrades=true"
+    "--set" "kubeletPlugin.updateStrategy.rollingUpdate.maxSurge=1"
+    "--set" "kubeletPlugin.updateStrategy.rollingUpdate.maxUnavailable=0"
+  )
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+}
+
+
+teardown_file() {
+  load 'helpers.sh'
+  # Restore the suite's default installation (gate off, default strategy) so
+  # that subsequent test files see the state they expect.
+  local _iargs=("--set" "logVerbosity=6")
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+}
+
+
+setup() {
+  load 'helpers.sh'
+  _common_setup
+  log_objects
+}
+
+
+bats::on_failure() {
+  echo -e "\n\nFAILURE HOOK START"
+  log_objects
+  kubectl get pods -n dra-driver-nvidia-gpu -o wide
+  show_kubelet_plugin_error_logs
+  show_gpu_plugin_log_tails
+  echo -e "FAILURE HOOK END\n\n"
+}
+
+
+# Name of the single Running, non-terminating gpu kubelet plugin pod on the
+# node that the workload pod (arg 1) runs on -- or, w/o arg, on any node.
+_running_plugin_pod() {
+  kubectl get pods -n dra-driver-nvidia-gpu \
+    -l dra-driver-nvidia-gpu-component=kubelet-plugin \
+    -o jsonpath='{range .items[?(@.status.phase=="Running")]}{.metadata.name}:{.metadata.deletionTimestamp}{"\n"}{end}' \
+    | grep ':$' | cut -d: -f1 | head -n1
+}
+
+# List socket files in the kubelet registrar dir and the driver plugin dir, as
+# seen from within a plugin pod (arg 1).
+_list_sockets_via() {
+  kubectl exec -n dra-driver-nvidia-gpu "$1" -c gpus -- \
+    bash -c 'ls /var/lib/kubelet/plugins_registry/ /var/lib/kubelet/plugins/gpu.nvidia.com/ | grep sock' 2>/dev/null
+}
+
+_rs_rv() {
+  kubectl get resourceslices -o jsonpath='{range .items[?(@.spec.driver=="gpu.nvidia.com")]}{.metadata.resourceVersion}{" "}{end}'
+}
+
+
+# bats test_tags=fastfeedback
+@test "GPUs: seamless upgrades: per-pod-UID sockets" {
+  local _kpod _uid
+  _kpod=$(_running_plugin_pod)
+  _uid=$(kubectl get pod -n dra-driver-nvidia-gpu "${_kpod}" -o jsonpath='{.metadata.uid}')
+  log "plugin pod: ${_kpod} uid: ${_uid}"
+
+  run _list_sockets_via "${_kpod}"
+  assert_output --partial "gpu.nvidia.com-${_uid}-reg.sock"
+  assert_output --partial "dra-${_uid}.sock"
+  # The plain (non-suffixed) names must not be in use.
+  refute_output --regexp "^gpu.nvidia.com-reg.sock$"
+  refute_output --regexp "^dra.sock$"
+
+  # The plugin's own log confirms the suffixed endpoints (also for the
+  # healthcheck client, which must dial the same suffixed sockets).
+  run kubectl logs -n dra-driver-nvidia-gpu "${_kpod}" -c gpus
+  assert_output --partial "endpoint=\"/var/lib/kubelet/plugins/gpu.nvidia.com/dra-${_uid}.sock\""
+  assert_output --partial "connecting to DRA socket path=unix:///var/lib/kubelet/plugins/gpu.nvidia.com/dra-${_uid}.sock"
+}
+
+
+# bats test_tags=fastfeedback
+@test "GPUs: seamless upgrades: surge rollout, prepare during overlap, no ResourceSlice churn, old sockets removed" {
+  local _old _olduid _new _newuid _rv0 _rv1
+
+  # Baseline workload, kept running across the rollout.
+  kubectl apply -f tests/bats/specs/gpu-simple-full.yaml
+  kubectl wait --for=condition=READY pods pod-full-gpu --timeout=20s
+
+  _old=$(_running_plugin_pod)
+  _olduid=$(kubectl get pod -n dra-driver-nvidia-gpu "${_old}" -o jsonpath='{.metadata.uid}')
+  log "old plugin pod: ${_old} (${_olduid})"
+
+  # Widen the overlap window: make the old instance linger 30 s after SIGTERM
+  # is due, so that we can reliably act while both instances are alive. This
+  # DaemonSet template change itself is a (short-overlap) surge rollout.
+  # (Strategic merge patch: target the gpus container by name -- its index in
+  # the pod spec depends on whether compute domains are enabled.)
+  kubectl patch ds -n dra-driver-nvidia-gpu dra-driver-nvidia-gpu-kubelet-plugin --type=strategic -p='{
+    "spec":{"template":{"spec":{"terminationGracePeriodSeconds":90,
+      "containers":[{"name":"gpus","lifecycle":{"preStop":{"exec":{"command":["sleep","30"]}}}}]}}}}'
+  kubectl rollout status ds -n dra-driver-nvidia-gpu dra-driver-nvidia-gpu-kubelet-plugin --timeout=180s
+  _old=$(_running_plugin_pod)
+  _olduid=$(kubectl get pod -n dra-driver-nvidia-gpu "${_old}" -o jsonpath='{.metadata.uid}')
+  log "old plugin pod (with preStop): ${_old} (${_olduid})"
+  sleep 3
+  _rv0=$(_rs_rv)
+  log "ResourceSlice resourceVersion before rollout: ${_rv0}"
+
+  # Trigger the rollout under test (pod template change).
+  kubectl set env ds -n dra-driver-nvidia-gpu dra-driver-nvidia-gpu-kubelet-plugin -c gpus SEAMLESS_UPGRADES_TEST=1
+
+  # Wait for the overlap window: new pod Ready while old pod is Terminating.
+  local _i
+  for _i in $(seq 1 90); do
+    _new=$(kubectl get pods -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin \
+      -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==true)]}{.metadata.name}:{.metadata.deletionTimestamp}{"\n"}{end}' \
+      | grep ':$' | cut -d: -f1 | grep -v "^${_old}$" | head -n1 || true)
+    if [ -n "${_new}" ] && [ -n "$(kubectl get pod -n dra-driver-nvidia-gpu "${_old}" -o jsonpath='{.metadata.deletionTimestamp}')" ]; then
+      break
+    fi
+    sleep 1
+  done
+  [ -n "${_new}" ]
+  _newuid=$(kubectl get pod -n dra-driver-nvidia-gpu "${_new}" -o jsonpath='{.metadata.uid}')
+  log "overlap window: old=${_old} (Terminating) new=${_new} (${_newuid}, Ready)"
+
+  # Both instances' sockets are present.
+  run _list_sockets_via "${_new}"
+  assert_output --partial "gpu.nvidia.com-${_olduid}-reg.sock"
+  assert_output --partial "gpu.nvidia.com-${_newuid}-reg.sock"
+  assert_output --partial "dra-${_olduid}.sock"
+  assert_output --partial "dra-${_newuid}.sock"
+
+  # A claim can be prepared while both instances are alive.
+  sed 's/pod-full-gpu/pod-full-gpu-overlap/; s/rct-single-gpu-full/rct-single-gpu-full-overlap/' \
+    tests/bats/specs/gpu-simple-full.yaml | kubectl apply -f -
+  kubectl wait --for=condition=READY pods pod-full-gpu-overlap --timeout=30s
+  # And the pre-rollout claim can be unprepared.
+  kubectl delete pod pod-full-gpu --wait=true --timeout=60s
+
+  # Old instance goes away; its sockets must be gone, the new one's remain.
+  kubectl wait --for=delete pod -n dra-driver-nvidia-gpu "${_old}" --timeout=120s
+  kubectl rollout status ds -n dra-driver-nvidia-gpu dra-driver-nvidia-gpu-kubelet-plugin --timeout=60s
+  run _list_sockets_via "${_new}"
+  refute_output --partial "${_olduid}"
+  assert_output --partial "gpu.nvidia.com-${_newuid}-reg.sock"
+  assert_output --partial "dra-${_newuid}.sock"
+
+  # No ResourceSlice churn: the two publishers must have converged on identical
+  # content without rewriting the slice (a rewrite would bump resourceVersion).
+  _rv1=$(_rs_rv)
+  log "ResourceSlice resourceVersion after rollout: ${_rv1}"
+  [ "${_rv0}" = "${_rv1}" ]
+
+  # Cleanup.
+  kubectl delete pod pod-full-gpu-overlap --wait=true --timeout=60s
+  kubectl delete resourceclaimtemplates rct-single-gpu-full rct-single-gpu-full-overlap --ignore-not-found
+}
+
+
+# bats test_tags=fastfeedback
+@test "GPUs: seamless upgrades: bad image keeps old instance serving, rollback is non-disruptive" {
+  local _good _rev
+
+  _good=$(_running_plugin_pod)
+  log "good plugin pod: ${_good}"
+  _rev=$(helm history "${TEST_HELM_RELEASE_NAME}" -n dra-driver-nvidia-gpu -o json | jq -r ".[-1].revision")
+
+  # Roll out an image that cannot be pulled. With maxUnavailable=0 the old
+  # instance must keep running; the surge pod gets stuck.
+  timeout -v 120 helm upgrade "${TEST_HELM_RELEASE_NAME}" "${TEST_CHART_REPO}" \
+    --version="${TEST_CHART_VERSION}" --namespace dra-driver-nvidia-gpu --reuse-values \
+    --set image.tag=does-not-exist-seamless-upgrades-test
+  sleep 20
+  kubectl get pods -n dra-driver-nvidia-gpu -o wide
+  run kubectl get pod -n dra-driver-nvidia-gpu "${_good}" -o jsonpath='{.status.phase}:{.metadata.deletionTimestamp}'
+  assert_output "Running:"
+  run kubectl get ds -n dra-driver-nvidia-gpu dra-driver-nvidia-gpu-kubelet-plugin -o jsonpath='{.status.numberReady}'
+  assert_output "1"
+
+  # Workloads still get prepared by the surviving instance.
+  kubectl apply -f tests/bats/specs/gpu-simple-full.yaml
+  kubectl wait --for=condition=READY pods pod-full-gpu --timeout=30s
+
+  # Rollback removes the stuck pod and does not restart the good one.
+  helm rollback "${TEST_HELM_RELEASE_NAME}" "${_rev}" -n dra-driver-nvidia-gpu --wait --timeout=120s
+  kubectl rollout status ds -n dra-driver-nvidia-gpu dra-driver-nvidia-gpu-kubelet-plugin --timeout=180s
+  run kubectl get pod -n dra-driver-nvidia-gpu "${_good}" -o jsonpath='{.status.phase}:{.metadata.deletionTimestamp}'
+  assert_output "Running:"
+  run kubectl get pods -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin --field-selector=status.phase=Running -o name
+  assert_line --index 0 "pod/${_good}"
+  [ "$(echo "${output}" | wc -l)" -eq 1 ]
+
+  kubectl delete pod pod-full-gpu --wait=true --timeout=60s
+  kubectl delete resourceclaimtemplates rct-single-gpu-full --ignore-not-found
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds seamless upgrade support to the GPU and compute domain kubelet plugins, behind the `SeamlessUpgrades` feature gate. Registration and DRA sockets are named after the plugin pod UID, so a surge instance can register while the outgoing one is still serving and a DaemonSet rollout hands over without a window in which no plugin is registered. The chart injects `POD_UID` and documents `maxSurge: 1` with `maxUnavailable: 0`.

It also makes ResourceSlice publishing deterministic, ordering devices by PCI bus ID and then name in the non DynamicMIG, health republish and compute domain paths.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

**This is intentionally a draft, so please don't spend review time on it yet.**

It is part of an experiment in bringing the three DRA drivers (dra-example-driver, dra-driver-nvidia-gpu and dra-driver-google-tpu) closer to feature parity, along with a few bugs found along the way.

**How it was produced:** the implementation was written largely by autonomous coding agents working under my direction, one per feature, each in its own branch. I am not asking you to take that on trust, which is exactly why it opens as a draft.

**Verified so far, unattended:** gofmt, Linux go vet and unit tests across the gpu plugin, compute domain plugin, internal/common and featuregates, golangci-lint clean, and a bats e2e on kind built from v1.37.0-rc.0 using this repo's mock NVML path, all 3 tests passing through the repo's own bats runner. It covers per UID sockets with kubelet confirming registration of the new instance before unregistration of the old one, a surge rollout with a new claim prepared and an existing claim unprepared during the overlap, sockets removed after the old pod exits, and a failing surge image followed by a non disruptive rollback.

**Not done yet:** my own reading of the full diff, and testing it again by hand under my supervision. That happens before this leaves draft, so no CI approval, `/ok-to-test`, or reviewer attention is needed until then.

I will drop the `WIP:` prefix and mark it ready for review only after that human pass.

Technical note on the ordering change, which is the part I would look at first: the e2e caught a real problem that unit tests could not. During the rollout overlap the ResourceSlice `resourceVersion` changed four times in about 45 seconds, with the two instances alternating. The device set was identical each time but the order differed, because the affected publish paths iterate Go maps, so the two resourceslice controllers kept correcting each other. The content was equivalent and the scheduler was unaffected, but every upgrade produced continuous API churn. After sorting, a repeat of the same 45 second overlap showed the `resourceVersion` unchanged across 111 samples.

Not covered here, and needing real hardware: DynamicMIG under surge, MPS control daemon ownership across handover, CUDA workload continuity, and IMEX channel prepare across handover. The registration, socket, checkpoint and DaemonSet mechanics are device independent and are covered above.

The same feature for dra-driver-google-tpu is in https://github.com/kubernetes-sigs/dra-driver-google-tpu/pull/38.

#### Does this PR introduce a user-facing change?

```release-note
The GPU and compute domain kubelet plugins support seamless upgrades behind the SeamlessUpgrades feature gate, so a DaemonSet rollout hands over without a window in which no plugin is registered on the node. ResourceSlice device ordering is now deterministic, which avoids repeated rewrites while two instances overlap.
```

#### Additional documentation (design docs, usage docs, etc.):

```docs
NONE
```

#### Checklist

- [x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [x] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
