### PR TITLE
WIP: Add design proposal for KEP-5007 device binding conditions

### DIFF
--- a/cmd/gpu-kubelet-plugin/bindingconditions.go
+++ b/cmd/gpu-kubelet-plugin/bindingconditions.go
@@ -1,0 +1,165 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/dynamic-resource-allocation/resourceslice"
+)
+
+// BindingConditions (KEP-5007) let an external controller gate pod binding on
+// device readiness that this driver cannot observe itself: the scheduler holds
+// the pod in PreBind until every configured condition type is True in
+// claim.status.devices[].conditions, and reschedules the pod if one of the
+// failure condition types becomes True.
+//
+// This driver only publishes the condition types on its devices. Satisfying
+// them is the job of whatever component performs the out-of-band work (for
+// example a power-management service bringing GPUs to their target power state
+// before a workload is allowed to start). That split is deliberate: the
+// readiness signal lives in the external system, and KEP-5007 is designed
+// around an external controller writing the conditions.
+//
+// Consequently, configuring condition types here without deploying a writer
+// for them means every pod requesting a GPU from this driver waits for the
+// scheduler's binding timeout and is then rescheduled, indefinitely. The flags
+// are therefore opt-in, empty by default, and additionally gated behind the
+// GPUBindingConditions feature gate.
+type bindingConditionsConfig struct {
+	// conditions must all be True before the scheduler binds a pod.
+	conditions []string
+	// failureConditions abort binding and trigger rescheduling if any is True.
+	failureConditions []string
+}
+
+// enabled reports whether any binding conditions are configured. Failure
+// conditions alone have no effect: the scheduler only evaluates them for
+// devices that also carry at least one binding condition.
+func (c bindingConditionsConfig) enabled() bool {
+	return len(c.conditions) > 0
+}
+
+// parseBindingConditions parses a comma-separated list of condition types,
+// ignoring surrounding whitespace and empty entries.
+func parseBindingConditions(s string) []string {
+	var out []string
+	for _, item := range strings.Split(s, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// newBindingConditionsConfig parses and validates the raw flag values, adding
+// the conditions this driver satisfies itself when power readiness is enabled.
+func newBindingConditionsConfig(conditions, failureConditions string, pr powerReadinessConfig) (bindingConditionsConfig, error) {
+	c := bindingConditionsConfig{
+		conditions:        parseBindingConditions(conditions),
+		failureConditions: parseBindingConditions(failureConditions),
+	}
+	if pr.enabled() {
+		c.conditions = appendUnique(c.conditions, powerReadyConditionType)
+		c.failureConditions = appendUnique(c.failureConditions, powerFailedConditionType)
+	}
+	return c, c.validate()
+}
+
+func appendUnique(list []string, value string) []string {
+	if slices.Contains(list, value) {
+		return list
+	}
+	return append(list, value)
+}
+
+// validate mirrors the API server's validation of these fields so that a
+// misconfiguration fails at startup with a clear message, instead of being
+// silently rejected later when the ResourceSlice is published. See
+// validateDeviceBindingParameters in
+// k8s.io/kubernetes/pkg/apis/resource/validation.
+func (c bindingConditionsConfig) validate() error {
+	var errs []error
+
+	// The apiserver requires the two lists to be set together, and rejects any
+	// ResourceSlice carrying one without the other. Catching that here matters:
+	// otherwise the plugin starts, stamps every device, and then every slice
+	// write is rejected, so the node's GPUs silently disappear from the cluster.
+	if len(c.conditions) == 0 && len(c.failureConditions) > 0 {
+		errs = append(errs, errors.New("--binding-conditions is required when --binding-failure-conditions is set: the scheduler only evaluates failure conditions for devices that also carry binding conditions"))
+	}
+	if len(c.failureConditions) == 0 && len(c.conditions) > 0 {
+		errs = append(errs, errors.New("--binding-failure-conditions is required when --binding-conditions is set: without it a pod that cannot become ready waits for the scheduler's binding timeout instead of being rescheduled"))
+	}
+
+	for _, check := range []struct {
+		flag    string
+		values  []string
+		maxSize int
+	}{
+		{"--binding-conditions", c.conditions, resourceapi.BindingConditionsMaxSize},
+		{"--binding-failure-conditions", c.failureConditions, resourceapi.BindingFailureConditionsMaxSize},
+	} {
+		if len(check.values) > check.maxSize {
+			errs = append(errs, fmt.Errorf("%s: %d condition types configured, at most %d are allowed", check.flag, len(check.values), check.maxSize))
+		}
+		seen := make(map[string]bool, len(check.values))
+		for _, condition := range check.values {
+			// Condition types are validated as label names upstream.
+			for _, msg := range validation.IsQualifiedName(condition) {
+				errs = append(errs, fmt.Errorf("%s: invalid condition type %q: %s", check.flag, condition, msg))
+			}
+			if seen[condition] {
+				errs = append(errs, fmt.Errorf("%s: duplicate condition type %q", check.flag, condition))
+			}
+			seen[condition] = true
+		}
+	}
+
+	for _, condition := range c.failureConditions {
+		if slices.Contains(c.conditions, condition) {
+			errs = append(errs, fmt.Errorf("condition type %q is listed as both a binding condition and a binding failure condition", condition))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// applyToResources stamps the configured condition types onto every device in
+// resources. It is a no-op when no binding conditions are configured.
+//
+// This is applied centrally, immediately before publishing, so that every path
+// that builds ResourceSlices (partitionable devices, the flat legacy layout,
+// and republishing after a device health change) is covered by construction.
+func (c bindingConditionsConfig) applyToResources(resources resourceslice.DriverResources) {
+	if !c.enabled() {
+		return
+	}
+	for _, pool := range resources.Pools {
+		for i := range pool.Slices {
+			for j := range pool.Slices[i].Devices {
+				pool.Slices[i].Devices[j].BindingConditions = slices.Clone(c.conditions)
+				pool.Slices[i].Devices[j].BindingFailureConditions = slices.Clone(c.failureConditions)
+			}
+		}
+	}
+}

--- a/cmd/gpu-kubelet-plugin/bindingconditions_test.go
+++ b/cmd/gpu-kubelet-plugin/bindingconditions_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/dynamic-resource-allocation/resourceslice"
+)
+
+func TestNewBindingConditionsConfig(t *testing.T) {
+	tests := []struct {
+		name                    string
+		conditions              string
+		failureConditions       string
+		expectedConditions      []string
+		expectedFailures        []string
+		expectedEnabled         bool
+		expectedErrorSubstrings []string
+	}{
+		{
+			name:            "empty by default",
+			expectedEnabled: false,
+		},
+		{
+			name:               "single condition pair",
+			conditions:         "power.nvidia.com/ready",
+			failureConditions:  "power.nvidia.com/failed",
+			expectedConditions: []string{"power.nvidia.com/ready"},
+			expectedFailures:   []string{"power.nvidia.com/failed"},
+			expectedEnabled:    true,
+		},
+		{
+			name:               "whitespace and empty entries are ignored",
+			conditions:         " power.nvidia.com/ready , ,power.nvidia.com/steady ",
+			failureConditions:  " power.nvidia.com/failed ",
+			expectedConditions: []string{"power.nvidia.com/ready", "power.nvidia.com/steady"},
+			expectedFailures:   []string{"power.nvidia.com/failed"},
+			expectedEnabled:    true,
+		},
+		{
+			name:               "conditions and failure conditions",
+			conditions:         "power.nvidia.com/ready",
+			failureConditions:  "power.nvidia.com/failed",
+			expectedConditions: []string{"power.nvidia.com/ready"},
+			expectedFailures:   []string{"power.nvidia.com/failed"},
+			expectedEnabled:    true,
+		},
+		{
+			name:                    "failure conditions without binding conditions",
+			failureConditions:       "power.nvidia.com/failed",
+			expectedErrorSubstrings: []string{"--binding-conditions is required"},
+		},
+		{
+			// The apiserver rejects a device carrying one list without the
+			// other, so this must fail at startup rather than at publish time.
+			name:                    "binding conditions without failure conditions",
+			conditions:              "power.nvidia.com/ready",
+			expectedErrorSubstrings: []string{"--binding-failure-conditions is required"},
+		},
+		{
+			name:                    "too many conditions",
+			conditions:              "a.com/1,a.com/2,a.com/3,a.com/4,a.com/5",
+			failureConditions:       "a.com/failed",
+			expectedErrorSubstrings: []string{"at most 4"},
+		},
+		{
+			name:                    "invalid condition type",
+			conditions:              "not a valid condition!",
+			failureConditions:       "power.nvidia.com/failed",
+			expectedErrorSubstrings: []string{"invalid condition type"},
+		},
+		{
+			name:                    "duplicate condition",
+			conditions:              "power.nvidia.com/ready,power.nvidia.com/ready",
+			failureConditions:       "power.nvidia.com/failed",
+			expectedErrorSubstrings: []string{"duplicate condition type"},
+		},
+		{
+			name:                    "overlapping condition and failure condition",
+			conditions:              "power.nvidia.com/ready",
+			failureConditions:       "power.nvidia.com/ready",
+			expectedErrorSubstrings: []string{"listed as both"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := newBindingConditionsConfig(test.conditions, test.failureConditions, powerReadinessConfig{})
+			if len(test.expectedErrorSubstrings) > 0 {
+				require.Error(t, err)
+				for _, substr := range test.expectedErrorSubstrings {
+					require.ErrorContains(t, err, substr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expectedConditions, c.conditions)
+			require.Equal(t, test.expectedFailures, c.failureConditions)
+			require.Equal(t, test.expectedEnabled, c.enabled())
+		})
+	}
+}
+
+// TestBindingConditionsMaxSizeMatchesAPI guards against the upstream limits
+// changing underneath the validation above.
+func TestBindingConditionsMaxSizeMatchesAPI(t *testing.T) {
+	require.Equal(t, 4, resourceapi.BindingConditionsMaxSize)
+	require.Equal(t, 4, resourceapi.BindingFailureConditionsMaxSize)
+}
+
+func TestApplyToResources(t *testing.T) {
+	// Two pools, one with two slices, to cover every device the driver can
+	// publish regardless of which ResourceSlice layout produced it.
+	newResources := func() resourceslice.DriverResources {
+		return resourceslice.DriverResources{
+			Pools: map[string]resourceslice.Pool{
+				"node-a": {Slices: []resourceslice.Slice{
+					{Devices: []resourceapi.Device{{Name: "gpu-0"}, {Name: "gpu-1"}}},
+					{Devices: []resourceapi.Device{{Name: "gpu-1-mig-1g24gb-0"}}},
+				}},
+				"node-b": {Slices: []resourceslice.Slice{
+					{Devices: []resourceapi.Device{{Name: "gpu-0"}}},
+				}},
+			},
+		}
+	}
+
+	t.Run("no-op when not configured", func(t *testing.T) {
+		resources := newResources()
+		bindingConditionsConfig{}.applyToResources(resources)
+		forEachDevice(resources, func(d *resourceapi.Device) {
+			require.Nil(t, d.BindingConditions, "device %s", d.Name)
+			require.Nil(t, d.BindingFailureConditions, "device %s", d.Name)
+		})
+	})
+
+	t.Run("stamps every device in every pool and slice", func(t *testing.T) {
+		c, err := newBindingConditionsConfig("power.nvidia.com/ready", "power.nvidia.com/failed", powerReadinessConfig{})
+		require.NoError(t, err)
+
+		resources := newResources()
+		c.applyToResources(resources)
+
+		count := 0
+		forEachDevice(resources, func(d *resourceapi.Device) {
+			count++
+			require.Equal(t, []string{"power.nvidia.com/ready"}, d.BindingConditions, "device %s", d.Name)
+			require.Equal(t, []string{"power.nvidia.com/failed"}, d.BindingFailureConditions, "device %s", d.Name)
+		})
+		require.Equal(t, 4, count, "every published device should be stamped")
+	})
+
+	t.Run("devices do not share slices with each other or with the config", func(t *testing.T) {
+		c, err := newBindingConditionsConfig("power.nvidia.com/ready", "power.nvidia.com/failed", powerReadinessConfig{})
+		require.NoError(t, err)
+
+		resources := newResources()
+		c.applyToResources(resources)
+
+		// Mutating one device's conditions must not affect any other device,
+		// nor the configuration itself.
+		resources.Pools["node-a"].Slices[0].Devices[0].BindingConditions[0] = "mutated"
+
+		require.Equal(t, "power.nvidia.com/ready", c.conditions[0])
+		require.Equal(t, []string{"power.nvidia.com/ready"},
+			resources.Pools["node-a"].Slices[0].Devices[1].BindingConditions)
+		require.Equal(t, []string{"power.nvidia.com/ready"},
+			resources.Pools["node-b"].Slices[0].Devices[0].BindingConditions)
+	})
+
+	t.Run("multiple condition types are all stamped", func(t *testing.T) {
+		c, err := newBindingConditionsConfig(
+			"power.nvidia.com/ready,power.nvidia.com/steady", "power.nvidia.com/failed", powerReadinessConfig{})
+		require.NoError(t, err)
+
+		resources := newResources()
+		c.applyToResources(resources)
+
+		forEachDevice(resources, func(d *resourceapi.Device) {
+			require.Equal(t, []string{"power.nvidia.com/ready", "power.nvidia.com/steady"},
+				d.BindingConditions, "device %s", d.Name)
+			require.Equal(t, []string{"power.nvidia.com/failed"},
+				d.BindingFailureConditions, "device %s", d.Name)
+		})
+	})
+}
+
+func forEachDevice(resources resourceslice.DriverResources, fn func(*resourceapi.Device)) {
+	for _, pool := range resources.Pools {
+		for i := range pool.Slices {
+			for j := range pool.Slices[i].Devices {
+				fn(&pool.Slices[i].Devices[j])
+			}
+		}
+	}
+}
+
+// Enabling power readiness makes the driver publish the conditions it satisfies
+// itself, so an operator never has to name them.
+func TestBindingConditionsWithPowerReadiness(t *testing.T) {
+	t.Run("adds the driver-owned pair when nothing else is configured", func(t *testing.T) {
+		c, err := newBindingConditionsConfig("", "", powerReadinessConfig{profileIDs: []int{4}})
+		require.NoError(t, err)
+		require.Equal(t, []string{powerReadyConditionType}, c.conditions)
+		require.Equal(t, []string{powerFailedConditionType}, c.failureConditions)
+		require.True(t, c.enabled())
+	})
+
+	t.Run("appends alongside operator-configured conditions", func(t *testing.T) {
+		c, err := newBindingConditionsConfig("dps.example.com/ready", "dps.example.com/failed",
+			powerReadinessConfig{profileIDs: []int{4}})
+		require.NoError(t, err)
+		require.Equal(t, []string{"dps.example.com/ready", powerReadyConditionType}, c.conditions)
+		require.Equal(t, []string{"dps.example.com/failed", powerFailedConditionType}, c.failureConditions)
+	})
+
+	t.Run("does not duplicate a condition the operator already listed", func(t *testing.T) {
+		c, err := newBindingConditionsConfig(powerReadyConditionType, powerFailedConditionType,
+			powerReadinessConfig{profileIDs: []int{4}})
+		require.NoError(t, err)
+		require.Equal(t, []string{powerReadyConditionType}, c.conditions)
+		require.Equal(t, []string{powerFailedConditionType}, c.failureConditions)
+	})
+
+	t.Run("adds nothing when power readiness is off", func(t *testing.T) {
+		c, err := newBindingConditionsConfig("", "", powerReadinessConfig{})
+		require.NoError(t, err)
+		require.False(t, c.enabled())
+	})
+
+	t.Run("still respects the four-condition ceiling", func(t *testing.T) {
+		_, err := newBindingConditionsConfig("a.com/1,a.com/2,a.com/3,a.com/4", "a.com/f",
+			powerReadinessConfig{profileIDs: []int{4}})
+		require.ErrorContains(t, err, "at most 4")
+	})
+}

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -67,6 +68,9 @@ type driver struct {
 	// Devices (required for k8s 1.35+) or combined SharedCounters and Devices
 	// in the same slice (required for k8s 1.34).
 	useSplitResourceSlices bool
+	// KEP-5007 binding condition types published on this driver's devices,
+	// satisfied by an external controller. Empty unless configured.
+	bindingConditions bindingConditionsConfig
 }
 
 func NewDriver(ctx context.Context, config *Config) (*driver, error) {
@@ -128,6 +132,32 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		state:                  state,
 		pulock:                 flock.NewFlock(puLockPath),
 		useSplitResourceSlices: useSplitSlices,
+		bindingConditions:      config.bindingConditions,
+	}
+
+	if config.powerReadiness.enabled() {
+		// Started before any ResourceSlice is published: if the writer cannot
+		// run, this driver must not advertise a binding condition that nothing
+		// will ever satisfy.
+		writer := newPowerReadinessWriter(config, state)
+		runWriter, err := writer.Start(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("starting power readiness writer: %w", err)
+		}
+		driver.wg.Add(1)
+		go func() {
+			defer driver.wg.Done()
+			runWriter()
+		}()
+	}
+
+	if driver.bindingConditions.enabled() {
+		klog.Infof("Publishing KEP-5007 binding conditions %v (failure conditions %v) on all devices. "+
+			"Pods requesting these devices will not bind until an external controller sets those "+
+			"conditions to True in claim.status.devices[]. This requires the DRADeviceBindingConditions "+
+			"and DRAResourceClaimDeviceStatus feature gates on both the kube-apiserver and the "+
+			"kube-scheduler; a scheduler without them treats these devices as unselectable.",
+			driver.bindingConditions.conditions, driver.bindingConditions.failureConditions)
 	}
 
 	opts := []kubeletplugin.Option{
@@ -376,7 +406,22 @@ func (d *driver) UnprepareResourceClaims(ctx context.Context, claimRefs []kubele
 }
 
 func (d *driver) HandleError(ctx context.Context, err error, msg string) {
-	// For now we just follow the advice documented in the DRAPlugin API docs.
+	// A DroppedFieldsError means the apiserver stored less than we asked for.
+	// The resourceslice helper reacts by rewriting its own desired state to
+	// match what was stored, so it never retries: the feature stays inert
+	// until this plugin is restarted. That is easy to miss, so call it out
+	// instead of letting it scroll past as a generic error.
+	var dropped *resourceslice.DroppedFieldsError
+	if errors.As(err, &dropped) && d.bindingConditions.enabled() &&
+		slices.Contains(dropped.DisabledFeatures(), "DRADeviceBindingConditions") {
+		klog.Errorf("The apiserver dropped the binding conditions published for pool %q, slice #%d. "+
+			"--binding-conditions has no effect unless the cluster has the DRADeviceBindingConditions and "+
+			"DRAResourceClaimDeviceStatus feature gates enabled; pods will bind without waiting for these "+
+			"conditions. Published slices have been downgraded to match the apiserver, so this plugin must be "+
+			"restarted after enabling the gates.", dropped.PoolName, dropped.SliceIndex)
+	}
+
+	// Otherwise we just follow the advice documented in the DRAPlugin API docs.
 	// See: https://pkg.go.dev/k8s.io/apimachinery/pkg/util/runtime#HandleErrorWithContext
 	runtime.HandleErrorWithContext(ctx, err, msg)
 }
@@ -479,6 +524,7 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 		// https://github.com/kubernetes/kubernetes/commit/a171795e313ee9f407fef4897c1a1e2052120991
 		klog.V(1).Infof("featuregates.DynamicMIG enabled: construct ResourceSlice objects according to KEP 4815 (partitionable devices)")
 		resources := d.GenerateDriverResources(config.flags.nodeName)
+		config.bindingConditions.applyToResources(resources)
 		if err := d.pluginhelper.PublishResources(ctx, resources); err != nil {
 			return err
 		}
@@ -499,6 +545,7 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 			config.flags.nodeName: {Slices: []resourceslice.Slice{resourceSlice}},
 		},
 	}
+	config.bindingConditions.applyToResources(resources)
 
 	if err := d.pluginhelper.PublishResources(ctx, resources); err != nil {
 		return err
@@ -566,6 +613,7 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string) {
 					nodeName: {Slices: []resourceslice.Slice{resourceSlice}},
 				},
 			}
+			d.bindingConditions.applyToResources(resources)
 
 			// NOTE: GPU_LOST and unmonitored events are already batched at the
 			// sender (all affected devices arrive in a single DeviceHealthEvent).

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -68,6 +68,9 @@ type Flags struct {
 	klogVerbosity                 int
 	additionalXidsToIgnore        string
 	consumableShares              string
+	bindingConditions             string
+	bindingFailureConditions      string
+	powerReadinessProfileIDs      string
 }
 
 type Config struct {
@@ -75,6 +78,8 @@ type Config struct {
 	clientsets           pkgflags.ClientSets
 	imagePullSecretNames []string
 	imagePullPolicy      string
+	bindingConditions    bindingConditionsConfig
+	powerReadiness       powerReadinessConfig
 }
 
 func (c Config) DriverPluginPath() string {
@@ -217,6 +222,24 @@ func newApp() *cli.App {
 			Destination: &flags.consumableShares,
 			EnvVars:     []string{"CONSUMABLE_SHARES"},
 		},
+		&cli.StringFlag{
+			Name:        "binding-conditions",
+			Usage:       "Comma-separated KEP-5007 binding condition types to publish on this driver's devices (e.g. 'power.nvidia.com/ready'). All of them must be set to True in the ResourceClaim's per-device status by an external controller before the scheduler binds a pod. Must be set together with --binding-failure-conditions. Requires the GPUBindingConditions feature gate here, and the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates on both the apiserver and the scheduler. Empty by default; configuring this without deploying a controller that satisfies the conditions prevents all GPU pods from binding.",
+			Destination: &flags.bindingConditions,
+			EnvVars:     []string{"BINDING_CONDITIONS"},
+		},
+		&cli.StringFlag{
+			Name:        "power-readiness-profile-ids",
+			Usage:       "Comma-separated NVIDIA workload power profile IDs that must be enforced on a GPU before a pod may bind to it. Setting this makes the driver publish and satisfy its own binding conditions (gpu.nvidia.com/power-ready and gpu.nvidia.com/power-failed), holding a pod until NVML reports every configured profile as enforced on each GPU allocated to it from this node. This mirrors the dps_wpps setting NVIDIA DPS applies from a Slurm prolog, for which Kubernetes has no equivalent hook. Applying the profiles remains the power manager's job; this only waits for them. GPUs that cannot report profiles (pre-Blackwell, or bound to vfio-pci) are treated as ready. Unset by default, in which case an external controller is expected to satisfy any conditions from --binding-conditions. Requires the GPUBindingConditions feature gate, and consumes one of the four available binding condition slots.",
+			Destination: &flags.powerReadinessProfileIDs,
+			EnvVars:     []string{"POWER_READINESS_PROFILE_IDS"},
+		},
+		&cli.StringFlag{
+			Name:        "binding-failure-conditions",
+			Usage:       "Comma-separated KEP-5007 binding failure condition types to publish on this driver's devices (e.g. 'power.nvidia.com/failed'). If an external controller sets any of them to True, the scheduler aborts binding and reschedules the pod. Required when --binding-conditions is set, and vice versa.",
+			Destination: &flags.bindingFailureConditions,
+			EnvVars:     []string{"BINDING_FAILURE_CONDITIONS"},
+		},
 	}
 	cliFlags = append(cliFlags, flags.kubeClientConfig.Flags()...)
 	cliFlags = append(cliFlags, featureGateConfig.Flags()...)
@@ -256,11 +279,30 @@ func newApp() *cli.App {
 				return fmt.Errorf("create client: %w", err)
 			}
 
+			profileIDs, err := parseProfileIDs(flags.powerReadinessProfileIDs)
+			if err != nil {
+				return fmt.Errorf("invalid power readiness settings: %w", err)
+			}
+			powerReadiness := powerReadinessConfig{
+				profileIDs: profileIDs,
+				interval:   defaultPowerReadinessInterval,
+			}
+			if err := powerReadiness.validate(); err != nil {
+				return fmt.Errorf("invalid power readiness settings: %w", err)
+			}
+
+			bindingConditions, err2 := newBindingConditionsConfig(flags.bindingConditions, flags.bindingFailureConditions, powerReadiness)
+			if err = err2; err != nil {
+				return fmt.Errorf("invalid binding conditions: %w", err)
+			}
+
 			config := &Config{
 				flags:                flags,
 				clientsets:           clientSets,
 				imagePullSecretNames: strings.Fields(strings.ReplaceAll(strings.TrimSpace(flags.imagePullSecrets), ",", " ")),
 				imagePullPolicy:      strings.TrimSpace(flags.imagePullPolicy),
+				bindingConditions:    bindingConditions,
+				powerReadiness:       powerReadiness,
 			}
 
 			return RunPlugin(c.Context, config)
@@ -301,6 +343,26 @@ func validateCLIFlags(flags *Flags) error {
 			}
 			return fmt.Errorf("error checking if host root is mounted at %q: %w", flags.hostRoot, err)
 		}
+	}
+
+	if (flags.bindingConditions != "" || flags.bindingFailureConditions != "") && !featuregates.Enabled(featuregates.GPUBindingConditions) {
+		return fmt.Errorf("--binding-conditions/--binding-failure-conditions require feature gate %s to be enabled", featuregates.GPUBindingConditions)
+	}
+
+	if flags.powerReadinessProfileIDs != "" && !featuregates.Enabled(featuregates.GPUBindingConditions) {
+		return fmt.Errorf("--power-readiness-profile-ids requires feature gate %s to be enabled", featuregates.GPUBindingConditions)
+	}
+
+	profileIDs, err := parseProfileIDs(flags.powerReadinessProfileIDs)
+	if err != nil {
+		return err
+	}
+	pr := powerReadinessConfig{profileIDs: profileIDs}
+	if err := pr.validate(); err != nil {
+		return err
+	}
+	if _, err := newBindingConditionsConfig(flags.bindingConditions, flags.bindingFailureConditions, pr); err != nil {
+		return err
 	}
 
 	if flags.consumableShares != "disabled" && !featuregates.Enabled(featuregates.ConsumableShares) {

--- a/cmd/gpu-kubelet-plugin/powerreadiness.go
+++ b/cmd/gpu-kubelet-plugin/powerreadiness.go
@@ -1,0 +1,484 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	resourceapi "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	resourcelisters "k8s.io/client-go/listers/resource/v1"
+	"k8s.io/klog/v2"
+)
+
+// Power readiness satisfies one of the binding conditions this driver publishes
+// (see bindingconditions.go) from the node itself, by checking which workload
+// power profiles a GPU is actually running under.
+//
+// This mirrors what NVIDIA DPS already does on Slurm. A job carries its power
+// settings in the job comment, including dps_wpps with the workload power
+// profile IDs, and a prolog runs dpsctl to create a resource group from the
+// nodes the scheduler allocated and apply those settings before the job starts.
+// Kubernetes has no prolog: the only hook between choosing a node and starting
+// the workload is NodePrepareResources, which runs after the pod is already
+// bound. Binding conditions are that missing hook, one phase earlier, and this
+// writer is the part that waits.
+//
+// Readiness is taken from the enforced mask, which NVML documents as the
+// "mask of currently enforced performance profiles post all arbitrations among
+// the requested profiles". A profile that was requested but lost an arbitration
+// is not active on the GPU, so requested is not good enough to start a workload
+// on.
+//
+// What this does not do is apply anything. Applying profiles is the power
+// manager's job, via dpsctl on Slurm today. If nothing applies them on a
+// Kubernetes cluster, the condition never becomes true and pods requesting
+// these GPUs wait out the scheduler's binding timeout, so this is only useful
+// alongside something that does.
+//
+// Only the readiness condition is ever written. Contention in these systems
+// arbitrates between profiles rather than failing outright, and a GPU running a
+// different profile is still a working GPU, so there is no honest way to turn
+// that into a binding failure from here.
+//
+// Profiles are reported only by hardware that supports them, Blackwell class
+// and later. A GPU that cannot report them is treated as ready and logged once:
+// the driver has no basis for holding a workload back on a GPU it cannot ask.
+type powerReadinessConfig struct {
+	// profileIDs are the workload power profile IDs that must be enforced on
+	// every allocated GPU before a pod may bind. Empty disables the mechanism.
+	profileIDs []int
+	// interval is how often claims are re-evaluated. The enforced mask is a
+	// polled value, not an event, so this is the resolution of the whole
+	// mechanism.
+	interval time.Duration
+}
+
+// Workload power profile IDs are numbered differently depending on who is
+// asking. DPS configures them out of band over Redfish and documents its range
+// as 3 to 258, while NVML and nvidia-smi use a value 3 lower, which is also the
+// bit index into nvmlMask255_t:
+//
+//	OOB value = NVML value + 3
+//
+// The IDs configured here are the DPS ones, so that they match the
+// dpsctl --workload-profile-ids invocation that applied them, and are converted
+// before the mask is indexed. Getting this wrong is invisible: the condition
+// simply never becomes true and pods wait out the binding timeout.
+const (
+	oobProfileIDOffset        = 3
+	minWorkloadPowerProfileID = oobProfileIDOffset
+	// The mask holds 255 bits, so the highest usable DPS ID is 254 + 3.
+	maxWorkloadPowerProfileID = 254 + oobProfileIDOffset
+	profileMaskBits           = 255
+)
+
+// The condition types this driver satisfies itself. They are owned by the
+// driver rather than configured: an operator who wants the driver to gate on
+// power says only how many watts, and naming the condition twice (once to
+// publish it, once to satisfy it) would be a way to get it wrong.
+//
+// A failure condition is published because the API server rejects a device
+// carrying one list without the other, but this driver never sets it: a GPU
+// clamped to a lower cap is still a working GPU.
+const (
+	powerReadyConditionType  = DriverName + "/power-ready"
+	powerFailedConditionType = DriverName + "/power-failed"
+)
+
+// defaultPowerReadinessInterval matches the scheduler's own poll period while
+// it waits in PreBind, so readiness is normally observed within one scheduler
+// tick without polling NVML more often than the result can be consumed.
+const defaultPowerReadinessInterval = 5 * time.Second
+
+func (c powerReadinessConfig) enabled() bool {
+	return len(c.profileIDs) > 0
+}
+
+func (c powerReadinessConfig) validate() error {
+	var errs []error
+	seen := make(map[int]bool, len(c.profileIDs))
+	for _, id := range c.profileIDs {
+		if id < minWorkloadPowerProfileID || id > maxWorkloadPowerProfileID {
+			errs = append(errs, fmt.Errorf("--power-readiness-profile-ids: %d is out of range, workload power profile IDs are %d to %d, the numbering DPS uses and three higher than the nvidia-smi value", id, minWorkloadPowerProfileID, maxWorkloadPowerProfileID))
+		}
+		if seen[id] {
+			errs = append(errs, fmt.Errorf("--power-readiness-profile-ids: duplicate profile ID %d", id))
+		}
+		seen[id] = true
+	}
+	return errors.Join(errs...)
+}
+
+// parseProfileIDs reads a comma separated list of workload power profile IDs.
+func parseProfileIDs(s string) ([]int, error) {
+	var out []int
+	for _, item := range strings.Split(s, ",") {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		id, err := strconv.Atoi(item)
+		if err != nil {
+			return nil, fmt.Errorf("--power-readiness-profile-ids: %q is not a number", item)
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+// maskHasProfile reports whether a DPS workload power profile ID is set in an
+// nvmlMask255_t, converting from the DPS numbering to the NVML bit index.
+func maskHasProfile(mask nvml.Mask255, oobID int) bool {
+	bit := oobID - oobProfileIDOffset
+	if bit < 0 || bit >= profileMaskBits {
+		return false
+	}
+	return mask.Mask[bit/32]&(1<<uint(bit%32)) != 0
+}
+
+// powerReadinessWriter marks the configured binding condition True on claims
+// allocated to this node once every allocated GPU reports a power limit at or
+// above the configured floor.
+//
+// It has to watch the API rather than react to a kubelet call: binding
+// conditions are evaluated before the pod is bound, so NodePrepareResources has
+// not been called and will not be called until this writer unblocks it.
+//
+// That has two costs worth understanding before enabling this at scale:
+//
+//   - There is no field selector for "claims allocated to my node", so each
+//     node watches every ResourceClaim in the cluster. Watch traffic and
+//     per-node cache both grow with the number of claims. A central controller
+//     would not have this problem, which is why the reference implementation
+//     puts its condition writer in one; a node-local writer is only used here
+//     because the readiness signal is node-local.
+//   - Writing claim status requires resourceclaims/status cluster-wide. On
+//     Kubernetes 1.36+ the resourceclaims/driver rule narrows that to claims
+//     allocated to this node, but on older clusters that narrowing does not
+//     exist and a compromised node could write any claim's device status.
+//
+// The claims informer is pinned to resource.k8s.io/v1, which is GA from
+// Kubernetes 1.34 and therefore present on every release that can serve the
+// binding condition fields this writer depends on.
+type powerReadinessWriter struct {
+	config *Config
+	state  *DeviceState
+	prc    powerReadinessConfig
+
+	lister resourcelisters.ResourceClaimLister
+
+	// unqueryable remembers devices whose profiles NVML cannot report, so that
+	// it is logged once rather than every interval.
+	unqueryableOnce sync.Map
+
+	// readCurrentProfiles reads the profile masks for one GPU. It exists as a
+	// field so that tests can exercise the readiness logic without NVML, which
+	// matters here more than usual: workload power profiles are reported only
+	// by Blackwell class hardware and later, so this cannot be run against a
+	// GPU on most machines.
+	readCurrentProfiles func(uuid string) (nvml.WorkloadPowerProfileCurrentProfiles, nvml.Return)
+}
+
+func newPowerReadinessWriter(config *Config, state *DeviceState) *powerReadinessWriter {
+	w := &powerReadinessWriter{config: config, state: state, prc: config.powerReadiness}
+	w.readCurrentProfiles = w.nvmlCurrentProfiles
+	return w
+}
+
+// nvmlCurrentProfiles is the real reader, asking NVML for the profile masks of
+// the GPU with the given UUID.
+//
+// Must be called with the DeviceState lock held: DeviceGetHandleByUUID writes
+// an unsynchronized handle cache that prepare and unprepare also write.
+func (w *powerReadinessWriter) nvmlCurrentProfiles(uuid string) (nvml.WorkloadPowerProfileCurrentProfiles, nvml.Return) {
+	handle, ret := w.state.nvdevlib.DeviceGetHandleByUUID(uuid)
+	if ret != nvml.SUCCESS {
+		return nvml.WorkloadPowerProfileCurrentProfiles{}, ret
+	}
+	return handle.WorkloadPowerProfileGetCurrentProfiles()
+}
+
+// Start brings up everything that can fail, so that a driver which cannot
+// satisfy the condition it is about to publish refuses to start at all. The
+// alternative is worse than a crash: the node would advertise
+// gpu.nvidia.com/power-ready with nothing able to set it, and every GPU pod
+// scheduled there would wait out the scheduler's binding timeout and be
+// rescheduled, forever, with no self-healing.
+//
+// The returned function runs the poll loop until ctx is canceled.
+func (w *powerReadinessWriter) Start(ctx context.Context) (func(), error) {
+	// NVML is reference counted and is only initialized for the duration of the
+	// operations that need it, so a long-lived reader has to hold its own
+	// reference. Without this every power read fails with ERROR_UNINITIALIZED.
+	//
+	// Use the driver's own wrapper rather than nvmllib.Init(): it passes
+	// INIT_FLAG_NO_GPUS, so a node whose GPUs are all bound to vfio-pci still
+	// initializes instead of failing and leaving the published condition with
+	// nobody to satisfy it.
+	if w.state.nvdevlib == nil || w.state.nvdevlib.nvmllib == nil {
+		return nil, errors.New("nvml library is nil")
+	}
+	if err := w.state.nvdevlib.Init(); err != nil {
+		return nil, fmt.Errorf("initializing NVML: %w", err)
+	}
+
+	factory := informers.NewSharedInformerFactory(w.config.clientsets.Core, 10*time.Minute)
+	informer := factory.Resource().V1().ResourceClaims()
+	w.lister = informer.Lister()
+
+	factory.Start(ctx.Done())
+	for typ, ok := range factory.WaitForCacheSync(ctx.Done()) {
+		if !ok {
+			w.state.nvdevlib.alwaysShutdown()
+			return nil, fmt.Errorf("failed to sync informer cache for %v", typ)
+		}
+	}
+
+	klog.Infof("Power readiness writer started: will set %q on claims allocated to this node once workload power profiles %v are enforced on every allocated GPU (checked every %s)",
+		powerReadyConditionType, w.prc.profileIDs, w.prc.interval)
+
+	return func() {
+		defer w.state.nvdevlib.alwaysShutdown()
+		ticker := time.NewTicker(w.prc.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				w.reconcileAll(ctx)
+			}
+		}
+	}, nil
+}
+
+func (w *powerReadinessWriter) reconcileAll(ctx context.Context) {
+	claims, err := w.lister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Power readiness: listing ResourceClaims failed: %v", err)
+		return
+	}
+	for _, claim := range claims {
+		if err := w.reconcile(ctx, claim); err != nil {
+			klog.Errorf("Power readiness: claim %s/%s: %v", claim.Namespace, claim.Name, err)
+		}
+	}
+}
+
+// devicesToGate returns the allocation results on this node that carry the
+// condition this writer satisfies and do not have it set to True yet.
+func (w *powerReadinessWriter) devicesToGate(claim *resourceapi.ResourceClaim) []resourceapi.DeviceRequestAllocationResult {
+	if claim.Status.Allocation == nil {
+		return nil
+	}
+	var out []resourceapi.DeviceRequestAllocationResult
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		if result.Driver != DriverName || result.Pool != w.config.flags.nodeName {
+			continue
+		}
+		if !slices.Contains(result.BindingConditions, powerReadyConditionType) {
+			continue
+		}
+		if conditionIsTrue(claim, result, powerReadyConditionType) {
+			continue
+		}
+		out = append(out, result)
+	}
+	return out
+}
+
+func (w *powerReadinessWriter) reconcile(ctx context.Context, claim *resourceapi.ResourceClaim) error {
+	results := w.devicesToGate(claim)
+	if len(results) == 0 {
+		return nil
+	}
+
+	for _, result := range results {
+		ready, err := w.deviceHasProfiles(result.Device)
+		if err != nil {
+			return err
+		}
+		if !ready {
+			klog.V(4).Infof("Power readiness: claim %s/%s device %s not ready yet, workload power profiles %v are not all enforced",
+				claim.Namespace, claim.Name, result.Device, w.prc.profileIDs)
+			return nil
+		}
+	}
+
+	// Every gated device on this node is at or above the floor.
+	updated := claim.DeepCopy()
+	now := metav1.Now()
+	for _, result := range results {
+		setDeviceCondition(updated, result, metav1.Condition{
+			Type:               powerReadyConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             "WorkloadPowerProfilesEnforced",
+			Message:            fmt.Sprintf("workload power profiles %v are enforced", w.prc.profileIDs),
+			LastTransitionTime: now,
+		})
+	}
+
+	_, err := w.config.clientsets.Resource.ResourceClaims(updated.Namespace).UpdateStatus(ctx, updated, metav1.UpdateOptions{})
+	switch {
+	case apierrors.IsConflict(err):
+		// Someone else wrote the claim first; the next tick works from a
+		// refreshed cache.
+		klog.V(5).Infof("Power readiness: conflict updating claim %s/%s, retrying next interval", updated.Namespace, updated.Name)
+		return nil
+	case apierrors.IsNotFound(err):
+		return nil
+	case err != nil:
+		return fmt.Errorf("updating status: %w", err)
+	}
+
+	klog.Infof("Power readiness: set %q on claim %s/%s for %d device(s)",
+		powerReadyConditionType, updated.Namespace, updated.Name, len(results))
+	return nil
+}
+
+// deviceHasProfiles reports whether every configured workload power profile is
+// currently enforced on the GPU backing the named device.
+//
+// A device whose profiles NVML cannot report (a GPU bound to vfio-pci, or
+// hardware older than Blackwell) is treated as ready: the driver has no basis
+// for holding a workload back on a GPU it cannot ask, and blocking would strand
+// it until the scheduler's binding timeout.
+func (w *powerReadinessWriter) deviceHasProfiles(deviceName string) (bool, error) {
+	// Both the allocatable device map and the NVML handle cache inside
+	// DeviceGetHandleByUUID are written by prepare/unprepare while they hold
+	// the DeviceState lock. Reading them from this goroutine without it is a
+	// concurrent map access, which is fatal in Go rather than merely racy. The
+	// read below is an NVML query measured in microseconds, so holding the lock
+	// across it does not meaningfully delay a prepare.
+	w.state.Lock()
+	defer w.state.Unlock()
+
+	uuid, ok := w.gpuUUIDForDevice(DeviceName(deviceName))
+	if !ok {
+		w.logUnqueryableOnce(deviceName, "no GPU UUID could be resolved for it")
+		return true, nil
+	}
+
+	current, ret := w.readCurrentProfiles(uuid)
+	if ret == nvml.ERROR_NOT_SUPPORTED {
+		w.logUnqueryableOnce(deviceName, "NVML reports workload power profiles as unsupported on this GPU")
+		return true, nil
+	}
+	if ret != nvml.SUCCESS {
+		return false, fmt.Errorf("reading workload power profiles for %s: %v", uuid, ret)
+	}
+
+	for _, id := range w.prc.profileIDs {
+		if !maskHasProfile(current.EnforcedProfilesMask, id) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// gpuUUIDForDevice maps a published device name to the UUID of the physical GPU
+// whose power limit governs it. MIG partitions do not have their own power
+// budget, so they resolve to their parent.
+//
+// Must be called with the DeviceState lock held.
+func (w *powerReadinessWriter) gpuUUIDForDevice(name DeviceName) (string, bool) {
+	for _, devices := range w.state.perGPUAllocatable.allocatablesMap {
+		device, ok := devices[name]
+		if !ok {
+			continue
+		}
+		switch {
+		case device.Gpu != nil:
+			return device.Gpu.UUID, true
+		case device.MigStatic != nil:
+			return device.MigStatic.ParentUUID, true
+		case device.MigDynamic != nil && device.MigDynamic.Parent != nil:
+			return device.MigDynamic.Parent.UUID, true
+		}
+		// A VFIO device is bound to vfio-pci and is not visible to NVML.
+		return "", false
+	}
+	return "", false
+}
+
+func (w *powerReadinessWriter) logUnqueryableOnce(deviceName, why string) {
+	if _, seen := w.unqueryableOnce.LoadOrStore(deviceName, struct{}{}); seen {
+		return
+	}
+	klog.Warningf("Power readiness: treating device %s as ready because %s; %q will be satisfied for it without a power check",
+		deviceName, why, powerReadyConditionType)
+}
+
+// conditionIsTrue reports whether the claim already records the condition as
+// True for the given device.
+func conditionIsTrue(claim *resourceapi.ResourceClaim, result resourceapi.DeviceRequestAllocationResult, conditionType string) bool {
+	for _, status := range claim.Status.Devices {
+		if status.Driver != result.Driver || status.Pool != result.Pool || status.Device != result.Device {
+			continue
+		}
+		for _, condition := range status.Conditions {
+			if condition.Type == conditionType {
+				return condition.Status == metav1.ConditionTrue
+			}
+		}
+	}
+	return false
+}
+
+// setDeviceCondition records a condition for one device, leaving every other
+// device entry -- including those written by other drivers -- untouched.
+func setDeviceCondition(claim *resourceapi.ResourceClaim, result resourceapi.DeviceRequestAllocationResult, condition metav1.Condition) {
+	for i := range claim.Status.Devices {
+		status := &claim.Status.Devices[i]
+		if status.Driver != result.Driver || status.Pool != result.Pool || status.Device != result.Device {
+			continue
+		}
+		for j := range status.Conditions {
+			if status.Conditions[j].Type == condition.Type {
+				if status.Conditions[j].Status != condition.Status {
+					status.Conditions[j] = condition
+				}
+				return
+			}
+		}
+		status.Conditions = append(status.Conditions, condition)
+		return
+	}
+	status := resourceapi.AllocatedDeviceStatus{
+		Driver:     result.Driver,
+		Pool:       result.Pool,
+		Device:     result.Device,
+		Conditions: []metav1.Condition{condition},
+	}
+	if result.ShareID != nil {
+		shareID := string(*result.ShareID)
+		status.ShareID = &shareID
+	}
+	claim.Status.Devices = append(claim.Status.Devices, status)
+}

--- a/cmd/gpu-kubelet-plugin/powerreadiness_test.go
+++ b/cmd/gpu-kubelet-plugin/powerreadiness_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPowerReadinessValidate(t *testing.T) {
+	require.NoError(t, powerReadinessConfig{}.validate())
+	require.NoError(t, powerReadinessConfig{profileIDs: []int{3, 5, 257}}.validate())
+	require.ErrorContains(t, powerReadinessConfig{profileIDs: []int{2}}.validate(), "out of range",
+		"2 is below the DPS range and would map to a negative bit")
+	require.ErrorContains(t, powerReadinessConfig{profileIDs: []int{258}}.validate(), "out of range")
+	require.ErrorContains(t, powerReadinessConfig{profileIDs: []int{5, 5}}.validate(), "duplicate profile ID")
+}
+
+func TestPowerReadinessEnabled(t *testing.T) {
+	require.False(t, powerReadinessConfig{}.enabled())
+	require.False(t, powerReadinessConfig{profileIDs: []int{}}.enabled())
+	require.True(t, powerReadinessConfig{profileIDs: []int{3}}.enabled())
+}
+
+func TestParseProfileIDs(t *testing.T) {
+	ids, err := parseProfileIDs("")
+	require.NoError(t, err)
+	require.Empty(t, ids)
+
+	ids, err = parseProfileIDs(" 1 , ,3 ")
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 3}, ids)
+
+	_, err = parseProfileIDs("1,nope")
+	require.ErrorContains(t, err, "is not a number")
+}
+
+// maskHasProfile converts a DPS profile ID to an NVML bit index before testing
+// the mask. That conversion cannot be exercised on the hardware available here
+// (workload power profiles are Blackwell class and later) and a mistake in it is
+// silent, so it is pinned down explicitly.
+func TestMaskHasProfile(t *testing.T) {
+	// DPS ID 3 is NVML bit 0, per "OOB value = NVML value + 3".
+	var m nvml.Mask255
+	m.Mask[0] = 1
+	require.True(t, maskHasProfile(m, 3), "DPS ID 3 is bit 0")
+	require.False(t, maskHasProfile(m, 0), "a raw NVML index must not be accepted as a DPS ID")
+	require.False(t, maskHasProfile(m, 4))
+
+	for _, tc := range []struct {
+		oobID int
+		bit   int
+	}{{3, 0}, {4, 1}, {34, 31}, {35, 32}, {66, 63}, {67, 64}, {257, 254}} {
+		var mask nvml.Mask255
+		mask.Mask[tc.bit/32] = 1 << uint(tc.bit%32)
+		require.True(t, maskHasProfile(mask, tc.oobID), "DPS ID %d should be bit %d", tc.oobID, tc.bit)
+		require.False(t, maskHasProfile(mask, tc.oobID+1))
+	}
+
+	// Out of range IDs never match rather than indexing outside the mask.
+	full := nvml.Mask255{Mask: [8]uint32{^uint32(0), ^uint32(0), ^uint32(0), ^uint32(0), ^uint32(0), ^uint32(0), ^uint32(0), ^uint32(0)}}
+	require.False(t, maskHasProfile(full, 2))
+	require.False(t, maskHasProfile(full, 258))
+	require.True(t, maskHasProfile(full, 257))
+}
+
+// writerForTest builds a writer with just enough config to exercise claim
+// selection, which needs no NVML.
+func writerForTest(nodeName string) *powerReadinessWriter {
+	return &powerReadinessWriter{
+		config: &Config{flags: &Flags{nodeName: nodeName}},
+		prc:    powerReadinessConfig{profileIDs: []int{4}, interval: time.Second},
+	}
+}
+
+func allocatedClaim(driver, pool, device string, conditions []string) *resourceapi.ResourceClaim {
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "claim"},
+		Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{
+					Results: []resourceapi.DeviceRequestAllocationResult{{
+						Driver:            driver,
+						Pool:              pool,
+						Device:            device,
+						BindingConditions: conditions,
+					}},
+				},
+			},
+		},
+	}
+}
+
+func TestDevicesToGate(t *testing.T) {
+	w := writerForTest("node-a")
+
+	t.Run("unallocated claim is ignored", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{powerReadyConditionType})
+		claim.Status.Allocation = nil
+		require.Empty(t, w.devicesToGate(claim))
+	})
+
+	t.Run("another driver's device is ignored", func(t *testing.T) {
+		claim := allocatedClaim("other.example.com", "node-a", "gpu-0", []string{powerReadyConditionType})
+		require.Empty(t, w.devicesToGate(claim))
+	})
+
+	t.Run("another node's pool is ignored", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-b", "gpu-0", []string{powerReadyConditionType})
+		require.Empty(t, w.devicesToGate(claim))
+	})
+
+	t.Run("device without our condition is ignored", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{"other.example.com/ready"})
+		require.Empty(t, w.devicesToGate(claim))
+	})
+
+	t.Run("device on this node with our condition is selected", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{powerReadyConditionType})
+		gated := w.devicesToGate(claim)
+		require.Len(t, gated, 1)
+		require.Equal(t, "gpu-0", gated[0].Device)
+	})
+
+	t.Run("device already marked ready is not selected again", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{powerReadyConditionType})
+		setDeviceCondition(claim, claim.Status.Allocation.Devices.Results[0], metav1.Condition{
+			Type:   powerReadyConditionType,
+			Status: metav1.ConditionTrue,
+		})
+		require.Empty(t, w.devicesToGate(claim))
+	})
+
+	t.Run("a False condition is still selected", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{powerReadyConditionType})
+		setDeviceCondition(claim, claim.Status.Allocation.Devices.Results[0], metav1.Condition{
+			Type:   powerReadyConditionType,
+			Status: metav1.ConditionFalse,
+		})
+		require.Len(t, w.devicesToGate(claim), 1)
+	})
+}
+
+func TestSetDeviceCondition(t *testing.T) {
+	result := resourceapi.DeviceRequestAllocationResult{
+		Driver: DriverName, Pool: "node-a", Device: "gpu-0",
+	}
+	ready := metav1.Condition{Type: powerReadyConditionType, Status: metav1.ConditionTrue, Reason: "PowerLimitSatisfied"}
+
+	t.Run("creates an entry when the device has no status yet", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{powerReadyConditionType})
+		setDeviceCondition(claim, result, ready)
+
+		require.Len(t, claim.Status.Devices, 1)
+		require.Equal(t, DriverName, claim.Status.Devices[0].Driver)
+		require.Equal(t, "gpu-0", claim.Status.Devices[0].Device)
+		require.Len(t, claim.Status.Devices[0].Conditions, 1)
+		require.Equal(t, metav1.ConditionTrue, claim.Status.Devices[0].Conditions[0].Status)
+	})
+
+	t.Run("leaves other drivers' entries untouched", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{powerReadyConditionType})
+		claim.Status.Devices = []resourceapi.AllocatedDeviceStatus{{
+			Driver: "other.example.com", Pool: "node-a", Device: "nic-0",
+			Conditions: []metav1.Condition{{Type: "other.example.com/ready", Status: metav1.ConditionTrue}},
+		}}
+
+		setDeviceCondition(claim, result, ready)
+
+		require.Len(t, claim.Status.Devices, 2)
+		require.Equal(t, "other.example.com", claim.Status.Devices[0].Driver)
+		require.Len(t, claim.Status.Devices[0].Conditions, 1)
+		require.Equal(t, DriverName, claim.Status.Devices[1].Driver)
+	})
+
+	t.Run("preserves a foreign condition on our own device entry", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{powerReadyConditionType})
+		claim.Status.Devices = []resourceapi.AllocatedDeviceStatus{{
+			Driver: DriverName, Pool: "node-a", Device: "gpu-0",
+			Conditions: []metav1.Condition{{Type: "someone.else/thing", Status: metav1.ConditionTrue}},
+		}}
+
+		setDeviceCondition(claim, result, ready)
+
+		require.Len(t, claim.Status.Devices, 1)
+		require.Len(t, claim.Status.Devices[0].Conditions, 2)
+		require.Equal(t, "someone.else/thing", claim.Status.Devices[0].Conditions[0].Type)
+		require.Equal(t, powerReadyConditionType, claim.Status.Devices[0].Conditions[1].Type)
+	})
+
+	t.Run("flips an existing condition rather than duplicating it", func(t *testing.T) {
+		claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{powerReadyConditionType})
+		setDeviceCondition(claim, result, metav1.Condition{Type: powerReadyConditionType, Status: metav1.ConditionFalse})
+		setDeviceCondition(claim, result, ready)
+
+		require.Len(t, claim.Status.Devices, 1)
+		require.Len(t, claim.Status.Devices[0].Conditions, 1)
+		require.Equal(t, metav1.ConditionTrue, claim.Status.Devices[0].Conditions[0].Status)
+		require.Equal(t, "PowerLimitSatisfied", claim.Status.Devices[0].Conditions[0].Reason)
+	})
+}
+
+func TestConditionIsTrue(t *testing.T) {
+	result := resourceapi.DeviceRequestAllocationResult{
+		Driver: DriverName, Pool: "node-a", Device: "gpu-0",
+	}
+	claim := allocatedClaim(DriverName, "node-a", "gpu-0", []string{powerReadyConditionType})
+
+	require.False(t, conditionIsTrue(claim, result, powerReadyConditionType))
+
+	setDeviceCondition(claim, result, metav1.Condition{Type: powerReadyConditionType, Status: metav1.ConditionFalse})
+	require.False(t, conditionIsTrue(claim, result, powerReadyConditionType))
+
+	setDeviceCondition(claim, result, metav1.Condition{Type: powerReadyConditionType, Status: metav1.ConditionTrue})
+	require.True(t, conditionIsTrue(claim, result, powerReadyConditionType))
+
+	// A different device on the same claim must not be confused with ours.
+	other := resourceapi.DeviceRequestAllocationResult{
+		Driver: DriverName, Pool: "node-a", Device: "gpu-1",
+	}
+	require.False(t, conditionIsTrue(claim, other, powerReadyConditionType))
+}
+
+// profileMask builds an nvmlMask255_t with the given profile IDs set.
+// profileMask builds a mask from DPS profile IDs, applying the same offset the
+// GPU firmware reports through NVML.
+func profileMask(oobIDs ...int) nvml.Mask255 {
+	var m nvml.Mask255
+	for _, id := range oobIDs {
+		bit := id - oobProfileIDOffset
+		m.Mask[bit/32] |= 1 << uint(bit%32)
+	}
+	return m
+}
+
+// writerWithGPU returns a writer whose node has one GPU named gpu-0, with the
+// NVML read stubbed out.
+func writerWithGPU(profileIDs []int, read func(uuid string) (nvml.WorkloadPowerProfileCurrentProfiles, nvml.Return)) *powerReadinessWriter {
+	return &powerReadinessWriter{
+		config: &Config{flags: &Flags{nodeName: "node-a"}},
+		state: &DeviceState{
+			perGPUAllocatable: &PerGPUAllocatableDevices{
+				allocatablesMap: map[PCIBusID]AllocatableDevices{
+					"0000:00:04.0": {"gpu-0": &AllocatableDevice{Gpu: &GpuInfo{UUID: "GPU-test"}}},
+				},
+			},
+		},
+		prc:                 powerReadinessConfig{profileIDs: profileIDs, interval: time.Second},
+		readCurrentProfiles: read,
+	}
+}
+
+func TestDeviceHasProfiles(t *testing.T) {
+	enforced := func(ids ...int) func(string) (nvml.WorkloadPowerProfileCurrentProfiles, nvml.Return) {
+		return func(string) (nvml.WorkloadPowerProfileCurrentProfiles, nvml.Return) {
+			return nvml.WorkloadPowerProfileCurrentProfiles{EnforcedProfilesMask: profileMask(ids...)}, nvml.SUCCESS
+		}
+	}
+
+	t.Run("ready when every configured profile is enforced", func(t *testing.T) {
+		w := writerWithGPU([]int{4, 6}, enforced(4, 6, 10))
+		ready, err := w.deviceHasProfiles("gpu-0")
+		require.NoError(t, err)
+		require.True(t, ready)
+	})
+
+	t.Run("not ready when one profile is missing", func(t *testing.T) {
+		w := writerWithGPU([]int{4, 6}, enforced(4))
+		ready, err := w.deviceHasProfiles("gpu-0")
+		require.NoError(t, err)
+		require.False(t, ready)
+	})
+
+	t.Run("requested but not enforced does not count", func(t *testing.T) {
+		// A profile can be requested and then lose arbitration. Only the
+		// enforced mask says what is actually active on the GPU.
+		w := writerWithGPU([]int{4}, func(string) (nvml.WorkloadPowerProfileCurrentProfiles, nvml.Return) {
+			return nvml.WorkloadPowerProfileCurrentProfiles{
+				RequestedProfilesMask: profileMask(4),
+				EnforcedProfilesMask:  profileMask(5),
+			}, nvml.SUCCESS
+		})
+		ready, err := w.deviceHasProfiles("gpu-0")
+		require.NoError(t, err)
+		require.False(t, ready)
+	})
+
+	t.Run("hardware without profile support is treated as ready", func(t *testing.T) {
+		w := writerWithGPU([]int{4}, func(string) (nvml.WorkloadPowerProfileCurrentProfiles, nvml.Return) {
+			return nvml.WorkloadPowerProfileCurrentProfiles{}, nvml.ERROR_NOT_SUPPORTED
+		})
+		ready, err := w.deviceHasProfiles("gpu-0")
+		require.NoError(t, err)
+		require.True(t, ready, "blocking on a GPU that cannot be asked would strand the pod")
+	})
+
+	t.Run("other NVML errors surface", func(t *testing.T) {
+		w := writerWithGPU([]int{4}, func(string) (nvml.WorkloadPowerProfileCurrentProfiles, nvml.Return) {
+			return nvml.WorkloadPowerProfileCurrentProfiles{}, nvml.ERROR_GPU_IS_LOST
+		})
+		_, err := w.deviceHasProfiles("gpu-0")
+		require.ErrorContains(t, err, "reading workload power profiles")
+	})
+
+	t.Run("a device with no resolvable GPU is treated as ready", func(t *testing.T) {
+		w := writerWithGPU([]int{4}, enforced(4))
+		ready, err := w.deviceHasProfiles("gpu-does-not-exist")
+		require.NoError(t, err)
+		require.True(t, ready)
+	})
+}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -309,6 +309,18 @@ spec:
         - name: CONSUMABLE_SHARES
           value: "{{ .Values.consumableShares }}"
         {{- end }}
+        {{- if .Values.bindingConditions }}
+        - name: BINDING_CONDITIONS
+          value: "{{ join "," .Values.bindingConditions }}"
+        {{- end }}
+        {{- if .Values.bindingFailureConditions }}
+        - name: BINDING_FAILURE_CONDITIONS
+          value: "{{ join "," .Values.bindingFailureConditions }}"
+        {{- end }}
+        {{- if (.Values.powerReadiness | default dict).profileIds }}
+        - name: POWER_READINESS_PROFILE_IDS
+          value: "{{- range $i, $v := .Values.powerReadiness.profileIds }}{{ if $i }},{{ end }}{{ $v }}{{ end }}"
+        {{- end }}
         {{- if .Values.featureGates }}
         - name: FEATURE_GATES
           value: "{{ range $key, $value := .Values.featureGates }}{{ $key }}={{ $value }},{{ end }}"

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml
@@ -11,6 +11,22 @@ rules:
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceclaims"]
   verbs: ["get", "list", "watch"]
+{{- if (.Values.powerReadiness | default dict).profileIds }}
+# Required to satisfy KEP-5007 binding conditions from the node: the plugin
+# marks the configured condition True in ResourceClaim.status.devices once the
+# allocated GPUs report a sufficient enforced power limit.
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/status"]
+  verbs: ["update"]
+# Kubernetes 1.36+ additionally enforces per-driver authorization for
+# status.devices writes via DRAResourceClaimGranularStatusAuthorization. As a
+# node-local writer we use the "associated-node" verbs for our own driver name.
+# This rule is inert on clusters where that gate is off.
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/driver"]
+  verbs: ["associated-node:update", "associated-node:patch"]
+  resourceNames: ["gpu.nvidia.com"]
+{{- end }}
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceslices"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/validation.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/validation.yaml
@@ -42,6 +42,55 @@
 {{- fail $error }}
 {{- end }}
 
+{{- $gpuBindingConditions := and .Values.featureGates (and (hasKey .Values.featureGates "GPUBindingConditions") .Values.featureGates.GPUBindingConditions) }}
+{{- $profileIds := (.Values.powerReadiness | default dict).profileIds | default list }}
+{{- $bc := .Values.bindingConditions | default list }}
+{{- $bfc := .Values.bindingFailureConditions | default list }}
+{{- if $profileIds }}
+{{- $bc = append $bc "gpu.nvidia.com/power-ready" | uniq }}
+{{- $bfc = append $bfc "gpu.nvidia.com/power-failed" | uniq }}
+{{- end }}
+
+{{- if or .Values.bindingConditions .Values.bindingFailureConditions }}
+{{- if not $gpuBindingConditions }}
+{{- $error := "" }}
+{{- $error = printf "%s\n\n'bindingConditions'/'bindingFailureConditions' are set, but the 'GPUBindingConditions' feature gate is not enabled." $error }}
+{{- $error = printf "%s\nThe kubelet plugin refuses to start in that combination, so this would take the 'gpus' container into CrashLoopBackOff on every node." $error }}
+{{- $error = printf "%s\n" $error }}
+{{- $error = printf "%s\n    --set 'featureGates.GPUBindingConditions=true'" $error }}
+{{- fail $error }}
+{{- end }}
+{{- end }}
+
+{{- if or $bc $bfc }}
+{{- if or (not $bc) (not $bfc) }}
+{{- $error := "" }}
+{{- $error = printf "%s\n\nBinding conditions and binding failure conditions must be set together (effective lists: %v / %v)." $error $bc $bfc }}
+{{- $error = printf "%s\nThe API server rejects any ResourceSlice whose devices carry one without the other, which would make this node's GPUs disappear from the cluster." $error }}
+{{- fail $error }}
+{{- end }}
+{{- if or (gt (len $bc) 4) (gt (len $bfc) 4) }}
+{{- $error := "" }}
+{{- $error = printf "%s\n\nAt most 4 binding conditions and 4 binding failure conditions are allowed; this configuration produces %d and %d." $error (len $bc) (len $bfc) }}
+{{- if $profileIds }}
+{{- $error = printf "%s\nNote that 'powerReadiness.profileIds' adds one to each list (gpu.nvidia.com/power-ready and gpu.nvidia.com/power-failed)." $error }}
+{{- end }}
+{{- $error = printf "%s\nThe kubelet plugin refuses to start otherwise." $error }}
+{{- fail $error }}
+{{- end }}
+{{- end }}
+
+{{- if $profileIds }}
+{{- if not $gpuBindingConditions }}
+{{- $error := "" }}
+{{- $error = printf "%s\n\n'powerReadiness.profileIds' is set, but the 'GPUBindingConditions' feature gate is not enabled." $error }}
+{{- $error = printf "%s\nThe kubelet plugin refuses to start in that combination." $error }}
+{{- $error = printf "%s\n" $error }}
+{{- $error = printf "%s\n    --set 'featureGates.GPUBindingConditions=true'" $error }}
+{{- fail $error }}
+{{- end }}
+{{- end }}
+
 {{- if .Values.nvidiaCtkPath }}
 {{- $error := "" }}
 {{- $error = printf "%s\nSetting a user-defined nvidiaCtkPath is no longer supported. It can simply be removed without consequence." $error }}

--- a/deployments/helm/dra-driver-nvidia-gpu/values.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/values.yaml
@@ -41,6 +41,84 @@ gpuResourcesEnabledOverride: false
 # Configure consumable shares support ("disabled", "memory", "unlimited", or a positive integer)
 consumableShares: ""
 
+# KEP-5007 device binding conditions published on this driver's GPU devices.
+#
+# The scheduler holds a pod in PreBind until every condition type listed in
+# bindingConditions is True in the ResourceClaim's per-device status, and
+# reschedules the pod if any type in bindingFailureConditions becomes True.
+# This lets an external controller gate pod binding on device readiness the
+# driver cannot observe itself, e.g. an out-of-band power-management service
+# bringing GPUs to their target power state before a workload starts.
+#
+# This driver only publishes the condition types; it never satisfies them.
+# WARNING: setting bindingConditions without deploying a controller that writes
+# these conditions prevents every pod requesting a GPU from this driver from
+# ever binding: each one waits for the scheduler's binding timeout (10 minutes
+# by default) and is then rescheduled, indefinitely.
+#
+# Requires featureGates.GPUBindingConditions=true here, and the
+# DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates on
+# BOTH the kube-apiserver and the kube-scheduler. A scheduler without them
+# treats every device carrying binding conditions as unselectable, so all GPU
+# pods stay Pending with no available devices -- and because the API server
+# stored the fields just fine, nothing in this driver's logs will say why.
+# DRADeviceBindingConditions is beta and on by default since Kubernetes 1.36.
+#
+# The two lists must be set together: the API server rejects a device that
+# carries one without the other. At most 4 entries each; entries must be valid
+# condition types (label names) and must not overlap.
+#
+# Example:
+#   bindingConditions:
+#     - power.nvidia.com/ready
+#   bindingFailureConditions:
+#     - power.nvidia.com/failed
+bindingConditions: []
+bindingFailureConditions: []
+
+# powerReadiness lets this driver gate binding on GPU workload power profiles by
+# itself, instead of relying on an external controller.
+#
+# Setting profileIds makes the driver publish its own condition pair
+# (gpu.nvidia.com/power-ready and gpu.nvidia.com/power-failed) and hold a pod
+# before binding until NVML reports every listed profile as enforced on each GPU
+# allocated to it from that node.
+#
+# This mirrors what NVIDIA DPS already does on Slurm, where a job carries
+# dps_wpps in its comment and a prolog runs dpsctl to apply those profiles to the
+# allocated nodes before the job starts. Kubernetes has no prolog, and binding
+# conditions are the closest equivalent.
+#
+# The driver only waits; applying the profiles remains the power manager's job.
+# If nothing applies them, the condition never becomes true and pods requesting
+# these GPUs wait out the scheduler's binding timeout, so only enable this
+# alongside something that does apply them.
+#
+# Readiness is taken from NVML's enforced profile mask, which DPS documents as
+# the profiles "currently active on the GPU" after the firmware arbitrates
+# between requested ones. A profile that was requested but lost arbitration is
+# therefore not treated as ready.
+#
+# The IDs are the ones DPS uses, matching dpsctl --workload-profile-ids, and run
+# from 3 to 257 here. DPS applies profiles out of band over Redfish and its
+# numbering is three higher than the value nvidia-smi reports for the same
+# profile, so passing an nvidia-smi value would silently never match. The driver
+# converts before reading the NVML mask.
+#
+# WPPS is not supported before Blackwell. GPUs that cannot report profiles,
+# including any bound to vfio-pci, are treated as ready and logged. Only the
+# readiness condition is ever set; a GPU running a different profile is not a
+# binding failure.
+#
+# Enabling this consumes one of the four binding condition slots. Requires
+# featureGates.GPUBindingConditions=true.
+#
+# Example, matching `dpsctl resource-group create --workload-profile-ids 5,7`:
+#   powerReadiness:
+#     profileIds: [5, 7]
+powerReadiness:
+  profileIds: []
+
 allowDefaultNamespace: false
 
 # resourceApiVersion sets the resource.k8s.io API version used for DRA resources (DeviceClass,
@@ -118,6 +196,7 @@ resources:
 #   HostManagedIMEXDaemon: false       # Gate allowing resources.computeDomains.imex.mode=hostManaged
 #   DRAListTypeAttributes: false       # Publish list-valued DRA device attributes
 #   ConsumableShares: false            # Publish consumable capacity and multi-allocation support for devices
+#   GPUBindingConditions: false        # Publish KEP-5007 binding conditions on GPU devices (see bindingConditions)
 featureGates: {}
 
 # Log verbosity for all components. Zero or greater, higher number means higher

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -97,6 +97,20 @@ const (
 	// of the same name enabled before enabling this in the driver.
 	DRAListTypeAttributes featuregate.Feature = "DRAListTypeAttributes"
 
+	// GPUBindingConditions enables publishing operator-configured KEP-5007
+	// binding conditions on the GPU devices advertised by the GPU kubelet
+	// plugin, via --binding-conditions / --binding-failure-conditions.
+	//
+	// The driver only publishes the condition types; an external controller
+	// must satisfy them by writing to claim.status.devices[].conditions (for
+	// example a power-management service that brings GPUs to their target
+	// power state before a workload is allowed to start). With condition types
+	// configured but no such writer deployed, every pod requesting a GPU from
+	// this driver waits for the scheduler's binding timeout and is then
+	// rescheduled. The cluster must have the Kubernetes DRADeviceBindingConditions
+	// and DRAResourceClaimDeviceStatus feature gates enabled.
+	GPUBindingConditions featuregate.Feature = "GPUBindingConditions"
+
 	// ConsumableShares enables publishing consumable capacity and multi-allocation
 	// (AllowMultipleAllocations) support for devices in ResourceSlices, allowing
 	// multiple ResourceClaims to share the same GPU or MIG device when configured
@@ -199,6 +213,13 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 		},
 	},
 	ConsumableShares: {
+		{
+			Default:    false,
+			PreRelease: featuregate.Alpha,
+			Version:    version.MajorMinor(0, 5),
+		},
+	},
+	GPUBindingConditions: {
 		{
 			Default:    false,
 			PreRelease: featuregate.Alpha,

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -189,6 +189,7 @@ tests-mock-nvml: MOCK_NVML := true
 tests-mock-nvml: runner-image
 	$(call RUN_BATS, \
 		tests/bats/test_gpu_basic.bats \
+		tests/bats/test_gpu_binding_conditions.bats \
 		tests/bats/test_gpu_cuda_workloads.bats \
 		tests/bats/test_gpu_sharing.bats \
 		tests/bats/test_gpu_robustness.bats \
@@ -206,6 +207,7 @@ tests-mock-nvml: runner-image
 tests-gpu-single: runner-image
 	$(call RUN_BATS, \
 		tests/bats/test_gpu_basic.bats \
+		tests/bats/test_gpu_binding_conditions.bats \
 		tests/bats/test_gpu_cuda_workloads.bats \
 		tests/bats/test_gpu_dynmig.bats \
 		tests/bats/test_gpu_sharing.bats \

--- a/tests/bats/specs/gpu-binding-conditions-failure.yaml
+++ b/tests/bats/specs/gpu-binding-conditions-failure.yaml
@@ -1,0 +1,33 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-bc-fail-gpu
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bc-pod-1
+  labels:
+    env: batssuite
+spec:
+  restartPolicy: Never
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-bc-fail-gpu

--- a/tests/bats/specs/gpu-binding-conditions.yaml
+++ b/tests/bats/specs/gpu-binding-conditions.yaml
@@ -1,0 +1,33 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-bc-gpu
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bc-pod-0
+  labels:
+    env: batssuite
+spec:
+  restartPolicy: Never
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-bc-gpu

--- a/tests/bats/test_gpu_binding_conditions.bats
+++ b/tests/bats/test_gpu_binding_conditions.bats
@@ -1,0 +1,183 @@
+# shellcheck disable=SC2148
+# shellcheck disable=SC2329
+
+# Tests for KEP-5007 device binding conditions published on GPU devices.
+# Requires feature gate: GPUBindingConditions=true, and a cluster with the
+# DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates
+# (both default-on since Kubernetes 1.36 and 1.37 respectively).
+#
+# The driver only publishes the condition types on its devices; satisfying them
+# is the job of an external controller (for example an out-of-band power
+# management service). These tests play that controller with kubectl, which is
+# also what makes them hardware-independent: nothing here depends on what the
+# external system actually does, only on the contract with the scheduler.
+
+_BC_READY="power.nvidia.com/ready"
+_BC_FAILED="power.nvidia.com/failed"
+
+setup_file() {
+  load 'helpers.sh'
+  _common_setup
+  local _iargs=("--set" "logVerbosity=6"
+    "--set" "featureGates.GPUBindingConditions=true"
+    "--set" "bindingConditions={power.nvidia.com/ready}"
+    "--set" "bindingFailureConditions={power.nvidia.com/failed}")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+}
+
+setup() {
+  load 'helpers.sh'
+  _common_setup
+  log_objects
+}
+
+bats::on_failure() {
+  echo -e "\n\nFAILURE HOOK START"
+  log_objects
+  kubectl get resourceclaims -o yaml || true
+  show_kubelet_plugin_error_logs
+  show_gpu_plugin_log_tails
+  echo -e "FAILURE HOOK END\n\n"
+}
+
+# KEP-5007 is only usable when the cluster serves the fields: the apiserver
+# silently drops bindingConditions when DRADeviceBindingConditions is disabled
+# (default-off before Kubernetes 1.36). Detect that from the published slice
+# rather than from a version number, so that an explicitly disabled gate is
+# handled too.
+_skip_unless_binding_conditions_supported() {
+  local _deadline=$((SECONDS + 90)) _published=""
+
+  # Deliberately not wait_for_all_gpu_resource_slices: that waits for *every*
+  # node to publish, which does not hold on clusters where only some nodes have
+  # GPUs. One slice carrying the conditions is all these tests need.
+  while (( SECONDS < _deadline )); do
+    _published=$(kubectl get resourceslices \
+      -o jsonpath='{.items[*].spec.devices[*].bindingConditions}' 2>/dev/null)
+    if [[ "${_published}" == *"${_BC_READY}"* ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  # Nothing showed up. Distinguish "the driver published nothing" (a real
+  # failure) from "the apiserver dropped the field" (nothing to test here).
+  local _drivers
+  _drivers=$(kubectl get resourceslices \
+    -o custom-columns=DRIVER:.spec.driver --no-headers 2>/dev/null)
+  if [[ "${_drivers}" != *"gpu.nvidia.com"* ]]; then
+    echo "no gpu.nvidia.com ResourceSlices were published within 90s"
+    return 1
+  fi
+  skip "cluster dropped bindingConditions from the published ResourceSlice; \
+the DRADeviceBindingConditions feature gate is disabled"
+}
+
+# Name of the ResourceClaim generated for a pod from its ResourceClaimTemplate.
+_claim_for_pod() {
+  kubectl get resourceclaim \
+    -o jsonpath="{.items[?(@.metadata.ownerReferences[0].name=='$1')].metadata.name}"
+}
+
+# Write a device condition into a ResourceClaim's status. This stands in for the
+# external controller that KEP-5007 expects to satisfy binding conditions; the
+# driver itself never writes these.
+_set_device_condition() {
+  local _claim="$1" _type="$2" _reason="$3" _message="$4"
+  local _driver _pool _device _now _jsonpath
+
+  _jsonpath='{.status.allocation.devices.results[0]'
+  _driver=$(kubectl get resourceclaim "${_claim}" -o jsonpath="${_jsonpath}.driver}")
+  _pool=$(kubectl get resourceclaim "${_claim}" -o jsonpath="${_jsonpath}.pool}")
+  _device=$(kubectl get resourceclaim "${_claim}" -o jsonpath="${_jsonpath}.device}")
+  _now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  kubectl patch resourceclaim "${_claim}" --subresource=status --type=merge -p \
+    "{\"status\":{\"devices\":[{\"driver\":\"${_driver}\",\"pool\":\"${_pool}\",\"device\":\"${_device}\",\"conditions\":[{\"type\":\"${_type}\",\"status\":\"True\",\"reason\":\"${_reason}\",\"message\":\"${_message}\",\"lastTransitionTime\":\"${_now}\"}]}]}}"
+}
+
+# bats test_tags=fastfeedback,gpu-binding-conditions
+@test "GPUs: BindingConditions — published on GPU devices in ResourceSlices" {
+  _skip_unless_binding_conditions_supported
+
+  run kubectl get resourceslices -o jsonpath='{.items[*].spec.devices[*].bindingConditions}'
+  assert_output --partial "${_BC_READY}"
+
+  run kubectl get resourceslices -o jsonpath='{.items[*].spec.devices[*].bindingFailureConditions}'
+  assert_output --partial "${_BC_FAILED}"
+}
+
+# bats test_tags=fastfeedback,gpu-binding-conditions
+@test "GPUs: BindingConditions — pod stays unbound until an external controller satisfies it" {
+  _skip_unless_binding_conditions_supported
+
+  local _specpath="tests/bats/specs/gpu-binding-conditions.yaml"
+
+  kubectl apply -f "${_specpath}"
+
+  # The scheduler holds the pod in PreBind and says so on the pod.
+  wait_for_pod_event "pod/bc-pod-0" "BindingConditionsPending" 90
+
+  # Held before binding: the claim is allocated, but the pod has no node yet.
+  run kubectl get pod bc-pod-0 -o jsonpath='{.spec.nodeName}'
+  assert_output ""
+
+  local _claim
+  _claim="$(_claim_for_pod bc-pod-0)"
+  assert [ -n "${_claim}" ]
+
+  # The scheduler copies the condition types from the slice into the allocation.
+  run kubectl get resourceclaim "${_claim}" \
+    -o jsonpath='{.status.allocation.devices.results[0].bindingConditions}'
+  assert_output --partial "${_BC_READY}"
+
+  # No writer has run yet, so there is no per-device status at all.
+  run kubectl get resourceclaim "${_claim}" -o jsonpath='{.status.devices}'
+  assert_output ""
+
+  # Now play the external controller: mark the device ready.
+  _set_device_condition "${_claim}" "${_BC_READY}" "PowerStateApplied" "set by the bats suite"
+
+  kubectl wait --for=condition=READY pods bc-pod-0 --timeout=120s
+
+  run kubectl get pod bc-pod-0 -o jsonpath='{.spec.nodeName}'
+  refute_output ""
+
+  run kubectl logs bc-pod-0 -c ctr
+  assert_output --partial "UUID: GPU-"
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods bc-pod-0 --timeout=60s
+}
+
+# bats test_tags=fastfeedback,gpu-binding-conditions
+@test "GPUs: BindingConditions — a failure condition aborts binding and frees the claim" {
+  _skip_unless_binding_conditions_supported
+
+  local _specpath="tests/bats/specs/gpu-binding-conditions-failure.yaml"
+
+  kubectl apply -f "${_specpath}"
+  wait_for_pod_event "pod/bc-pod-1" "BindingConditionsPending" 90
+
+  local _claim
+  _claim="$(_claim_for_pod bc-pod-1)"
+  assert [ -n "${_claim}" ]
+
+  # Play the external controller again, but report failure this time.
+  _set_device_condition "${_claim}" "${_BC_FAILED}" "SimulatedFailure" "set by the bats suite"
+
+  # The scheduler surfaces the failure verbatim and then releases the device by
+  # deallocating the claim, so the pod can be retried elsewhere.
+  wait_for_pod_event "pod/bc-pod-1" "device binding failed" 120
+  wait_for_pod_event "pod/bc-pod-1" "deallocation of ResourceClaim completed" 120
+
+  # Still not bound: nothing ever satisfied the readiness condition.
+  run kubectl get pod bc-pod-1 -o jsonpath='{.spec.nodeName}'
+  assert_output ""
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods bc-pod-1 --timeout=60s
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds `PROPOSAL.md`, a design discussion of device binding conditions (KEP-5007) for ComputeDomain channel devices, with a proposed v1 scope, the alternatives, and the open questions.

**This is a design document, not shippable code, and it is not asking for a merge decision.** I am putting it up as a PR because this repo takes PRs directly rather than design issues. If you would rather this lived somewhere else, or not at all, say so.

#### Which issue(s) this PR is related to:

KEP: kubernetes/enhancements#5007

#### Special notes for your reviewer:

**This is intentionally a draft, so please don't spend review time on it yet.**

It is part of an experiment in bringing the three DRA drivers (dra-example-driver, dra-driver-nvidia-gpu and dra-driver-google-tpu) closer to feature parity, along with a few bugs found along the way.

**How it was produced:** the implementation was written largely by autonomous coding agents working under my direction, one per feature, each in its own branch. I am not asking you to take that on trust, which is exactly why it opens as a draft.

**Verified so far, unattended:** there is no code here, so instead every claim about upstream behaviour was checked against primary sources and cited file and line in a Sources section: the KEP text and `kep.yaml` at kubernetes/enhancements, and the implementation at kubernetes/kubernetes `c44d2a82ef7`. That covers feature gate stages, PreBind polling and `BindingTimeout`, the failure path through Unreserve, Filter and PostFilter, validation limits, the scheduler event and metrics, and the KEP-4817 granular status authorization the controller would need. An automated review pass found ten factual errors in the first draft, which were corrected and then reverified against the source.

**Not done yet:** my own reading of the full diff, and testing it again by hand under my supervision. That happens before this leaves draft, so no CI approval, `/ok-to-test`, or reviewer attention is needed until then.

I will drop the `WIP:` prefix and mark it ready for review only after that human pass.

Two conclusions worth flagging because they run against the intuition the first draft had: a pod waiting in PreBind is already assumed on the node, so binding conditions buy failure handling and observability rather than freed capacity; and reschedule stickiness is best effort through `nominatedNodeName` rather than absent. The document also notes that the KEP itself cites NVIDIA ComputeDomain and IMEX as beta feedback, which is worth reconciling with prior design work here.

The companion document for dra-driver-google-tpu is in https://github.com/kubernetes-sigs/dra-driver-google-tpu/pull/41, and shared facts are worded identically between the two.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

```docs
NONE
```
