### PR TITLE
test(gpu-kubelet-plugin): add unit tests for vfio-cdi.go

### DIFF
--- a/cmd/gpu-kubelet-plugin/vfio-cdi_test.go
+++ b/cmd/gpu-kubelet-plugin/vfio-cdi_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NVIDIA/go-nvlib/pkg/nvpci"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVfioCDIHandler(t *testing.T) {
+	t.Run("iommufd disabled when /dev/iommu missing", func(t *testing.T) {
+		handler, err := NewVfioCDIHandler(&deviceLib{hostRoot: t.TempDir()})
+		require.NoError(t, err)
+		require.False(t, handler.iommuFDEnabled)
+	})
+
+	t.Run("iommufd enabled when /dev/iommu exists", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(hostRoot, "dev"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(hostRoot, iommuDevicePath), nil, 0o644))
+
+		handler, err := NewVfioCDIHandler(&deviceLib{hostRoot: hostRoot})
+		require.NoError(t, err)
+		require.True(t, handler.iommuFDEnabled)
+	})
+}
+
+func TestVfioCDIHandlerGetCommonEdits(t *testing.T) {
+	testCases := []struct {
+		name            string
+		enableAPIDevice bool
+		preferIommuFD   bool
+		iommuFDEnabled  bool
+		expectedPaths   []string
+	}{
+		{
+			name:            "api device disabled",
+			enableAPIDevice: false,
+			preferIommuFD:   true,
+			iommuFDEnabled:  true,
+			expectedPaths:   []string{},
+		},
+		{
+			name:            "iommufd preferred and enabled",
+			enableAPIDevice: true,
+			preferIommuFD:   true,
+			iommuFDEnabled:  true,
+			expectedPaths:   []string{iommuDevicePath},
+		},
+		{
+			name:            "iommufd preferred but not enabled",
+			enableAPIDevice: true,
+			preferIommuFD:   true,
+			iommuFDEnabled:  false,
+			expectedPaths:   []string{"/dev/vfio/vfio"},
+		},
+		{
+			name:            "iommufd enabled but not preferred",
+			enableAPIDevice: true,
+			preferIommuFD:   false,
+			iommuFDEnabled:  true,
+			expectedPaths:   []string{"/dev/vfio/vfio"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := &vfioCDIHandler{iommuFDEnabled: tc.iommuFDEnabled}
+
+			edits, err := handler.GetCommonEdits(tc.enableAPIDevice, tc.preferIommuFD)
+			require.NoError(t, err)
+			require.Equal(t, []string{"NVIDIA_VISIBLE_DEVICES=void"}, edits.Env)
+
+			paths := []string{}
+			for _, node := range edits.DeviceNodes {
+				paths = append(paths, node.Path)
+			}
+			require.Equal(t, tc.expectedPaths, paths)
+		})
+	}
+}
+
+func TestVfioCDIHandlerGetDeviceSpecsByPCIBusID(t *testing.T) {
+	testCases := []struct {
+		name           string
+		preferIommuFD  bool
+		iommuFDEnabled bool
+		device         *nvpci.NvidiaPCIDevice
+		deviceErr      error
+		expectedPath   string
+		expectedErr    string
+	}{
+		{
+			name:           "legacy vfio group device",
+			preferIommuFD:  false,
+			iommuFDEnabled: true,
+			device:         &nvpci.NvidiaPCIDevice{Address: "0000:01:00.0", IommuGroup: 42},
+			expectedPath:   "/dev/vfio/42",
+		},
+		{
+			name:           "iommufd cdev",
+			preferIommuFD:  true,
+			iommuFDEnabled: true,
+			device:         &nvpci.NvidiaPCIDevice{Address: "0000:01:00.0", IommuFD: "vfio0"},
+			expectedPath:   "/dev/vfio/devices/vfio0",
+		},
+		{
+			name:           "iommufd cdev missing",
+			preferIommuFD:  true,
+			iommuFDEnabled: true,
+			device:         &nvpci.NvidiaPCIDevice{Address: "0000:01:00.0"},
+			expectedErr:    "missing iommufd cdev",
+		},
+		{
+			name:        "pci lookup error",
+			deviceErr:   errors.New("device not found"),
+			expectedErr: "error getting PCI device info",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := &vfioCDIHandler{
+				iommuFDEnabled: tc.iommuFDEnabled,
+				deviceLib: &deviceLib{
+					nvpci: &nvpci.InterfaceMock{
+						GetGPUByPciBusIDFunc: func(s string) (*nvpci.NvidiaPCIDevice, error) {
+							return tc.device, tc.deviceErr
+						},
+					},
+				},
+			}
+
+			specs, err := handler.GetDeviceSpecsByPCIBusID("0000:01:00.0", tc.preferIommuFD)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, specs, 1)
+			require.Len(t, specs[0].ContainerEdits.DeviceNodes, 1)
+			require.Equal(t, tc.expectedPath, specs[0].ContainerEdits.DeviceNodes[0].Path)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
Fixes #1300 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note

```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
