### PR TITLE
Validate CD domain ID before generating the IMEX configuration files

### DIFF
--- a/api/nvidia.com/resource/v1beta1/computedomainconfig.go
+++ b/api/nvidia.com/resource/v1beta1/computedomainconfig.go
@@ -18,9 +18,33 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
 
+	"k8s.io/apimachinery/pkg/api/validate/content"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
+
+// ValidateDomainID reports whether domainID is safe to use as a single path
+// component when constructing on-disk paths for a ComputeDomain.
+// DomainID always originates from an opaque, claim-author-controlled device
+// configuration, so it must never be allowed to contain a path separator or
+// resolve to "." or "..": either would let it escape the directory it is
+// joined into.
+func ValidateDomainID(domainID string) error {
+	if domainID == "" {
+		return fmt.Errorf("domainID cannot be empty")
+	}
+	if errs := content.IsPathSegmentName(domainID); len(errs) > 0 {
+		return fmt.Errorf("domainID %q is not a valid single path component: %s", domainID, strings.Join(errs, ", "))
+	}
+	// DomainID is also a node label value so this rejects over-long or invalid names that
+	// pass the path check but would fail later at MkdirAll or the label update.
+	if errs := validation.IsValidLabelValue(domainID); len(errs) != 0 {
+		return fmt.Errorf("domainID must be a valid label value: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -46,12 +70,9 @@ func (c *ComputeDomainChannelConfig) Normalize() error {
 	return nil
 }
 
-// Validate ensures that ComputeDomainDaemonConfig has a valid set of values.
+// Validate ensures that ComputeDomainChannelConfig has a valid set of values.
 func (c *ComputeDomainChannelConfig) Validate() error {
-	if c.DomainID == "" {
-		return fmt.Errorf("domainID cannot be empty")
-	}
-	return nil
+	return ValidateDomainID(c.DomainID)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -79,8 +100,5 @@ func (c *ComputeDomainDaemonConfig) Normalize() error {
 
 // Validate ensures that ComputeDomainDaemonConfig has a valid set of values.
 func (c *ComputeDomainDaemonConfig) Validate() error {
-	if c.DomainID == "" {
-		return fmt.Errorf("domainID cannot be empty")
-	}
-	return nil
+	return ValidateDomainID(c.DomainID)
 }

--- a/api/nvidia.com/resource/v1beta1/computedomainconfig_test.go
+++ b/api/nvidia.com/resource/v1beta1/computedomainconfig_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	configapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+)
+
+func TestValidateDomainID(t *testing.T) {
+	testCases := []struct {
+		description string
+		domainID    string
+		expectError bool
+	}{
+		{
+			description: "valid UID-shaped domainID",
+			domainID:    "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		},
+		{
+			description: "empty",
+			domainID:    "",
+			expectError: true,
+		},
+		{
+			description: "dot",
+			domainID:    ".",
+			expectError: true,
+		},
+		{
+			description: "dot-dot",
+			domainID:    "..",
+			expectError: true,
+		},
+		{
+			description: "relative path traversal",
+			domainID:    "../../../../../../escape-target/pwn",
+			expectError: true,
+		},
+		{
+			description: "absolute path",
+			domainID:    "/etc/passwd",
+			expectError: true,
+		},
+		{
+			description: "embedded traversal segment",
+			domainID:    "foo/../../bar",
+			expectError: true,
+		},
+		{
+			description: "single embedded slash",
+			domainID:    "foo/bar",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := configapi.ValidateDomainID(tc.domainID)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/cmd/compute-domain-kubelet-plugin/computedomain.go
+++ b/cmd/compute-domain-kubelet-plugin/computedomain.go
@@ -189,14 +189,17 @@ func (m *ComputeDomainManager) Stop() error {
 	return nil
 }
 
-func (m *ComputeDomainManager) NewSettings(domainID string) *ComputeDomainDaemonSettings {
+func (m *ComputeDomainManager) NewSettings(domainID string) (*ComputeDomainDaemonSettings, error) {
+	if err := nvapi.ValidateDomainID(domainID); err != nil {
+		return nil, fmt.Errorf("invalid domainID: %w", err)
+	}
 	return &ComputeDomainDaemonSettings{
 		manager:         m,
 		domainID:        domainID,
-		rootDir:         fmt.Sprintf("%s/%s", m.configFilesRoot, domainID),
-		configTmplPath:  fmt.Sprintf("%s/%s/%s", m.configFilesRoot, domainID, "imexd.cfg.tmpl"),
-		nodesConfigPath: fmt.Sprintf("%s/%s/%s", m.configFilesRoot, domainID, "nodes.cfg"),
-	}
+		rootDir:         filepath.Join(m.configFilesRoot, domainID),
+		configTmplPath:  filepath.Join(m.configFilesRoot, domainID, "imexd.cfg.tmpl"),
+		nodesConfigPath: filepath.Join(m.configFilesRoot, domainID, "nodes.cfg"),
+	}, nil
 }
 
 func (m *ComputeDomainManager) GetComputeDomainChannelContainerEdits(devRoot string, info *common.NVcapDeviceInfo) *cdiapi.ContainerEdits {

--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -603,7 +603,10 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, cs *resourceapi.Reso
 			}
 		case *configapi.ComputeDomainDaemonConfig:
 			// If a daemon type, unprepare the new ComputeDomain daemon.
-			computeDomainDaemonSettings := s.computeDomainManager.NewSettings(config.DomainID)
+			computeDomainDaemonSettings, err := s.computeDomainManager.NewSettings(config.DomainID)
+			if err != nil {
+				return fmt.Errorf("error creating ComputeDomain daemon settings: %w", err)
+			}
 			if err := computeDomainDaemonSettings.Unprepare(ctx); err != nil {
 				return fmt.Errorf("error unpreparing ComputeDomain daemon settings: %w", err)
 			}
@@ -764,7 +767,10 @@ func (s *DeviceState) applyComputeDomainDaemonConfig(ctx context.Context, config
 	}
 
 	// Create new ComputeDomain daemon settings from the ComputeDomainManager.
-	computeDomainDaemonSettings := s.computeDomainManager.NewSettings(config.DomainID)
+	computeDomainDaemonSettings, err := s.computeDomainManager.NewSettings(config.DomainID)
+	if err != nil {
+		return nil, permanentError{fmt.Errorf("error creating ComputeDomain daemon settings: %w", err)}
+	}
 
 	// Prepare injecting IMEX daemon config files even if IMEX is not supported.
 	// This for example creates

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -37,7 +37,8 @@ import (
 )
 
 const (
-	DriverName = "gpu.nvidia.com"
+	DriverName              = "gpu.nvidia.com"
+	ComputeDomainDriverName = "compute-domain.nvidia.com"
 )
 
 type Flags struct {
@@ -196,7 +197,7 @@ func readAdmissionReview(data []byte) (*admissionv1.AdmissionReview, error) {
 }
 
 // admitResourceClaimParameters accepts both ResourceClaims and ResourceClaimTemplates and validates their
-// opaque device configuration parameters for this driver.
+// opaque device configuration parameters for both gpu and compute-domain drivers.
 func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	klog.V(2).Info("admitting resource claim parameters")
 
@@ -243,7 +244,8 @@ func admitResourceClaimParameters(ar admissionv1.AdmissionReview) *admissionv1.A
 
 	var errs []error
 	for configIndex, config := range deviceConfigs {
-		if config.Opaque == nil || config.Opaque.Driver != DriverName {
+		if config.Opaque == nil ||
+			(config.Opaque.Driver != DriverName && config.Opaque.Driver != ComputeDomainDriverName) {
 			continue
 		}
 

--- a/cmd/webhook/main_test.go
+++ b/cmd/webhook/main_test.go
@@ -115,6 +115,29 @@ func TestResourceClaimValidatingWebhook(t *testing.T) {
 			expectedAllowed: false,
 			expectedMessage: "2 configs failed to validate: object at spec.devices.config[0].opaque.parameters is invalid: unknown time-slice interval: Invalid Interval, supported time-slice intervals: Default, Short, Medium, Long; object at spec.devices.config[1].opaque.parameters is invalid: active thread percentage must not be negative",
 		},
+		"valid ComputeDomainDaemonConfig in ResourceClaim": {
+			admissionReview: admissionReviewWithObject(
+				resourceClaimWithComputeDomainDaemonConfig(
+					resourceClaimResourceV1Beta1,
+					&configapi.ComputeDomainDaemonConfig{
+						DomainID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+					},
+				),
+			),
+			expectedAllowed: true,
+		},
+		"path traversal domainID in ComputeDomainDaemonConfig is rejected": {
+			admissionReview: admissionReviewWithObject(
+				resourceClaimWithComputeDomainDaemonConfig(
+					resourceClaimResourceV1Beta1,
+					&configapi.ComputeDomainDaemonConfig{
+						DomainID: "../../../../../../escape-target/pwn",
+					},
+				),
+			),
+			expectedAllowed: false,
+			expectedMessage: `1 configs failed to validate: object at spec.devices.config[0].opaque.parameters is invalid: domainID "../../../../../../escape-target/pwn" is not a valid single path component: may not contain '/'`,
+		},
 		"valid GpuConfig in ResourceClaimTemplate": {
 			featureGates: map[string]bool{
 				string(featuregates.TimeSlicingSettings): true,
@@ -497,6 +520,36 @@ func resourceClaimTemplateWithGpuConfigs(gvr metav1.GroupVersionResource, gpuCon
 		},
 	}
 	return resourceClaimTemplate
+}
+
+func resourceClaimWithComputeDomainDaemonConfig(gvr metav1.GroupVersionResource, config *configapi.ComputeDomainDaemonConfig) *resourceapi.ResourceClaim {
+	config.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   configapi.GroupName,
+		Version: configapi.Version,
+		Kind:    "ComputeDomainDaemonConfig",
+	})
+	return &resourceapi.ResourceClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gvr.Group + "/" + gvr.Version,
+			Kind:       "ResourceClaim",
+		},
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{
+				Config: []resourceapi.DeviceClaimConfiguration{
+					{
+						DeviceConfiguration: resourceapi.DeviceConfiguration{
+							Opaque: &resourceapi.OpaqueDeviceConfiguration{
+								Driver: ComputeDomainDriverName,
+								Parameters: runtime.RawExtension{
+									Object: config,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func resourceClaimSpecWithGpuConfigs(gpuConfigs ...*configapi.GpuConfig) resourceapi.ResourceClaimSpec {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

Validate the claim's opaque-config-supplied ComputeDomain ID before using it to construct IMEX configuration file paths.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind cleanup

#### What this PR does / why we need it:

This PR validates the ComputeDomain ID embedded in the opaque configuration to ensure it hasn't been tampered with or hand-crafted by the user.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->

/release-note-none


#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
