### PR TITLE
gpu: checkpoint only the allocation results we serve

### DIFF
--- a/cmd/gpu-kubelet-plugin/checkpointv.go
+++ b/cmd/gpu-kubelet-plugin/checkpointv.go
@@ -112,7 +112,7 @@ func (v1 *CheckpointV1) ToV2() *CheckpointV2 {
 	for claimUID, v1Claim := range v1.PreparedClaims {
 		v2.PreparedClaims[claimUID] = PreparedClaimV2{
 			CheckpointState: ClaimCheckpointStatePrepareCompleted,
-			Status:          v1Claim.Status,
+			Status:          ownedStatus(v1Claim.Status),
 			PreparedDevices: v1Claim.PreparedDevices,
 		}
 	}

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -347,7 +347,7 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	err = s.updateCheckpoint(ctx, func(cp *Checkpoint) {
 		cp.V2.PreparedClaims[claimUID] = PreparedClaim{
 			CheckpointState: ClaimCheckpointStatePrepareStarted,
-			Status:          claim.Status,
+			Status:          ownedStatus(claim.Status),
 			Name:            claim.Name,
 			Namespace:       claim.Namespace,
 		}
@@ -389,7 +389,7 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	err = s.updateCheckpoint(ctx, func(cp *Checkpoint) {
 		cp.V2.PreparedClaims[claimUID] = PreparedClaim{
 			CheckpointState: ClaimCheckpointStatePrepareCompleted,
-			Status:          claim.Status,
+			Status:          ownedStatus(claim.Status),
 			PreparedDevices: preparedDevices,
 		}
 	})
@@ -1984,6 +1984,34 @@ func (s *DeviceState) IsMigCapable() bool {
 		}
 	}
 	return false
+}
+
+// ownedStatus is claim.Status with the allocation results of other drivers
+// dropped. What we checkpoint is this driver's own view of the claim, and
+// everything reading it back treats a result as a device we placed.
+func ownedStatus(status resourceapi.ResourceClaimStatus) resourceapi.ResourceClaimStatus {
+	if status.Allocation == nil {
+		return status
+	}
+	results := status.Allocation.Devices.Results
+	owned := make([]resourceapi.DeviceRequestAllocationResult, 0, len(results))
+	var dropped []string
+	for _, r := range results {
+		if r.Driver == DriverName {
+			owned = append(owned, r)
+			continue
+		}
+		dropped = append(dropped, fmt.Sprintf("%s/%s", r.Driver, r.Device))
+	}
+	if len(dropped) == 0 {
+		return status
+	}
+	klog.V(2).Infof("Checkpointing claim without %d result(s) of other drivers: %v", len(dropped), dropped)
+
+	// The claim is the informer cache's copy, so the filtered view must be ours.
+	out := *status.DeepCopy()
+	out.Allocation.Devices.Results = owned
+	return out
 }
 
 func isAdminAccess(results []resourceapi.DeviceRequestAllocationResult) bool {

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -658,6 +658,89 @@ func TestValidateAdminAccessRequest(t *testing.T) {
 	}
 }
 
+func TestOwnedStatusKeepsOnlyOurResults(t *testing.T) {
+	statusWith := func(results ...resourceapi.DeviceRequestAllocationResult) resourceapi.ResourceClaimStatus {
+		return resourceapi.ResourceClaimStatus{Allocation: &resourceapi.AllocationResult{
+			Devices: resourceapi.DeviceAllocationResult{Results: results},
+		}}
+	}
+
+	t.Run("an unallocated claim is left alone", func(t *testing.T) {
+		require.Nil(t, ownedStatus(resourceapi.ResourceClaimStatus{}).Allocation)
+	})
+
+	t.Run("results of other drivers are dropped", func(t *testing.T) {
+		in := statusWith(
+			resourceapi.DeviceRequestAllocationResult{Driver: "other.driver.com", Device: "foreign-0"},
+			resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: "gpu-0"},
+		)
+
+		got := ownedStatus(in)
+
+		require.Equal(t,
+			[]resourceapi.DeviceRequestAllocationResult{{Driver: DriverName, Device: "gpu-0"}},
+			got.Allocation.Devices.Results)
+	})
+
+	// claim.Status comes from the informer cache, so filtering must not reach it.
+	t.Run("the claim we were handed is not modified", func(t *testing.T) {
+		in := statusWith(
+			resourceapi.DeviceRequestAllocationResult{Driver: "other.driver.com", Device: "foreign-0"},
+			resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: "gpu-0"},
+		)
+
+		_ = ownedStatus(in)
+
+		require.Len(t, in.Allocation.Devices.Results, 2)
+	})
+
+	// Every claim a single-driver node sees takes this path, so it must not pay
+	// for a copy of the status.
+	t.Run("a claim that is all ours is handed straight back", func(t *testing.T) {
+		in := statusWith(resourceapi.DeviceRequestAllocationResult{Driver: DriverName, Device: "gpu-0"})
+
+		got := ownedStatus(in)
+
+		require.Same(t, in.Allocation, got.Allocation)
+	})
+
+	t.Run("an allocation with no results keeps having none", func(t *testing.T) {
+		in := resourceapi.ResourceClaimStatus{Allocation: &resourceapi.AllocationResult{}}
+
+		got := ownedStatus(in)
+
+		require.Nil(t, got.Allocation.Devices.Results)
+	})
+
+	t.Run("a claim with nothing of ours ends up empty", func(t *testing.T) {
+		in := statusWith(resourceapi.DeviceRequestAllocationResult{Driver: "other.driver.com", Device: "foreign-0"})
+
+		got := ownedStatus(in)
+
+		require.Empty(t, got.Allocation.Devices.Results)
+	})
+}
+
+// An upgrade converts the checkpoint on read, which is a write of our own.
+func TestCheckpointV1ToV2KeepsOnlyOurResults(t *testing.T) {
+	v1 := &CheckpointV1{PreparedClaims: PreparedClaimsByUIDV1{
+		"claim-uid": {Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{Results: []resourceapi.DeviceRequestAllocationResult{
+					{Driver: "other.driver.com", Device: "foreign-0"},
+					{Driver: DriverName, Device: "gpu-0"},
+				}},
+			},
+		}},
+	}}
+
+	v2 := v1.ToV2()
+
+	require.Equal(t,
+		[]resourceapi.DeviceRequestAllocationResult{{Driver: DriverName, Device: "gpu-0"}},
+		v2.PreparedClaims["claim-uid"].Status.Allocation.Devices.Results)
+}
+
 func TestIsAdminAccessIgnoresOtherDrivers(t *testing.T) {
 	results := []resourceapi.DeviceRequestAllocationResult{
 		{Driver: "other.driver.com", AdminAccess: ptr.To(true)},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`Prepare()` checkpoints `claim.Status` whole, so a ResourceClaim allocated from more than one driver leaves allocation results in our checkpoint that this plugin never placed. kubelet hands the same claim to every driver named in its allocation results, so nothing unusual is needed beyond one claim with two drivers in it.

That matters because the checkpoint is read back as this plugin's own view of the node. `DestroyUnknownMIGDevices` builds its keep-list from exactly those results and hands it to `obliterateStaleMIGDevices`, which deletes every MIG device not on it, so a foreign result whose device name happens to parse as a MIG name keeps a live MIG device off the stale list. The same name also reads as "in use by a completely prepared claim" in `deleteMigDevIfExistsAndNotUsedByCompletedClaim`.

The second commit is a nil dereference I found while testing the first. Those two readers and the partial rollback all walk a claim's results without checking whether the claim has an allocation at all, so an entry without one takes the plugin down, in the startup case before it has cleaned anything up.

#### Which issue(s) this PR is related to:

Part of #1327, the half that is about what we write rather than what we act on. The ownership check inside the partial MIG rollback landed separately in #1328.

#### Special notes for your reviewer:

**Why the filter moved to the read and write funnels.** The previous revision filtered at the two `Prepare()` checkpoint writes. That only fixed checkpoints written from then on, which is the gap I asked about last time, and it restated the invariant at every future writer. `getCheckpoint` and `updateCheckpoint` are the only two places that read the file, and the only write that can carry claims goes through `updateCheckpoint`, since the other writer puts down a fresh empty checkpoint at startup. One call in each therefore covers legacy checkpoints, the V1 conversion, and anything added later. In `getCheckpoint` it runs after `GetCheckpoint()` has verified the checksum against the bytes on disk; in `updateCheckpoint` after `mutate()`, so a claim that update adds is filtered too. `CheckpointV1.ToV2()` is back to a pure version conversion, and the V1 case is covered through the real read path instead.

**Why the second commit does not simply skip a claim without an allocation.** Reading that as "this claim holds nothing" is worse than the panic: every device the keep-list does not name is destroyed on the next line, and a claim the in-use scan skips stops protecting the device it holds. A completed claim records what it was prepared with, so `preparedClaimDevices` answers from `PreparedDevices` when the allocation is missing, and reports that it could not tell when neither is recorded. The keep-list run is then skipped and the device the scan was asked about is kept. A partially prepared claim has no `PreparedDevices` checkpointed yet, so there the results really are all there is and the rollback has nothing left to do; deleting that claim's checkpoint entry through the ordinary `Unprepare` path is what clears the state.

The prepared devices are read field by field rather than through `CanonicalName()`, which panics on an entry malformed enough to reach this path at all.

**Log level.** `getCheckpoint` runs on every periodic cleanup tick, and a checkpoint that is never written reaches the filter each time, so the line that reports dropped results is `V(4)`.

**Tests.** The filtering is asserted through `getCheckpoint` and `updateCheckpoint` on a real checkpoint manager, for a V1 and a V2 file, and for a claim the update itself adds. The helper's own cases cover the copy: mutating the returned status must not reach the caller's claim, which the previous revision did not catch. The second commit drives all three readers, the keep-list one through `DestroyUnknownMIGDevices` itself, and covers a claim answered by its prepared devices, a device no claim names so that teardown still happens, and a prepared device with nothing in it.

Every mutation I could think of fails at least one test: re-introducing the aliasing, removing either funnel call, moving the filter back before `mutate()`, emptying the helper, reading the prepared devices through `CanonicalName()` again, dropping its nil check, turning either fail-safe answer back into a skip, removing the rollback's check, and claiming the helper always knows.

**Testing.** `golangci-lint run ./...` (0 issues), `go vet` and `go test -race ./...` are clean, with `-count=2` and three shuffle seeds for the package, and each commit builds and tests on its own. `go.mod`, `go.sum` and `vendor` are untouched, so `check-generate` and `check-modules` are unaffected.

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the kubelet plugin recording other drivers' allocation results in its checkpoint, which could keep a stale MIG device from being cleaned up when a ResourceClaim was allocated from more than one driver. A checkpointed claim whose allocation is missing no longer crashes the plugin, and no longer lets MIG devices be torn down on its behalf.
```

#### Additional documentation (design docs, usage docs, etc.):

```docs

```

#### Checklist

- [x] `make check test` passes locally (golangci-lint, go test -race; codegen and modules untouched)
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
