### PR TITLE
Fix getFMLibraryPath to search for the libnvfm.so.1 SONAME instead of the unversioned libnvfm.so

### DIFF
--- a/cmd/gpu-kubelet-plugin/root.go
+++ b/cmd/gpu-kubelet-plugin/root.go
@@ -48,7 +48,7 @@ func (r root) getDriverLibraryPath() (string, error) {
 }
 
 func (r root) getFMLibraryPath() (string, error) {
-	libraryPath, err := r.findFile("libnvfm.so", librarySearchPaths...)
+	libraryPath, err := r.findFile("libnvfm.so.1", librarySearchPaths...)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gpu-kubelet-plugin/root_test.go
+++ b/cmd/gpu-kubelet-plugin/root_test.go
@@ -190,7 +190,7 @@ func TestRootGetDriverAndBinaryPaths(t *testing.T) {
 		return want
 	}
 	wantNVML := writeFile("usr/lib64/libnvidia-ml.so.1")
-	wantFM := writeFile("usr/lib64/libnvfm.so")
+	wantFM := writeFile("usr/lib64/libnvfm.so.1")
 	wantSMI := writeFile("usr/bin/nvidia-smi")
 
 	r := root(testRoot)


### PR DESCRIPTION

Fix getFMLibraryPath to search for the libnvfm.so.1 SONAME instead of the unversioned libnvfm.so. The unversioned name is a convenience symlink, not something the driver's ABI guarantees across every install path.

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

Fabric activation is failing on certain systems as the plugin is not able to find the libnvfm library installed by the GPU driver container.

```
I0818 05:37:35.510792       1 root.go:106] Skipping candidate "/driver-root/libnvfm.so": error resolving link "/driver-root/libnvfm.so": lstat /driver-root/libnvfm.so: no such file or directory
I0818 05:37:35.510813       1 root.go:106] Skipping candidate "/driver-root/usr/lib64/libnvfm.so": error resolving link "/driver-root/usr/lib64/libnvfm.so": lstat /driver-root/usr/lib64/libnvfm.so: no such file or directory
I0818 05:37:35.510831       1 root.go:106] Skipping candidate "/driver-root/usr/lib/x86_64-linux-gnu/libnvfm.so": error resolving link "/driver-root/usr/lib/x86_64-linux-gnu/libnvfm.so": lstat /driver-root/usr/lib/x86_64-linux-gnu/libnvfm.so: no such file or directory
I0818 05:37:35.510840       1 root.go:106] Skipping candidate "/driver-root/usr/lib/aarch64-linux-gnu/libnvfm.so": error resolving link "/driver-root/usr/lib/aarch64-linux-gnu/libnvfm.so": lstat /driver-root/usr/lib/aarch64-linux-gnu: no such file or directory
I0818 05:37:35.510860       1 root.go:106] Skipping candidate "/driver-root/lib64/libnvfm.so": error resolving link "/driver-root/lib64/libnvfm.so": lstat /driver-root/usr/lib64/libnvfm.so: no such file or directory
I0818 05:37:35.510883       1 root.go:106] Skipping candidate "/driver-root/lib/x86_64-linux-gnu/libnvfm.so": error resolving link "/driver-root/lib/x86_64-linux-gnu/libnvfm.so": lstat /driver-root/usr/lib/x86_64-linux-gnu/libnvfm.so: no such file or directory
I0818 05:37:35.510896       1 root.go:106] Skipping candidate "/driver-root/lib/aarch64-linux-gnu/libnvfm.so": error resolving link "/driver-root/lib/aarch64-linux-gnu/libnvfm.so": lstat /driver-root/usr/lib/aarch64-linux-gnu: no such file or directory
I0818 05:37:35.512089       1 main.go:272] shutdown
Error: error creating driver: FabricManagerPartitioning enabled but fabric manager library not found: error locating "libnvfm.so"
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->

/release-note-none

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [x] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
