### PR TITLE
Add bats e2e for KEP-4680 device health reporting and KEP-5055 health taints

### DIFF
--- a/.github/workflows/mock-nvml-e2e.yaml
+++ b/.github/workflows/mock-nvml-e2e.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           repository: NVIDIA/k8s-test-infra
-          ref: 1275802ba689f3e40be78d15859123c21d3271c4
+          ref: 64bae6b2b53cdd8d6dd0dd11dfacaf46e786a718 # includes NVIDIA/k8s-test-infra#735 (Xid event fidelity) and #746 (ERROR_GPU_IS_LOST from event wait)
           path: _k8s-test-infra
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
         with:

--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -116,6 +116,9 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.Serialize(false),
 		kubeletplugin.RegistrarDirectoryPath(config.flags.kubeletRegistrarDirectoryPath),
 		kubeletplugin.PluginDataDirectoryPath(config.DriverPluginPath()),
+		// This plugin does not report device health (KEP-4680), so don't
+		// advertise the DRAResourceHealth service to the kubelet.
+		kubeletplugin.HealthService(false),
 	)
 	if err != nil {
 		return nil, err
@@ -173,6 +176,13 @@ func (d *driver) Shutdown() error {
 
 	d.pluginhelper.Stop()
 	return nil
+}
+
+// WatchHealthStatus implements [kubeletplugin.DRAPlugin]. The ComputeDomain
+// plugin does not report device health (see also the HealthService option in
+// NewDriver, which keeps the DRAResourceHealth service from being advertised).
+func (d *driver) WatchHealthStatus(ctx context.Context, reports chan<- kubeletplugin.DeviceHealthReport) error {
+	return kubeletplugin.ErrHealthNotSupported
 }
 
 func (d *driver) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {
@@ -248,10 +258,6 @@ func (d *driver) HandleError(ctx context.Context, err error, msg string) {
 	// For now we just follow the advice documented in the DRAPlugin API docs.
 	// See: https://pkg.go.dev/k8s.io/apimachinery/pkg/util/runtime#HandleErrorWithContext
 	runtime.HandleErrorWithContext(ctx, err, msg)
-}
-
-func (d *driver) WatchHealthStatus(context.Context, chan<- kubeletplugin.DeviceHealthReport) error {
-	return kubeletplugin.ErrHealthNotSupported
 }
 
 // nodePrepareResource() returns a 2-tuple; the first value is a boolean

--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -347,10 +347,28 @@ func (d *AllocatableDevice) Taints() []resourceapi.DeviceTaint {
 	return slices.Clone(d.taints)
 }
 
+// taintEffectSeverity orders taint effects so that a later event can never
+// weaken a taint: None < NoSchedule < NoExecute.
+func taintEffectSeverity(effect resourceapi.DeviceTaintEffect) int {
+	switch effect {
+	case resourceapi.DeviceTaintEffectNoExecute:
+		return 2
+	case resourceapi.DeviceTaintEffectNoSchedule:
+		return 1
+	default:
+		return 0
+	}
+}
+
 // AddOrUpdateTaint adds a new taint or updates an existing one with the same
-// key. The value and effect are always updated to the latest event received.
-// Meaning, if a device receives multiple events for the same taint dimension
-// (e.g., XID 48 followed by XID 63), the value is overwritten and only the most recent event data is retained.
+// key. A later event for the same taint dimension replaces the value and
+// effect (e.g., XID 48 followed by XID 63 keeps only 63) unless it would
+// weaken the effect: a device tainted NoSchedule by a critical event stays
+// NoSchedule (and keeps that event's value) when a later non-fatal event
+// arrives, because a non-fatal event is no evidence that the critical
+// failure was fixed. This mirrors the sticky Unhealthy device health
+// reported to the kubelet, which is derived from these taints
+// (deviceHealthFromTaints).
 // Returns true if the taint set was modified.
 func (d *AllocatableDevice) AddOrUpdateTaint(taint *resourceapi.DeviceTaint) bool {
 	for i, existing := range d.taints {
@@ -361,7 +379,12 @@ func (d *AllocatableDevice) AddOrUpdateTaint(taint *resourceapi.DeviceTaint) boo
 				return false
 			}
 
-			// 2. Otherwise, update the fields and the timestamp
+			// 2. Never downgrade the effect of an existing taint.
+			if taintEffectSeverity(taint.Effect) < taintEffectSeverity(existing.Effect) {
+				return false
+			}
+
+			// 3. Otherwise, update the fields and the timestamp
 			d.taints[i].Value = taint.Value
 			d.taints[i].Effect = taint.Effect
 			d.taints[i].TimeAdded = nil // reset timestamp for the API server
@@ -369,7 +392,7 @@ func (d *AllocatableDevice) AddOrUpdateTaint(taint *resourceapi.DeviceTaint) boo
 		}
 	}
 
-	// 3. Key doesn't exist yet, append the dereferenced struct
+	// 4. Key doesn't exist yet, append the dereferenced struct
 	d.taints = append(d.taints, *taint)
 	return true
 }

--- a/cmd/gpu-kubelet-plugin/device_health.go
+++ b/cmd/gpu-kubelet-plugin/device_health.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	resourceapi "k8s.io/api/resource/v1"
@@ -64,16 +65,43 @@ type DeviceHealthEvent struct {
 	EventData uint64
 }
 
+// logIfUnknownType reports an event type the driver does not know, once per
+// received event; such events are treated as unmonitored by both consumers.
+func (e *DeviceHealthEvent) logIfUnknownType() {
+	switch e.EventType {
+	case HealthEventXID, HealthEventGPULost, HealthEventUnmonitored:
+	default:
+		klog.Errorf("Unknown health event type %q, treating as unmonitored", e.EventType)
+	}
+}
+
+// IsCritical reports whether the event is a hardware failure that makes the
+// device unusable until fixed: a lost GPU, or an XID that the monitor does
+// not classify as non-fatal. It is the single decision behind both the
+// device taint derived from the event (healthEventToTaint, KEP-5055) and the
+// device health reported to the kubelet (deviceHealthFromTaints, KEP-4680), so
+// the two cannot drift apart.
+func (e *DeviceHealthEvent) IsCritical(monitor deviceHealthMonitor) bool {
+	switch e.EventType {
+	case HealthEventXID:
+		return monitor == nil || !monitor.IsEventNonFatal(e)
+	case HealthEventGPULost:
+		return true
+	default:
+		return false
+	}
+}
+
 // healthEventToTaint maps a DeviceHealthEvent to the corresponding DRA
 // DeviceTaint using the Option A taint key schema: one key per health
 // dimension under the gpu.nvidia.com domain.
 func healthEventToTaint(monitor deviceHealthMonitor, event *DeviceHealthEvent) *resourceapi.DeviceTaint {
+	effect := resourceapi.DeviceTaintEffectNone
+	if event.IsCritical(monitor) {
+		effect = resourceapi.DeviceTaintEffectNoSchedule
+	}
 	switch event.EventType {
 	case HealthEventXID:
-		effect := resourceapi.DeviceTaintEffectNoSchedule
-		if monitor != nil && monitor.IsEventNonFatal(event) {
-			effect = resourceapi.DeviceTaintEffectNone
-		}
 		return &resourceapi.DeviceTaint{
 			Key:    TaintKeyXID,
 			Value:  strconv.FormatUint(event.EventData, 10),
@@ -82,21 +110,31 @@ func healthEventToTaint(monitor deviceHealthMonitor, event *DeviceHealthEvent) *
 	case HealthEventGPULost:
 		return &resourceapi.DeviceTaint{
 			Key:    TaintKeyGPULost,
-			Effect: resourceapi.DeviceTaintEffectNoSchedule,
-		}
-	case HealthEventUnmonitored:
-		return &resourceapi.DeviceTaint{
-			Key:    TaintKeyUnmonitored,
-			Effect: resourceapi.DeviceTaintEffectNone,
+			Effect: effect,
 		}
 	default:
-		klog.Errorf("Unknown health event type %q, defaulting to unmonitored taint", event.EventType)
+		// HealthEventUnmonitored and unknown event types.
 		return &resourceapi.DeviceTaint{
 			Key:    TaintKeyUnmonitored,
-			Effect: resourceapi.DeviceTaintEffectNone,
+			Effect: effect,
 		}
 	}
 }
+
+// monitorHeartbeatInterval is how often the monitor's event loop signals that
+// it is alive. The kubelet reports device health as unknown when it is not
+// refreshed within each device's health check timeout (30 seconds by
+// default), so the driver re-sends its health report on every heartbeat. The
+// heartbeat deliberately originates from the event loop itself, after each
+// NVML event wait returns: if the loop or the NVML call wedges, the resends
+// stop and the kubelet correctly decays the devices' health to unknown
+// instead of trusting a stale report.
+const monitorHeartbeatInterval = 15 * time.Second
+
+// eventWaitRetryDelay is how long the event loop pauses after an NVML event
+// wait fails with an error other than ERROR_TIMEOUT, which return immediately
+// instead of after the wait timeout. A variable so tests can shorten it.
+var eventWaitRetryDelay = time.Second
 
 type nvmlDeviceHealthMonitor struct {
 	nvmllib           nvml.Interface
@@ -104,6 +142,8 @@ type nvmlDeviceHealthMonitor struct {
 	unhealthy         chan *DeviceHealthEvent
 	perGPUAllocatable *PerGPUAllocatableDevices
 	gpuInfosByUUID    map[string]*GpuInfo
+	heartbeat         chan struct{}
+	lastHeartbeat     time.Time
 	skippedXids       map[uint64]bool
 	wg                sync.WaitGroup
 }
@@ -128,6 +168,7 @@ func newNvmlDeviceHealthMonitor(config *Config, perGPUAllocatable *PerGPUAllocat
 		unhealthy:         make(chan *DeviceHealthEvent, len(all)),
 		perGPUAllocatable: perGPUAllocatable,
 		gpuInfosByUUID:    nvdevlib.gpuInfosByUUID,
+		heartbeat:         make(chan struct{}, 1),
 		skippedXids:       xidsToSkip(config.flags.additionalXidsToIgnore),
 	}
 	return m, nil
@@ -211,17 +252,24 @@ func (m *nvmlDeviceHealthMonitor) Stop() {
 
 	m.wg.Wait()
 
-	if ret := m.eventSet.Free(); ret != nvml.SUCCESS {
-		klog.Warningf("failed to unset events: %v", ret)
-	}
-
-	if ret := m.nvmllib.Shutdown(); ret != nvml.SUCCESS {
-		klog.Warningf("failed to shutdown NVML: %v", ret)
+	// The event set and the NVML session it belongs to exist only after a
+	// successful RegisterEvents; a failed registration cleans up after
+	// itself, so Stop must not touch NVML in that case.
+	if m.eventSet != nil {
+		if ret := m.eventSet.Free(); ret != nvml.SUCCESS {
+			klog.Warningf("failed to unset events: %v", ret)
+		}
+		if ret := m.nvmllib.Shutdown(); ret != nvml.SUCCESS {
+			klog.Warningf("failed to shutdown NVML: %v", ret)
+		}
 	}
 	close(m.unhealthy)
 }
 
 func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
+	// lastRet is the previous event wait return, to log a persistent error
+	// once instead of on every retry.
+	lastRet := nvml.SUCCESS
 	for {
 		select {
 		case <-ctx.Done():
@@ -229,20 +277,57 @@ func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
 			return
 		default:
 			event, ret := m.eventSet.Wait(5000) // timeout in 5000 ms.
+
+			// The heartbeat proves the NVML event stream is responsive, so
+			// it fires only for returns that show NVML answered about the
+			// devices: a successful wait, ERROR_TIMEOUT after the 5s deadline
+			// (the normal idle path, which drives the heartbeat on a quiet,
+			// healthy GPU), and ERROR_GPU_IS_LOST, where NVML is responsive
+			// and reports a known failure that is tainted below, so the
+			// kubelet keeps seeing the devices as unhealthy rather than
+			// unknown. A wedged NVML call returns nothing at all and any
+			// other error (for example ERROR_UNINITIALIZED or ERROR_UNKNOWN)
+			// means no events can be received: in both cases the heartbeat
+			// stops and the kubelet then reports the devices' health as
+			// unknown instead of trusting stale data.
+			if ret == nvml.SUCCESS || ret == nvml.ERROR_TIMEOUT || ret == nvml.ERROR_GPU_IS_LOST {
+				m.beat()
+			}
+
 			if ret == nvml.ERROR_TIMEOUT {
+				lastRet = ret
 				continue
 			}
-			// not all return errors are handled as currently there is no proper way to process these errors other than marking all devices healthy.
+			// Only ERROR_GPU_IS_LOST maps to a taint. Other errors are not
+			// mapped to any health state: the loop backs off and retries,
+			// and since no heartbeat is emitted for them (above) the health
+			// reported to the kubelet decays to unknown while they persist.
 			// Ref doc: [https://docs.nvidia.com/deploy/nvml-api/group__nvmlEvents.html#group__nvmlEvents_1g9714b0ca9a34c7a7780f87fee16b205c].
 			if ret != nvml.SUCCESS {
 				if ret == nvml.ERROR_GPU_IS_LOST {
-					klog.Warningf("GPU is lost error: %v; Tainting all devices with %s", ret, TaintKeyGPULost)
+					// A lost GPU is re-reported on every retry; warn once
+					// per episode, the taint update is idempotent.
+					if lastRet != ret {
+						klog.Warningf("GPU is lost error: %v; Tainting all devices with %s", ret, TaintKeyGPULost)
+					} else {
+						klog.V(6).Infof("GPU is still lost: %v", ret)
+					}
 					m.sendHealthEventForAllDevices(HealthEventGPULost)
-					continue
+				} else {
+					klog.V(6).Infof("Error waiting for NVML event: %v. Retrying...", ret)
 				}
-				klog.V(6).Infof("Error waiting for NVML event: %v. Retrying...", ret)
+				lastRet = ret
+				// A persistent error (including a GPU that stays lost)
+				// returns immediately instead of after the wait timeout;
+				// pause before retrying so the loop does not spin.
+				select {
+				case <-ctx.Done():
+				case <-time.After(eventWaitRetryDelay):
+				}
 				continue
 			}
+
+			lastRet = ret
 
 			// TODO: check why other supported types are not considered?
 			eType := event.EventType
@@ -264,23 +349,33 @@ func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
 				m.sendHealthEventForAllDevices(HealthEventGPULost)
 				continue
 			}
-			affectedDevice, err := m.resolveDeviceByEventAddress(eventUUID, event.Device, gi, ci)
-			// An error indicates inconsistent UUID/PCI inventory. A nil device
+			affectedDevices, err := m.resolveDevicesByEventAddress(eventUUID, event.Device, gi, ci)
+			// An error indicates inconsistent UUID/PCI inventory. No devices
 			// without an error means the event's GI/CI is not available.
 			if err != nil {
 				klog.Warningf("Unable to resolve XID=%d event for UUID:%s, GI:%d, CI:%d: %v", xid, eventUUID, gi, ci, err)
 				continue
 			}
-			if affectedDevice == nil {
+			if len(affectedDevices) == 0 {
 				klog.V(6).Infof("Ignoring event for unexpected device (UUID:%s, GI:%d, CI:%d)", eventUUID, gi, ci)
 				continue
 			}
 
-			klog.V(4).Infof("Sending XID=%d health event for device %s", xid, affectedDevice.CanonicalName())
-			m.unhealthy <- &DeviceHealthEvent{
-				Devices:   []*AllocatableDevice{affectedDevice},
+			for _, affectedDevice := range affectedDevices {
+				klog.V(4).Infof("Sending XID=%d health event for device %s", xid, affectedDevice.CanonicalName())
+			}
+			// The send observes ctx so that a full channel (for example an
+			// XID storm before the consumer goroutine starts) cannot park
+			// this goroutine past shutdown and deadlock Stop().
+			select {
+			case m.unhealthy <- &DeviceHealthEvent{
+				Devices:   affectedDevices,
 				EventType: HealthEventXID,
 				EventData: xid,
+			}:
+			case <-ctx.Done():
+				klog.V(6).Info("Stopping event-driven GPU health monitor...")
+				return
 			}
 		}
 	}
@@ -288,6 +383,30 @@ func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
 
 func (m *nvmlDeviceHealthMonitor) Unhealthy() <-chan *DeviceHealthEvent {
 	return m.unhealthy
+}
+
+// beat signals that the NVML event wait returned, at most once per
+// monitorHeartbeatInterval. The interval clock only advances when the signal
+// is actually delivered: a dropped beat must not consume the interval, or a
+// slow consumer would stretch the gap between delivered heartbeats and erode
+// the margin to the kubelet's health check timeout. Only called from the run
+// goroutine.
+func (m *nvmlDeviceHealthMonitor) beat() {
+	if time.Since(m.lastHeartbeat) < monitorHeartbeatInterval {
+		return
+	}
+	select {
+	case m.heartbeat <- struct{}{}:
+		m.lastHeartbeat = time.Now()
+	default:
+	}
+}
+
+// Heartbeat signals that the monitor's event loop is alive. The driver
+// re-sends its current health report on each heartbeat to keep the kubelet's
+// health data fresh.
+func (m *nvmlDeviceHealthMonitor) Heartbeat() <-chan struct{} {
+	return m.heartbeat
 }
 
 // sendHealthEventForAllDevices aggregates every device across all GPUs into a
@@ -307,9 +426,13 @@ func (m *nvmlDeviceHealthMonitor) sendHealthEventForDevices(devices AllocatableD
 // ID, compute instance ID). A full-GPU event reports FullGPUInstanceID for both
 // the GPU instance ID and compute instance ID.
 //
-// resolveDeviceByEventAddress maps this address, extracted from an NVML event,
-// to an advertised allocatable device.
-func (m *nvmlDeviceHealthMonitor) resolveDeviceByEventAddress(parentUUID string, eventDevice nvml.Device, gi, ci uint32) (*AllocatableDevice, error) {
+// resolveDevicesByEventAddress maps this address, extracted from an NVML
+// event, to the advertised allocatable devices it affects: a MIG-scoped event
+// affects that one MIG device; a full-GPU event (for example XID 79, the GPU
+// fell off the bus) affects the GPU and every MIG device on it, whether the
+// full GPU itself is allocatable or not (static MIG mode, Dynamic MIG on
+// Ampere), as in the device plugin's health checker.
+func (m *nvmlDeviceHealthMonitor) resolveDevicesByEventAddress(parentUUID string, eventDevice nvml.Device, gi, ci uint32) ([]*AllocatableDevice, error) {
 	parent, ok := m.gpuInfosByUUID[parentUUID]
 	if !ok {
 		return nil, fmt.Errorf("failed to find parent GPU UUID %s in the discovered GPU inventory", parentUUID)
@@ -322,22 +445,27 @@ func (m *nvmlDeviceHealthMonitor) resolveDeviceByEventAddress(parentUUID string,
 
 	switch {
 	case gi == FullGPUInstanceID && ci == FullGPUInstanceID:
-		return devices.GetGPUDeviceByUUID(parentUUID), nil
+		return devices.List(), nil
 
 	case gi != FullGPUInstanceID && ci != FullGPUInstanceID:
+		var device *AllocatableDevice
 		if featuregates.Enabled(featuregates.DynamicMIG) {
 			spec, err := resolveMigEvent(eventDevice, parent, gi, ci)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve Dynamic MIG device for parent %s, GI=%d, CI=%d: %w", parentUUID, gi, ci, err)
 			}
-			return devices.GetMigDynamicDeviceByTuple(spec), nil
+			device = devices.GetMigDynamicDeviceByTuple(spec)
+		} else {
+			device = devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+				ParentUUID: parentUUID,
+				GIID:       int(gi),
+				CIID:       int(ci),
+			})
 		}
-
-		return devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
-			ParentUUID: parentUUID,
-			GIID:       int(gi),
-			CIID:       int(ci),
-		}), nil
+		if device == nil {
+			return nil, nil
+		}
+		return []*AllocatableDevice{device}, nil
 
 	default:
 		// A GI can exist without a CI, but it does not represent a usable,

--- a/cmd/gpu-kubelet-plugin/device_health_status.go
+++ b/cmd/gpu-kubelet-plugin/device_health_status.go
@@ -1,0 +1,287 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+// This file implements device health reporting (KEP-4680) for the GPU kubelet
+// plugin: the version-neutral [kubeletplugin.DRAPlugin] WatchHealthStatus
+// API, through which the health of allocated GPUs surfaces in
+// pod.status.containerStatuses[].allocatedResourcesStatus.
+//
+// There is exactly one health state per device: the DRA device taints
+// (KEP-5055) that the NVML health monitor's events put on each
+// AllocatableDevice and that are published in the ResourceSlice. The health
+// reported to the kubelet is derived from those taints at report time
+// (deviceHealthFromTaints), so the scheduler-facing and the pod-facing view of
+// a device can never disagree: whatever makes a taint sticky, or removes it
+// (a destroyed dynamic MIG device, a re-discovered VFIO sibling), applies to
+// both.
+
+// deviceHealthFromTaints derives the kubelet-facing health of a device from
+// its taints:
+//
+//   - a NoSchedule health taint (critical XID, GPU lost) makes it Unhealthy;
+//   - an unmonitored taint makes it Unknown;
+//   - an informational XID taint keeps it Healthy but surfaces the event;
+//   - without health taints it is Healthy, except for VFIO passthrough
+//     devices, which NVML cannot observe and which are therefore Unknown.
+//
+// The taints are sticky in the critical direction (AddOrUpdateTaint never
+// lowers an effect), so once a device is Unhealthy a later non-fatal event
+// does not mask the unrecovered failure. Recovery requires fixing the device
+// and restarting the driver, which re-discovers the device without taints.
+func deviceHealthFromTaints(dev *AllocatableDevice) (kubeletplugin.HealthStatus, string) {
+	var unmonitored, informational *resourceapi.DeviceTaint
+	taints := dev.Taints()
+	for i := range taints {
+		taint := &taints[i]
+		switch taint.Key {
+		case TaintKeyGPULost:
+			if taint.Effect != resourceapi.DeviceTaintEffectNone {
+				return kubeletplugin.HealthStatusUnhealthy, "GPU is lost"
+			}
+		case TaintKeyXID:
+			if taint.Effect != resourceapi.DeviceTaintEffectNone {
+				return kubeletplugin.HealthStatusUnhealthy, fmt.Sprintf("critical XID %s reported by NVML", taint.Value)
+			}
+			informational = taint
+		case TaintKeyUnmonitored:
+			unmonitored = taint
+		}
+	}
+	switch {
+	case unmonitored != nil:
+		return kubeletplugin.HealthStatusUnknown, "device health is not monitored"
+	case informational != nil:
+		return kubeletplugin.HealthStatusHealthy, fmt.Sprintf("non-fatal XID %s reported by NVML", informational.Value)
+	case dev.Type() == VfioDeviceType:
+		return kubeletplugin.HealthStatusUnknown, "vfio passthrough devices are not covered by the NVML health monitor"
+	default:
+		return kubeletplugin.HealthStatusHealthy, ""
+	}
+}
+
+// applyQueuedHealthEvents applies the health events the NVML monitor queued
+// during event registration (devices it could not register are reported as
+// unmonitored) as device taints, before the health service is advertised and
+// before the initial ResourceSlice publish. An early kubelet subscription
+// therefore never sees such a device as Healthy, and the initial slices carry
+// the taints without a republish.
+func (d *driver) applyQueuedHealthEvents() {
+	if d.deviceHealthMonitor == nil {
+		return
+	}
+	for {
+		select {
+		case event, ok := <-d.deviceHealthMonitor.Unhealthy():
+			if !ok {
+				return
+			}
+			event.logIfUnknownType()
+			taint := healthEventToTaint(d.deviceHealthMonitor, event)
+			for _, dev := range event.Devices {
+				klog.Warningf("Received %s health event for device %s during startup", event.EventType, dev.CanonicalName())
+				d.state.AddDeviceTaint(dev, taint)
+			}
+		default:
+			return
+		}
+	}
+}
+
+// deviceHealthChanged is called after the device taints or the device set
+// changed (a health event was applied, a taint was removed, a VFIO sibling
+// re-discovered): it refreshes the health snapshot from the devices and wakes
+// the WatchHealthStatus subscribers so they re-send it. The refresh waits for
+// the state lock: the callers have just modified the devices under that lock
+// themselves, so it is free or about to be, and the snapshot must reflect the
+// change before the subscribers wake, whatever claim operation runs next.
+func (d *driver) deviceHealthChanged() {
+	d.refreshDeviceHealth()
+	d.notifyHealthSubscribers()
+}
+
+// deviceHealthConfirmed is called on each heartbeat of the NVML monitor's
+// event loop: the health of every device is confirmed as current, and the
+// subscribers re-send it with a fresh timestamp. (The kubelet stamps its own
+// receipt time on each report; the timestamp is kept fresh for the kubelet
+// plugin helper and for readers of the stream.)
+func (d *driver) deviceHealthConfirmed() {
+	d.touchDeviceHealth()
+	d.notifyHealthSubscribers()
+}
+
+func (d *driver) touchDeviceHealth() {
+	d.healthMu.Lock()
+	d.healthUpdatedAt = time.Now()
+	d.healthMu.Unlock()
+}
+
+// refreshDeviceHealth rebuilds the health snapshot from the current device
+// taints, waiting for the state lock if a claim operation holds it. NewDriver
+// calls it once before the kubelet can subscribe, so that the initial report
+// always covers all devices; deviceHealthChanged calls it after every taint
+// or device set change.
+func (d *driver) refreshDeviceHealth() {
+	d.state.Lock()
+	entries := d.snapshotDeviceHealthLocked()
+	d.state.Unlock()
+
+	d.healthMu.Lock()
+	d.lastHealthReport = entries
+	d.healthMu.Unlock()
+}
+
+// snapshotDeviceHealthLocked derives the health of every allocatable device
+// from its taints. The state lock must be held.
+func (d *driver) snapshotDeviceHealthLocked() []kubeletplugin.DeviceHealth {
+	allocatable := d.state.perGPUAllocatable.GetAllDevices()
+	entries := make([]kubeletplugin.DeviceHealth, 0, len(allocatable))
+	for devname, dev := range allocatable {
+		health, message := deviceHealthFromTaints(dev)
+		entries = append(entries, kubeletplugin.DeviceHealth{
+			PoolName:   d.nodeName,
+			DeviceName: devname,
+			Health:     health,
+			Message:    message,
+		})
+	}
+	return entries
+}
+
+// buildHealthReport returns the health of every allocatable device, derived
+// from its taints. The allocatable device maps are mutated at claim prepare
+// and unprepare time under the state lock, which those operations hold for
+// their whole duration. A report must never wait behind a slow prepare, or
+// the kubelet's health check timeout expires and every device decays to
+// Unknown while NVML is fine: when the lock is busy the last snapshot is
+// re-sent with a fresh timestamp. That snapshot is never stale: every taint
+// or device set change refreshes it (deviceHealthChanged) before the
+// subscribers are woken, and NewDriver seeds it before the kubelet can
+// subscribe.
+func (d *driver) buildHealthReport() kubeletplugin.DeviceHealthReport {
+	d.healthMu.Lock()
+	defer d.healthMu.Unlock()
+
+	if d.healthUpdatedAt.IsZero() {
+		d.healthUpdatedAt = time.Now()
+	}
+
+	if d.state.TryLock() {
+		d.lastHealthReport = d.snapshotDeviceHealthLocked()
+		d.state.Unlock()
+	} else {
+		klog.V(6).Info("Device state busy; re-sending the previous health report")
+	}
+
+	devices := make([]kubeletplugin.DeviceHealth, len(d.lastHealthReport))
+	for i, entry := range d.lastHealthReport {
+		entry.LastUpdated = d.healthUpdatedAt
+		devices[i] = entry
+	}
+	return kubeletplugin.DeviceHealthReport{Devices: devices}
+}
+
+// notifyHealthSubscribers wakes all pending WatchHealthStatus calls to send a
+// fresh health report. The subscriber channels have capacity one and the send
+// is non-blocking, so notifications coalesce: however many updates arrive
+// while a subscriber is busy, it wakes once and builds the latest snapshot at
+// send time. No health data is queued here; the state lives on the devices
+// and this is only a notification.
+func (d *driver) notifyHealthSubscribers() {
+	d.healthSubMu.RLock()
+	defer d.healthSubMu.RUnlock()
+
+	for _, subscriber := range d.healthSubscribers {
+		select {
+		case subscriber <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// WatchHealthStatus implements [kubeletplugin.DRAPlugin]. The kubeletplugin
+// helper calls it whenever the kubelet subscribes to device health updates and
+// takes care of translating the reports into the DRAResourceHealth gRPC API
+// version that the kubelet supports.
+func (d *driver) WatchHealthStatus(ctx context.Context, reports chan<- kubeletplugin.DeviceHealthReport) error {
+	if !featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
+		// The health service is not advertised in this case (see the
+		// HealthService option in NewDriver), so the kubelet is not expected
+		// to subscribe at all; answer any stray subscription accordingly.
+		return kubeletplugin.ErrHealthNotSupported
+	}
+
+	klog.V(4).Info("Kubelet subscribed to device health updates")
+
+	// A capacity-one notification channel: notifications coalesce, and the
+	// report is built fresh at send time (see notifyHealthSubscribers).
+	subscriber := make(chan struct{}, 1)
+	d.healthSubMu.Lock()
+	d.healthSubscribers = append(d.healthSubscribers, subscriber)
+	d.healthSubMu.Unlock()
+
+	defer func() {
+		d.healthSubMu.Lock()
+		d.healthSubscribers = slices.DeleteFunc(d.healthSubscribers, func(ch chan struct{}) bool {
+			return ch == subscriber
+		})
+		d.healthSubMu.Unlock()
+		klog.V(4).Info("Kubelet unsubscribed from device health updates")
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case reports <- d.buildHealthReport():
+	}
+
+	// Send a fresh snapshot on every notification. Periodic resends
+	// (required because the kubelet treats health data older than the
+	// health check timeout as stale) are not generated here: the
+	// notifications are driven by the NVML monitor's heartbeat, so that a
+	// resend is evidence the monitoring loop is actually alive.
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-subscriber:
+			// Empty reports (a node with no allocatable devices) are sent
+			// too: they are valid subset reports for the kubelet, and the
+			// kubeletplugin helper resets its staleness tracking only when
+			// it receives a report, so suppressing them would trigger
+			// spurious staleness errors on device-less nodes.
+			select {
+			case <-ctx.Done():
+				return nil
+			case reports <- d.buildHealthReport():
+			}
+		}
+	}
+}

--- a/cmd/gpu-kubelet-plugin/device_health_status_test.go
+++ b/cmd/gpu-kubelet-plugin/device_health_status_test.go
@@ -1,0 +1,628 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+// newHealthTestDriver builds a driver with a single full GPU device gpu-0
+// (GpuInfo minor 0) and a republish stub, ready to exercise health reporting.
+func newHealthTestDriver(monitor deviceHealthMonitor) (*driver, *AllocatableDevice) {
+	dev := &AllocatableDevice{Gpu: &GpuInfo{}}
+	d := &driver{
+		nodeName:            "node1",
+		deviceHealthMonitor: monitor,
+		state: &DeviceState{
+			perGPUAllocatable: &PerGPUAllocatableDevices{
+				allocatablesMap: map[PCIBusID]AllocatableDevices{
+					"0000:01:00.0": {"gpu-0": dev},
+				},
+			},
+		},
+		republishResources: func(context.Context) error { return nil },
+	}
+	return d, dev
+}
+
+// enableHealthGate turns the NVMLDeviceHealthCheck feature gate on for the
+// duration of the test; WatchHealthStatus declines subscriptions without it.
+func enableHealthGate(t *testing.T) {
+	t.Helper()
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+		string(featuregates.NVMLDeviceHealthCheck): true,
+	}))
+	t.Cleanup(func() {
+		require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{
+			string(featuregates.NVMLDeviceHealthCheck): false,
+		}))
+	})
+}
+
+// startWatch runs WatchHealthStatus in a goroutine, consumes and returns the
+// initial snapshot, and hands back the reports channel plus a stop function
+// which cancels the watch and asserts it returns cleanly.
+func startWatch(t *testing.T, d *driver) (kubeletplugin.DeviceHealthReport, <-chan kubeletplugin.DeviceHealthReport, func()) {
+	t.Helper()
+	enableHealthGate(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	reports := make(chan kubeletplugin.DeviceHealthReport)
+	done := make(chan error, 1)
+	go func() {
+		done <- d.WatchHealthStatus(ctx, reports)
+	}()
+
+	var initial kubeletplugin.DeviceHealthReport
+	select {
+	case initial = <-reports:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial health report")
+	}
+
+	stop := func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("WatchHealthStatus returned error: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for WatchHealthStatus to return")
+		}
+	}
+	return initial, reports, stop
+}
+
+// receiveReport reads one health report or fails the test.
+func receiveReport(t *testing.T, reports <-chan kubeletplugin.DeviceHealthReport) kubeletplugin.DeviceHealthReport {
+	t.Helper()
+	select {
+	case report := <-reports:
+		return report
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for health report")
+		return kubeletplugin.DeviceHealthReport{}
+	}
+}
+
+func reportByName(report kubeletplugin.DeviceHealthReport) map[string]kubeletplugin.DeviceHealth {
+	byName := map[string]kubeletplugin.DeviceHealth{}
+	for _, dev := range report.Devices {
+		byName[dev.DeviceName] = dev
+	}
+	return byName
+}
+
+func newTaint(key, value string, effect resourceapi.DeviceTaintEffect) *resourceapi.DeviceTaint {
+	return &resourceapi.DeviceTaint{Key: key, Value: value, Effect: effect}
+}
+
+// TestDeviceHealthFromTaints verifies the single mapping from a device's
+// taints (the health state shared with the ResourceSlice) to the health
+// reported to the kubelet.
+func TestDeviceHealthFromTaints(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent"}
+	testCases := []struct {
+		name            string
+		dev             *AllocatableDevice
+		taints          []*resourceapi.DeviceTaint
+		expectedHealth  kubeletplugin.HealthStatus
+		expectedMessage string
+	}{
+		{
+			name:           "full GPU without taints",
+			dev:            &AllocatableDevice{Gpu: parent},
+			expectedHealth: kubeletplugin.HealthStatusHealthy,
+		},
+		{
+			name:           "static MIG without taints",
+			dev:            &AllocatableDevice{MigStatic: &MigDeviceInfo{parent: parent}},
+			expectedHealth: kubeletplugin.HealthStatusHealthy,
+		},
+		{
+			name:           "dynamic MIG without taints (GPU-scoped events fan out to it)",
+			dev:            &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent}},
+			expectedHealth: kubeletplugin.HealthStatusHealthy,
+		},
+		{
+			name:            "VFIO passthrough cannot be observed",
+			dev:             &AllocatableDevice{Vfio: &VfioDeviceInfo{UUID: "GPU-parent", PciBusID: "0000:01:00.0"}},
+			expectedHealth:  kubeletplugin.HealthStatusUnknown,
+			expectedMessage: "vfio passthrough devices are not covered by the NVML health monitor",
+		},
+		{
+			name:            "critical XID",
+			dev:             &AllocatableDevice{Gpu: parent},
+			taints:          []*resourceapi.DeviceTaint{newTaint(TaintKeyXID, "79", resourceapi.DeviceTaintEffectNoSchedule)},
+			expectedHealth:  kubeletplugin.HealthStatusUnhealthy,
+			expectedMessage: "critical XID 79 reported by NVML",
+		},
+		{
+			name:            "non-fatal XID",
+			dev:             &AllocatableDevice{Gpu: parent},
+			taints:          []*resourceapi.DeviceTaint{newTaint(TaintKeyXID, "31", resourceapi.DeviceTaintEffectNone)},
+			expectedHealth:  kubeletplugin.HealthStatusHealthy,
+			expectedMessage: "non-fatal XID 31 reported by NVML",
+		},
+		{
+			name:            "GPU lost",
+			dev:             &AllocatableDevice{Gpu: parent},
+			taints:          []*resourceapi.DeviceTaint{newTaint(TaintKeyGPULost, "", resourceapi.DeviceTaintEffectNoSchedule)},
+			expectedHealth:  kubeletplugin.HealthStatusUnhealthy,
+			expectedMessage: "GPU is lost",
+		},
+		{
+			name:            "unmonitored",
+			dev:             &AllocatableDevice{Gpu: parent},
+			taints:          []*resourceapi.DeviceTaint{newTaint(TaintKeyUnmonitored, "", resourceapi.DeviceTaintEffectNone)},
+			expectedHealth:  kubeletplugin.HealthStatusUnknown,
+			expectedMessage: "device health is not monitored",
+		},
+		{
+			name: "critical outranks unmonitored and informational",
+			dev:  &AllocatableDevice{Gpu: parent},
+			taints: []*resourceapi.DeviceTaint{
+				newTaint(TaintKeyUnmonitored, "", resourceapi.DeviceTaintEffectNone),
+				newTaint(TaintKeyGPULost, "", resourceapi.DeviceTaintEffectNoSchedule),
+			},
+			expectedHealth:  kubeletplugin.HealthStatusUnhealthy,
+			expectedMessage: "GPU is lost",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, taint := range tc.taints {
+				tc.dev.AddOrUpdateTaint(taint)
+			}
+			health, message := deviceHealthFromTaints(tc.dev)
+			assert.Equal(t, tc.expectedHealth, health)
+			assert.Equal(t, tc.expectedMessage, message)
+		})
+	}
+}
+
+// TestApplyQueuedHealthEvents verifies that health events queued by the
+// monitor during registration (devices it could not register) are applied as
+// taints before the health service is advertised, so both the initial
+// ResourceSlice and an early kubelet subscription see the device as
+// unmonitored.
+func TestApplyQueuedHealthEvents(t *testing.T) {
+	gpu0 := &AllocatableDevice{Gpu: &GpuInfo{minor: 0}}
+	gpu1 := &AllocatableDevice{Gpu: &GpuInfo{minor: 1}}
+	unhealthy := make(chan *DeviceHealthEvent, 1)
+	unhealthy <- &DeviceHealthEvent{Devices: []*AllocatableDevice{gpu1}, EventType: HealthEventUnmonitored}
+	d := &driver{
+		nodeName:            "node1",
+		deviceHealthMonitor: &mockHealthMonitor{unhealthyCh: unhealthy},
+		state: &DeviceState{
+			perGPUAllocatable: &PerGPUAllocatableDevices{
+				allocatablesMap: map[PCIBusID]AllocatableDevices{
+					"0000:01:00.0": {"gpu-0": gpu0},
+					"0000:02:00.0": {"gpu-1": gpu1},
+				},
+			},
+		},
+	}
+
+	d.applyQueuedHealthEvents()
+
+	assert.Empty(t, unhealthy, "queued events must be drained")
+	assert.Empty(t, gpu0.Taints())
+	require.Len(t, gpu1.Taints(), 1)
+	assert.Equal(t, TaintKeyUnmonitored, gpu1.Taints()[0].Key)
+
+	initial, _, stopWatch := startWatch(t, d)
+	defer stopWatch()
+	byName := reportByName(initial)
+	assert.Equal(t, kubeletplugin.HealthStatusHealthy, byName["gpu-0"].Health)
+	assert.Equal(t, kubeletplugin.HealthStatusUnknown, byName["gpu-1"].Health)
+}
+
+// TestDeviceHealthEvents_HeartbeatResends verifies that a heartbeat from the
+// NVML monitor's event loop wakes the watcher and re-sends a report with a
+// fresh timestamp: the kubelet compares LastUpdated against its health check
+// timeout, so a resend with a stale timestamp would still let the device
+// decay to Unknown.
+func TestDeviceHealthEvents_HeartbeatResends(t *testing.T) {
+	monitor := &mockHealthMonitor{heartbeatCh: make(chan struct{}, 1)}
+	d, _ := newHealthTestDriver(monitor)
+	d.healthUpdatedAt = time.Now().Add(-time.Minute)
+
+	initial, reports, stopWatch := startWatch(t, d)
+	defer stopWatch()
+	require.Len(t, initial.Devices, 1)
+	stale := initial.Devices[0].LastUpdated
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	eventsDone := make(chan struct{})
+	go func() {
+		defer close(eventsDone)
+		d.deviceHealthHeartbeats(ctx)
+	}()
+
+	before := time.Now()
+	monitor.heartbeatCh <- struct{}{}
+
+	report := receiveReport(t, reports)
+	require.Len(t, report.Devices, 1)
+	assert.Equal(t, "gpu-0", report.Devices[0].DeviceName)
+	assert.Equal(t, kubeletplugin.HealthStatusHealthy, report.Devices[0].Health)
+	assert.True(t, report.Devices[0].LastUpdated.After(stale))
+	assert.False(t, report.Devices[0].LastUpdated.Before(before), "heartbeat must refresh LastUpdated")
+
+	cancel()
+	<-eventsDone
+}
+
+// TestDeviceHealthEvents_EventTaintsAndReports verifies that an event from
+// the monitor taints the device, republishes the ResourceSlice once, and is
+// reported to the kubelet from that same taint.
+func TestDeviceHealthEvents_EventTaintsAndReports(t *testing.T) {
+	monitor := &mockHealthMonitor{
+		heartbeatCh: make(chan struct{}),
+		unhealthyCh: make(chan *DeviceHealthEvent, 1),
+	}
+	d, dev := newHealthTestDriver(monitor)
+	published := make(chan struct{}, 2)
+	d.republishResources = func(context.Context) error {
+		published <- struct{}{}
+		return nil
+	}
+
+	initial, reports, stopWatch := startWatch(t, d)
+	defer stopWatch()
+	require.Equal(t, kubeletplugin.HealthStatusHealthy, initial.Devices[0].Health)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	eventsDone := make(chan struct{})
+	go func() {
+		defer close(eventsDone)
+		d.deviceHealthEvents(ctx)
+	}()
+
+	monitor.unhealthyCh <- &DeviceHealthEvent{
+		EventType: HealthEventXID, EventData: 79, Devices: []*AllocatableDevice{dev},
+	}
+	select {
+	case <-published:
+	case <-time.After(5 * time.Second):
+		t.Fatal("event was not applied")
+	}
+	report := receiveReport(t, reports)
+	require.Len(t, report.Devices, 1)
+	assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, report.Devices[0].Health)
+	assert.Equal(t, "critical XID 79 reported by NVML", report.Devices[0].Message)
+	require.Len(t, dev.Taints(), 1)
+	assert.Equal(t, resourceapi.DeviceTaintEffectNoSchedule, dev.Taints()[0].Effect)
+
+	cancel()
+	<-eventsDone
+	assert.Empty(t, published, "one event must republish exactly once")
+}
+
+// TestDeviceHealth_UnhealthyIsSticky verifies that once a device is
+// unhealthy, later events cannot flip it back: a non-fatal XID after a
+// critical one must not mask the unrecovered failure. This follows from the
+// taints being the single health state and AddOrUpdateTaint never lowering
+// an effect.
+func TestDeviceHealth_UnhealthyIsSticky(t *testing.T) {
+	monitor := &mockHealthMonitor{nonFatalXids: map[uint64]bool{31: true}}
+	d, dev := newHealthTestDriver(monitor)
+	ctx := t.Context()
+
+	d.applyHealthEventTaint(ctx, &DeviceHealthEvent{
+		EventType: HealthEventXID, EventData: 79, Devices: []*AllocatableDevice{dev},
+	})
+	health, message := deviceHealthFromTaints(dev)
+	require.Equal(t, kubeletplugin.HealthStatusUnhealthy, health)
+
+	d.applyHealthEventTaint(ctx, &DeviceHealthEvent{
+		EventType: HealthEventXID, EventData: 31, Devices: []*AllocatableDevice{dev},
+	})
+	health2, message2 := deviceHealthFromTaints(dev)
+	assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, health2)
+	assert.Equal(t, message, message2, "the message must keep naming the critical failure")
+
+	d.applyHealthEventTaint(ctx, &DeviceHealthEvent{
+		EventType: HealthEventUnmonitored, Devices: []*AllocatableDevice{dev},
+	})
+	health3, _ := deviceHealthFromTaints(dev)
+	assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, health3, "unmonitored must not hide an unhealthy device")
+}
+
+// TestDeviceHealth_FollowsTaintRemoval verifies that removing a taint (as the
+// Dynamic MIG unprepare path does for a destroyed instance) is reflected in
+// the reported health, because both come from the same state.
+func TestDeviceHealth_FollowsTaintRemoval(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent"}
+	mig := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent}}
+	mig.AddOrUpdateTaint(newTaint(TaintKeyXID, "79", resourceapi.DeviceTaintEffectNoSchedule))
+	health, _ := deviceHealthFromTaints(mig)
+	require.Equal(t, kubeletplugin.HealthStatusUnhealthy, health)
+
+	_, removed := mig.RemoveTaint(TaintKeyXID)
+	require.True(t, removed)
+	health, message := deviceHealthFromTaints(mig)
+	assert.Equal(t, kubeletplugin.HealthStatusHealthy, health)
+	assert.Empty(t, message)
+}
+
+// TestNotifyHealthSubscribers_Coalesces verifies the notification semantics:
+// updates arriving while a watcher is busy collapse into a single pending
+// wake-up, and the report is built at send time, so the watcher sends one
+// report reflecting the latest state instead of a queue of stale snapshots.
+func TestNotifyHealthSubscribers_Coalesces(t *testing.T) {
+	monitor := &mockHealthMonitor{nonFatalXids: map[uint64]bool{31: true}}
+	d, dev := newHealthTestDriver(monitor)
+	ctx := t.Context()
+
+	// Register a subscriber directly, without a running watcher, to model a
+	// watcher which is busy while updates arrive.
+	subscriber := make(chan struct{}, 1)
+	d.healthSubMu.Lock()
+	d.healthSubscribers = append(d.healthSubscribers, subscriber)
+	d.healthSubMu.Unlock()
+
+	// A burst of updates and a heartbeat while the watcher is busy.
+	require.True(t, d.applyHealthEventTaint(ctx, &DeviceHealthEvent{
+		EventType: HealthEventXID, EventData: 31, Devices: []*AllocatableDevice{dev},
+	}))
+	d.deviceHealthChanged()
+	require.True(t, d.applyHealthEventTaint(ctx, &DeviceHealthEvent{
+		EventType: HealthEventXID, EventData: 79, Devices: []*AllocatableDevice{dev},
+	}))
+	d.deviceHealthChanged()
+	d.deviceHealthConfirmed()
+
+	// Exactly one pending wake-up, no queued snapshots.
+	require.Len(t, subscriber, 1)
+
+	// What the watcher does on wake-up: build the report at send time. It
+	// must reflect the latest state (the critical XID), not the first event
+	// of the burst.
+	<-subscriber
+	report := d.buildHealthReport()
+	require.Len(t, report.Devices, 1)
+	assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, report.Devices[0].Health)
+	assert.Contains(t, report.Devices[0].Message, "critical XID 79")
+
+	// Nothing left pending: the burst coalesced into that single wake-up.
+	assert.Empty(t, subscriber)
+}
+
+// TestBuildHealthReport_TracksDevices verifies that each report reflects the
+// current allocatable devices (for example a VFIO sibling removed and
+// re-added at unprepare), and that a report never waits behind the state
+// lock: while a claim operation holds it, the previous report is re-sent
+// with a fresh timestamp.
+func TestBuildHealthReport_TracksDevices(t *testing.T) {
+	d, _ := newHealthTestDriver(&mockHealthMonitor{})
+
+	d.state.Lock()
+	d.state.perGPUAllocatable.allocatablesMap["0000:02:00.0"] = AllocatableDevices{
+		"gpu-1": {Gpu: &GpuInfo{}},
+	}
+	d.state.Unlock()
+	report := d.buildHealthReport()
+	require.Len(t, report.Devices, 2)
+	assert.Equal(t, kubeletplugin.HealthStatusHealthy, reportByName(report)["gpu-1"].Health)
+
+	d.state.Lock()
+	delete(d.state.perGPUAllocatable.allocatablesMap, "0000:01:00.0")
+	d.state.Unlock()
+	report = d.buildHealthReport()
+	require.Len(t, report.Devices, 1)
+	assert.Equal(t, "gpu-1", report.Devices[0].DeviceName)
+	first := report.Devices[0].LastUpdated
+
+	// State lock held by a claim operation which is changing the device
+	// set: the report must come back at once with the previous snapshot
+	// (not the half-modified map) and a fresh timestamp.
+	d.state.Lock()
+	d.state.perGPUAllocatable.allocatablesMap["0000:03:00.0"] = AllocatableDevices{
+		"gpu-2": {Gpu: &GpuInfo{}},
+	}
+	d.touchDeviceHealth()
+	done := make(chan kubeletplugin.DeviceHealthReport, 1)
+	go func() { done <- d.buildHealthReport() }()
+	select {
+	case report = <-done:
+	case <-time.After(2 * time.Second):
+		d.state.Unlock()
+		t.Fatal("buildHealthReport blocked on the state lock")
+	}
+	d.state.Unlock()
+	require.Len(t, report.Devices, 1)
+	assert.Equal(t, "gpu-1", report.Devices[0].DeviceName)
+	assert.True(t, report.Devices[0].LastUpdated.After(first))
+
+	// Lock released: the next report picks up the change.
+	report = d.buildHealthReport()
+	require.Len(t, report.Devices, 2)
+	assert.Contains(t, reportByName(report), "gpu-2")
+}
+
+// runHealthConsumers starts the driver's health consumer goroutines the way
+// NewDriver does and returns a function that stops them.
+func runHealthConsumers(t *testing.T, d *driver) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	d.startDeviceHealthConsumers(ctx)
+	return func() {
+		cancel()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.wg.Wait()
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for health consumers to stop")
+		}
+	}
+}
+
+// expectNoReport asserts that no health report arrives within d.
+func expectNoReport(t *testing.T, reports <-chan kubeletplugin.DeviceHealthReport, d time.Duration, msg string) {
+	t.Helper()
+	select {
+	case <-reports:
+		t.Fatal(msg)
+	case <-time.After(d):
+	}
+}
+
+// TestHeartbeatResend_NotStarvedByStateLock verifies that a heartbeat still
+// triggers a re-send while the event consumer is parked on the state lock
+// (a health event arrived during a long Prepare/Unprepare). If it did not,
+// the kubelet would decay every device to Unknown while NVML is answering.
+func TestHeartbeatResend_NotStarvedByStateLock(t *testing.T) {
+	monitor := &mockHealthMonitor{
+		heartbeatCh: make(chan struct{}, 1),
+		unhealthyCh: make(chan *DeviceHealthEvent, 1),
+	}
+	d, dev := newHealthTestDriver(monitor)
+	_, reports, stopWatch := startWatch(t, d)
+	defer stopWatch()
+
+	stopConsumers := runHealthConsumers(t, d)
+	defer stopConsumers()
+
+	// A claim operation holds the state lock for a long time.
+	d.state.Lock()
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			d.state.Unlock()
+		}
+	}()
+
+	// An event arrives; the consumer dequeues it and blocks in AddDeviceTaint.
+	monitor.unhealthyCh <- &DeviceHealthEvent{
+		EventType: HealthEventXID, EventData: 79, Devices: []*AllocatableDevice{dev},
+	}
+	require.Eventually(t, func() bool { return len(monitor.unhealthyCh) == 0 }, 5*time.Second, 5*time.Millisecond)
+
+	// The monitor keeps beating: the report must still be re-sent (the
+	// previous snapshot with a fresh timestamp), the lock must not matter.
+	monitor.heartbeatCh <- struct{}{}
+	select {
+	case report := <-reports:
+		require.Len(t, report.Devices, 1)
+		assert.Equal(t, kubeletplugin.HealthStatusHealthy, report.Devices[0].Health, "previous snapshot is re-sent while the lock is busy")
+	case <-time.After(2 * time.Second):
+		t.Fatal("heartbeat re-send was starved by the state lock")
+	}
+
+	// Release the lock: the event is applied and reported.
+	d.state.Unlock()
+	unlocked = true
+	require.Eventually(t, func() bool {
+		select {
+		case report := <-reports:
+			return report.Devices[0].Health == kubeletplugin.HealthStatusUnhealthy
+		default:
+			return false
+		}
+	}, 5*time.Second, 5*time.Millisecond, "event must be reported once the lock is released")
+}
+
+// TestWatchHealthStatus_InitialReportWhileStateLockBusy verifies that the
+// initial report covers all devices even when a claim operation holds the
+// state lock at subscription time (the DRAPlugin contract requires an
+// initial report covering all devices).
+func TestWatchHealthStatus_InitialReportWhileStateLockBusy(t *testing.T) {
+	d, _ := newHealthTestDriver(&mockHealthMonitor{})
+	// NewDriver seeds the snapshot before the kubelet can subscribe.
+	d.refreshDeviceHealth()
+
+	d.state.Lock()
+	initial, _, stopWatch := startWatch(t, d)
+	d.state.Unlock()
+	defer stopWatch()
+
+	require.Len(t, initial.Devices, 1, "initial report must cover all devices even while the state lock is busy")
+	assert.Equal(t, "gpu-0", initial.Devices[0].DeviceName)
+}
+
+// TestDeviceHealth_TaintChangeReportedWhileStateLockBusy verifies that a
+// taint applied by the event consumer is reflected in the next report even
+// if a claim operation grabs the state lock before the watcher wakes up. A
+// re-sent snapshot must never carry a fresh timestamp for stale health.
+func TestDeviceHealth_TaintChangeReportedWhileStateLockBusy(t *testing.T) {
+	d, dev := newHealthTestDriver(&mockHealthMonitor{})
+	require.Equal(t, kubeletplugin.HealthStatusHealthy, d.buildHealthReport().Devices[0].Health)
+
+	// What the event consumer does for an event.
+	require.True(t, d.applyHealthEventTaint(t.Context(), &DeviceHealthEvent{
+		EventType: HealthEventXID, EventData: 79, Devices: []*AllocatableDevice{dev},
+	}))
+	d.deviceHealthChanged()
+
+	// A claim operation takes the lock before the watcher builds its report.
+	d.state.Lock()
+	defer d.state.Unlock()
+	report := d.buildHealthReport()
+	require.Len(t, report.Devices, 1)
+	assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, report.Devices[0].Health, "applied taint must be reported even while the state lock is busy")
+}
+
+// TestDeviceHealthEvents_RepeatedEventDoesNotResend verifies that an event
+// which does not change any taint (a persistently lost GPU re-reports every
+// retry) neither republishes the ResourceSlice nor wakes the health watchers.
+func TestDeviceHealthEvents_RepeatedEventDoesNotResend(t *testing.T) {
+	monitor := &mockHealthMonitor{
+		heartbeatCh: make(chan struct{}),
+		unhealthyCh: make(chan *DeviceHealthEvent, 1),
+	}
+	d, dev := newHealthTestDriver(monitor)
+	published := make(chan struct{}, 4)
+	d.republishResources = func(context.Context) error {
+		published <- struct{}{}
+		return nil
+	}
+	_, reports, stopWatch := startWatch(t, d)
+	defer stopWatch()
+	stopConsumers := runHealthConsumers(t, d)
+	defer stopConsumers()
+
+	event := func() *DeviceHealthEvent {
+		return &DeviceHealthEvent{EventType: HealthEventGPULost, Devices: []*AllocatableDevice{dev}}
+	}
+
+	monitor.unhealthyCh <- event()
+	report := receiveReport(t, reports)
+	assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, report.Devices[0].Health)
+	require.Len(t, published, 1)
+
+	monitor.unhealthyCh <- event()
+	require.Eventually(t, func() bool { return len(monitor.unhealthyCh) == 0 }, 5*time.Second, 5*time.Millisecond)
+	expectNoReport(t, reports, 200*time.Millisecond, "a repeated event with no taint change must not re-send the health report")
+	assert.Len(t, published, 1, "a repeated event with no taint change must not republish")
+}

--- a/cmd/gpu-kubelet-plugin/device_health_test.go
+++ b/cmd/gpu-kubelet-plugin/device_health_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	nvdev "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -31,11 +32,14 @@ import (
 // mockHealthMonitor implements deviceHealthMonitor for testing healthEventToTaint.
 type mockHealthMonitor struct {
 	nonFatalXids map[uint64]bool
+	heartbeatCh  chan struct{}
+	unhealthyCh  chan *DeviceHealthEvent
 }
 
 func (m *mockHealthMonitor) Start(context.Context) error          { return nil }
 func (m *mockHealthMonitor) Stop()                                {}
-func (m *mockHealthMonitor) Unhealthy() <-chan *DeviceHealthEvent { return nil }
+func (m *mockHealthMonitor) Unhealthy() <-chan *DeviceHealthEvent { return m.unhealthyCh }
+func (m *mockHealthMonitor) Heartbeat() <-chan struct{}           { return m.heartbeatCh }
 func (m *mockHealthMonitor) IsEventNonFatal(e *DeviceHealthEvent) bool {
 	if e.EventType == HealthEventXID {
 		return m.nonFatalXids[e.EventData]
@@ -127,6 +131,38 @@ func TestAddOrUpdateTaint_DifferentKeysAppended(t *testing.T) {
 	require.Len(t, taints, 2)
 	assert.Equal(t, TaintKeyXID, taints[0].Key)
 	assert.Equal(t, TaintKeyGPULost, taints[1].Key)
+}
+
+// A non-fatal event after a critical one must not weaken the taint: the
+// device stays NoSchedule with the critical Xid, matching the sticky
+// Unhealthy device health reported from the same events.
+func TestAddOrUpdateTaint_NeverDowngradesEffect(t *testing.T) {
+	dev := &AllocatableDevice{}
+	dev.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+		Key:    TaintKeyXID,
+		Value:  "79",
+		Effect: resourceapi.DeviceTaintEffectNoSchedule,
+	})
+
+	changed := dev.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+		Key:    TaintKeyXID,
+		Value:  "43",
+		Effect: resourceapi.DeviceTaintEffectNone,
+	})
+
+	require.False(t, changed, "a weaker event must not modify the taint")
+	require.Len(t, dev.Taints(), 1)
+	assert.Equal(t, "79", dev.Taints()[0].Value)
+	assert.Equal(t, resourceapi.DeviceTaintEffectNoSchedule, dev.Taints()[0].Effect)
+
+	// A later critical event still updates the value.
+	changed = dev.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+		Key:    TaintKeyXID,
+		Value:  "74",
+		Effect: resourceapi.DeviceTaintEffectNoSchedule,
+	})
+	require.True(t, changed)
+	assert.Equal(t, "74", dev.Taints()[0].Value)
 }
 
 func TestAddOrUpdateTaint_TimeAddedResetOnChange(t *testing.T) {
@@ -375,7 +411,7 @@ func TestAllocatableDevicesFindDynamicMIGBySpec(t *testing.T) {
 	}
 }
 
-func TestResolveDeviceByEventAddressUsesGPUUUIDIndex(t *testing.T) {
+func TestResolveDevicesByEventAddressUsesGPUUUIDIndex(t *testing.T) {
 	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0, pciBusID: "0000:01:00.0"}
 	staticMIG := &AllocatableDevice{
 		MigStatic: &MigDeviceInfo{
@@ -395,17 +431,64 @@ func TestResolveDeviceByEventAddressUsesGPUUUIDIndex(t *testing.T) {
 		gpuInfosByUUID: map[string]*GpuInfo{parent.UUID: parent},
 	}
 
-	got, err := monitor.resolveDeviceByEventAddress(parent.UUID, nil, 2, 3)
+	got, err := monitor.resolveDevicesByEventAddress(parent.UUID, nil, 2, 3)
 	require.NoError(t, err)
-	require.Equal(t, staticMIG, got)
+	require.Equal(t, []*AllocatableDevice{staticMIG}, got)
 
-	got, err = monitor.resolveDeviceByEventAddress(parent.UUID, nil, FullGPUInstanceID, 3)
-	require.Nil(t, got)
+	got, err = monitor.resolveDevicesByEventAddress(parent.UUID, nil, 2, 4)
+	require.NoError(t, err)
+	require.Empty(t, got, "unknown MIG address resolves to no device")
+
+	got, err = monitor.resolveDevicesByEventAddress(parent.UUID, nil, FullGPUInstanceID, 3)
+	require.Empty(t, got)
 	require.NoError(t, err)
 
-	_, err = monitor.resolveDeviceByEventAddress("GPU-unknown", nil, 2, 3)
+	_, err = monitor.resolveDevicesByEventAddress("GPU-unknown", nil, 2, 3)
 	require.ErrorContains(t, err, "failed to find parent GPU UUID")
+}
 
+// TestResolveDevicesByEventAddress_GPUScopedEventCoversMIGDevices verifies
+// that a full-GPU event (GI and CI both FullGPUInstanceID) affects the GPU and
+// every MIG device on it, so that a pod using a MIG device sees the parent
+// GPU's critical XID in its health, including when the full GPU itself is not
+// allocatable.
+func TestResolveDevicesByEventAddress_GPUScopedEventCoversMIGDevices(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", minor: 0, pciBusID: "0000:01:00.0"}
+	other := &GpuInfo{UUID: "GPU-parent-2", minor: 1, pciBusID: "0000:02:00.0"}
+	fullGPU := &AllocatableDevice{Gpu: parent}
+	staticMIG := &AllocatableDevice{MigStatic: &MigDeviceInfo{ParentUUID: parent.UUID, GIID: 2, CIID: 3, parent: parent}}
+	dynamicMIG := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent}}
+	otherGPU := &AllocatableDevice{Gpu: other}
+
+	newMonitor := func(devices AllocatableDevices) *nvmlDeviceHealthMonitor {
+		return &nvmlDeviceHealthMonitor{
+			perGPUAllocatable: &PerGPUAllocatableDevices{
+				allocatablesMap: map[PCIBusID]AllocatableDevices{
+					parent.pciBusID: devices,
+					other.pciBusID:  {"gpu-1": otherGPU},
+				},
+			},
+			gpuInfosByUUID: map[string]*GpuInfo{parent.UUID: parent, other.UUID: other},
+		}
+	}
+
+	// Full GPU allocatable alongside MIG devices (Dynamic MIG on Hopper).
+	monitor := newMonitor(AllocatableDevices{"gpu-0": fullGPU, "static": staticMIG, "dynamic": dynamicMIG})
+	got, err := monitor.resolveDevicesByEventAddress(parent.UUID, nil, FullGPUInstanceID, FullGPUInstanceID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*AllocatableDevice{fullGPU, staticMIG, dynamicMIG}, got)
+	assert.NotContains(t, got, otherGPU, "devices of other GPUs are unaffected")
+
+	// Full GPU not allocatable (static MIG mode, Dynamic MIG on Ampere).
+	monitor = newMonitor(AllocatableDevices{"static": staticMIG, "dynamic": dynamicMIG})
+	got, err = monitor.resolveDevicesByEventAddress(parent.UUID, nil, FullGPUInstanceID, FullGPUInstanceID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*AllocatableDevice{staticMIG, dynamicMIG}, got)
+
+	// A MIG-scoped event still affects only that MIG device.
+	got, err = monitor.resolveDevicesByEventAddress(parent.UUID, nil, 2, 3)
+	require.NoError(t, err)
+	assert.Equal(t, []*AllocatableDevice{staticMIG}, got)
 }
 
 func TestAllocatableDevicesFindRejectsWrongParent(t *testing.T) {
@@ -437,6 +520,140 @@ func TestAllocatableDevicesFindRejectsWrongParent(t *testing.T) {
 		GIID:       2,
 		CIID:       3,
 	}))
+}
+
+// fakeEventSet is an nvml.EventSet whose Wait returns scripted results.
+type fakeEventSet struct {
+	rets  []nvml.Return
+	calls int
+}
+
+func (f *fakeEventSet) Free() nvml.Return { return nvml.SUCCESS }
+func (f *fakeEventSet) Wait(uint32) (nvml.EventData, nvml.Return) {
+	ret := f.rets[len(f.rets)-1]
+	if f.calls < len(f.rets) {
+		ret = f.rets[f.calls]
+	}
+	f.calls++
+	return nvml.EventData{}, ret
+}
+
+// runMonitorFor drives the monitor's event loop against the fake event set
+// until the context expires and reports whether a heartbeat was emitted.
+func runMonitorFor(t *testing.T, rets []nvml.Return, d time.Duration) bool {
+	t.Helper()
+	m := &nvmlDeviceHealthMonitor{
+		eventSet:          &fakeEventSet{rets: rets},
+		unhealthy:         make(chan *DeviceHealthEvent, 1),
+		heartbeat:         make(chan struct{}, 1),
+		perGPUAllocatable: &PerGPUAllocatableDevices{allocatablesMap: map[PCIBusID]AllocatableDevices{}},
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), d)
+	defer cancel()
+	m.run(ctx)
+	select {
+	case <-m.heartbeat:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestHealthMonitorHeartbeat_OnlyOnResponsiveWait verifies that only a
+// successful wait, the normal ERROR_TIMEOUT, or ERROR_GPU_IS_LOST (NVML
+// answering with a known, tainted failure) counts as proof the event stream
+// is alive; any other persistent NVML failure must let the kubelet's health
+// data expire to unknown rather than keep asserting healthy.
+func TestHealthMonitorHeartbeat_OnlyOnResponsiveWait(t *testing.T) {
+	orig := eventWaitRetryDelay
+	eventWaitRetryDelay = time.Millisecond
+	t.Cleanup(func() { eventWaitRetryDelay = orig })
+
+	assert.True(t, runMonitorFor(t, []nvml.Return{nvml.ERROR_TIMEOUT}, 50*time.Millisecond), "ERROR_TIMEOUT must heartbeat")
+	assert.True(t, runMonitorFor(t, []nvml.Return{nvml.ERROR_GPU_IS_LOST}, 50*time.Millisecond), "ERROR_GPU_IS_LOST must heartbeat so the lost devices stay unhealthy, not unknown")
+	assert.False(t, runMonitorFor(t, []nvml.Return{nvml.ERROR_UNINITIALIZED}, 50*time.Millisecond), "ERROR_UNINITIALIZED must not heartbeat")
+	assert.False(t, runMonitorFor(t, []nvml.Return{nvml.ERROR_UNKNOWN}, 50*time.Millisecond), "ERROR_UNKNOWN must not heartbeat")
+}
+
+// TestHealthMonitorRun_GPULostTaintsAndHeartbeats verifies that when the
+// NVML wait keeps reporting ERROR_GPU_IS_LOST, the loop both emits a GPU-lost
+// event for every device (which taints them) and keeps heartbeating, so the
+// kubelet keeps seeing the devices as unhealthy rather than letting the
+// report decay to unknown.
+func TestHealthMonitorRun_GPULostTaintsAndHeartbeats(t *testing.T) {
+	orig := eventWaitRetryDelay
+	eventWaitRetryDelay = time.Millisecond
+	t.Cleanup(func() { eventWaitRetryDelay = orig })
+
+	dev := &AllocatableDevice{Gpu: &GpuInfo{}}
+	m := &nvmlDeviceHealthMonitor{
+		eventSet:  &fakeEventSet{rets: []nvml.Return{nvml.ERROR_GPU_IS_LOST}},
+		unhealthy: make(chan *DeviceHealthEvent, 1),
+		heartbeat: make(chan struct{}, 1),
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{"0000:01:00.0": {"gpu-0": dev}},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.run(ctx)
+	}()
+
+	select {
+	case event := <-m.unhealthy:
+		assert.Equal(t, HealthEventGPULost, event.EventType)
+		assert.Equal(t, []*AllocatableDevice{dev}, event.Devices)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ERROR_GPU_IS_LOST must emit a GPU-lost event for the devices")
+	}
+	select {
+	case <-m.heartbeat:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ERROR_GPU_IS_LOST must heartbeat")
+	}
+	cancel()
+	<-done
+}
+
+// TestHealthMonitorRun_BacksOffOnError verifies the event loop does not spin
+// when the NVML wait fails immediately with a persistent error.
+func TestHealthMonitorRun_BacksOffOnError(t *testing.T) {
+	orig := eventWaitRetryDelay
+	eventWaitRetryDelay = 20 * time.Millisecond
+	t.Cleanup(func() { eventWaitRetryDelay = orig })
+
+	for _, ret := range []nvml.Return{nvml.ERROR_UNKNOWN, nvml.ERROR_GPU_IS_LOST} {
+		es := &fakeEventSet{rets: []nvml.Return{ret}}
+		m := &nvmlDeviceHealthMonitor{
+			eventSet:          es,
+			unhealthy:         make(chan *DeviceHealthEvent, 1),
+			heartbeat:         make(chan struct{}, 1),
+			perGPUAllocatable: &PerGPUAllocatableDevices{allocatablesMap: map[PCIBusID]AllocatableDevices{}},
+		}
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		m.run(ctx)
+		cancel()
+		assert.LessOrEqual(t, es.calls, 10, "%v path must pause between retries", ret)
+	}
+}
+
+// nilNvml is an nvml.Interface whose every method panics (embedded nil
+// interface), for asserting that a code path makes no NVML call.
+type nilNvml struct{ nvml.Interface }
+
+// Stop is used as deferred cleanup in NewDriver and may run before
+// RegisterEvents succeeded; it must not touch the (absent) event set or NVML
+// session then.
+func TestHealthMonitorStopBeforeRegisterEvents(t *testing.T) {
+	m := &nvmlDeviceHealthMonitor{
+		nvmllib:   nilNvml{},
+		unhealthy: make(chan *DeviceHealthEvent, 1),
+	}
+	require.NotPanics(t, m.Stop)
+	_, open := <-m.unhealthy
+	assert.False(t, open, "the event channel must still be closed for consumers")
 }
 
 func TestHealthMonitorStartRequiresRegisteredEvents(t *testing.T) {
@@ -491,12 +708,43 @@ func TestClearDynamicMIGXIDTaint(t *testing.T) {
 		},
 	}
 
-	state.clearDynamicMIGXIDTaint("dynamic")
-	state.clearDynamicMIGXIDTaint("static")
+	assert.True(t, state.clearDynamicMIGXIDTaint("dynamic"))
+	assert.False(t, state.clearDynamicMIGXIDTaint("static"))
 
 	require.Len(t, dynamic.Taints(), 1)
 	assert.Equal(t, TaintKeyGPULost, dynamic.Taints()[0].Key)
 
 	require.Len(t, static.Taints(), 1)
 	assert.Equal(t, TaintKeyXID, static.Taints()[0].Key)
+}
+
+// TestClearDynamicMIGXIDTaint_KeepsParentScopedXID verifies that the XID
+// taint of a destroyed Dynamic MIG device is kept while its parent GPU still
+// carries a critical XID (a GPU-scoped event fanned out to the MIG device),
+// and cleared once the parent's XID is only informational.
+func TestClearDynamicMIGXIDTaint_KeepsParentScopedXID(t *testing.T) {
+	parent := &GpuInfo{UUID: "GPU-parent-1", pciBusID: "0000:01:00.0"}
+	fullGPU := &AllocatableDevice{Gpu: parent}
+	dynamic := &AllocatableDevice{MigDynamic: &MigSpec{Parent: parent}}
+	critical := &resourceapi.DeviceTaint{Key: TaintKeyXID, Value: "79", Effect: resourceapi.DeviceTaintEffectNoSchedule}
+	fullGPU.AddOrUpdateTaint(critical)
+	dynamic.AddOrUpdateTaint(critical)
+
+	state := &DeviceState{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				parent.pciBusID: {"gpu-0": fullGPU, "dynamic": dynamic},
+			},
+		},
+	}
+
+	assert.False(t, state.clearDynamicMIGXIDTaint("dynamic"))
+	require.Len(t, dynamic.Taints(), 1, "taint must be kept while the parent GPU is still critical")
+
+	// Parent without a critical XID: the MIG device's own XID taint is cleared.
+	_, removed := fullGPU.RemoveTaint(TaintKeyXID)
+	require.True(t, removed)
+	fullGPU.AddOrUpdateTaint(&resourceapi.DeviceTaint{Key: TaintKeyXID, Value: "31", Effect: resourceapi.DeviceTaintEffectNone})
+	assert.True(t, state.clearDynamicMIGXIDTaint("dynamic"))
+	assert.Empty(t, dynamic.Taints())
 }

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -1997,9 +1997,23 @@ func isAdminAccess(results []resourceapi.DeviceRequestAllocationResult) bool {
 	return false
 }
 
+// dynamicMIGParentDevice returns the allocatable full-GPU device of a Dynamic
+// MIG device, or nil when the full GPU is not allocatable.
+func (s *DeviceState) dynamicMIGParentDevice(device *AllocatableDevice) *AllocatableDevice {
+	if device.MigDynamic == nil || device.MigDynamic.Parent == nil {
+		return nil
+	}
+	return s.perGPUAllocatable.GetGPUDeviceByPCIBusID(device.MigDynamic.Parent.pciBusID)
+}
+
 // clearDynamicMIGXIDTaint clears health state that belongs to a concrete
 // Dynamic MIG incarnation after that device no longer exists. Parent-scoped
-// taints, such as GPU lost or an unavailable health monitor, remain intact.
+// taints, such as GPU lost or an unavailable health monitor, remain intact,
+// and so does an XID taint that the parent GPU still carries as critical: a
+// GPU-scoped XID is fanned out to every MIG device on the GPU, and destroying
+// one MIG instance does not fix the GPU. (On GPUs whose full-GPU device is
+// not allocatable, such as Ampere in MIG mode, the parent's taints are not
+// tracked and the XID taint is cleared.)
 //
 // NOTE: An XID event already queued before deletion could re-add the taint.
 // This cleanup intentionally does not track concrete MIG
@@ -2008,6 +2022,15 @@ func (s *DeviceState) clearDynamicMIGXIDTaint(name DeviceName) bool {
 	device := s.perGPUAllocatable.GetAllocatableDevice(name)
 	if device == nil || device.Type() != MigDynamicDeviceType {
 		return false
+	}
+	if parent := s.dynamicMIGParentDevice(device); parent != nil {
+		for _, taint := range parent.Taints() {
+			if taint.Key == TaintKeyXID && taint.Effect != resourceapi.DeviceTaintEffectNone {
+				klog.V(4).Infof("Keeping health taint on destroyed Dynamic MIG device %s: parent GPU %s still has critical XID %s",
+					name, parent.CanonicalName(), taint.Value)
+				return false
+			}
+		}
 	}
 	if taint, removed := device.RemoveTaint(TaintKeyXID); removed {
 		klog.V(4).Infof("Cleared health taint for destroyed Dynamic MIG device %s: key=%q, value=%q, effect=%s",

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -51,6 +51,10 @@ type deviceHealthMonitor interface {
 	Start(context.Context) error
 	Stop()
 	Unhealthy() <-chan *DeviceHealthEvent
+	// Heartbeat signals that the monitor's event loop is alive; the driver
+	// re-sends its health report to the kubelet on each heartbeat so the
+	// kubelet's health data does not go stale.
+	Heartbeat() <-chan struct{}
 	// Allows the driver to query the HealthMonitor's health policy
 	IsEventNonFatal(event *DeviceHealthEvent) bool
 }
@@ -63,13 +67,31 @@ type driver struct {
 	healthcheck         *healthcheck
 	deviceHealthMonitor deviceHealthMonitor
 	wg                  sync.WaitGroup
+	// nodeName is the ResourceSlice pool name (publishResources builds the
+	// pools from config.flags.nodeName); the kubelet matches a device health
+	// entry to a claim allocation by pool and device name, so the health
+	// reports must use the same value.
+	nodeName string
+	// Device health reported to the kubelet through WatchHealthStatus is
+	// derived from the device taints (see device_health_status.go); these
+	// only track when it was last confirmed and what was last reported.
+	healthMu         sync.Mutex
+	healthUpdatedAt  time.Time
+	lastHealthReport []kubeletplugin.DeviceHealth
+	// republishResources republishes the ResourceSlices after a taint
+	// update. Set in NewDriver; a seam for tests.
+	republishResources func(ctx context.Context) error
+	healthSubMu        sync.RWMutex
+	// healthSubscribers holds one capacity-one notification channel per
+	// pending WatchHealthStatus call (see notifyHealthSubscribers).
+	healthSubscribers []chan struct{}
 	// Idicates whether to use separate ResourceSlices for SharedCounters and
 	// Devices (required for k8s 1.35+) or combined SharedCounters and Devices
 	// in the same slice (required for k8s 1.34).
 	useSplitResourceSlices bool
 }
 
-func NewDriver(ctx context.Context, config *Config) (*driver, error) {
+func NewDriver(ctx context.Context, config *Config) (_ *driver, retErr error) {
 	state, err := NewDeviceState(ctx, config)
 	if err != nil {
 		return nil, err
@@ -128,24 +150,46 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		state:                  state,
 		pulock:                 flock.NewFlock(puLockPath),
 		useSplitResourceSlices: useSplitSlices,
+		nodeName:               config.flags.nodeName,
 	}
-
 	// Register NVML events before kubeletplugin.Start exposes Prepare/Unprepare.
-	// On plugin restart, previously prepared devices and their workloads can remain
-	// live and emit an XID before the kubelet service is available. NVML does not
-	// retain events that occur before registration.
+	// On plugin restart, previously prepared devices and their workloads can
+	// remain live and emit an XID before the kubelet service is available. NVML
+	// does not retain events that occur before registration, so registration
+	// happens here; the event wait loop is started later (after the initial
+	// ResourceSlice publish) by the consumer block below.
 	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
 		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
 		}
 		driver.deviceHealthMonitor = deviceHealthMonitor
+		// Stop the monitor again if any of the later setup steps fail, so
+		// that error returns do not leak its run goroutine and NVML state.
+		defer func() {
+			if retErr != nil {
+				deviceHealthMonitor.Stop()
+			}
+		}()
 
 		// Events recorded after registration remain queued until Start begins
 		// waiting after the kubelet helper is available.
 		if err := deviceHealthMonitor.RegisterEvents(); err != nil {
 			return nil, fmt.Errorf("failed to register NVML device events: %w", err)
 		}
+
+		// Apply the health events RegisterEvents may already have queued
+		// (devices it could not register) as device taints now, before the
+		// kubelet can subscribe to health updates and before the initial
+		// ResourceSlice publish, so both see those devices as unmonitored.
+		driver.applyQueuedHealthEvents()
+
+		// Seed the health snapshot before the kubelet can subscribe: the
+		// initial report must cover all devices, even when a claim
+		// operation holds the state lock at subscription time
+		// (buildHealthReport then re-sends this snapshot rather than
+		// waiting).
+		driver.refreshDeviceHealth()
 	}
 
 	opts := []kubeletplugin.Option{
@@ -155,6 +199,16 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.Serialize(false),
 		kubeletplugin.RegistrarDirectoryPath(config.flags.kubeletRegistrarDirectoryPath),
 		kubeletplugin.PluginDataDirectoryPath(config.DriverPluginPath()),
+		// KEP-4680: device health is reported to the kubelet only when the
+		// NVML health monitor is enabled; otherwise the DRAResourceHealth
+		// service is not advertised. Advertising it here, before the
+		// monitor's event wait loop starts below, is safe: the first report
+		// for a subscribing kubelet is derived from the device taints, which
+		// already include the events queued at registration, and NVML queues
+		// events registered above until the loop waits for them. The loop
+		// itself has to start after the initial ResourceSlice publish, since
+		// its consumer republishes slices for taints.
+		kubeletplugin.HealthService(featuregates.Enabled(featuregates.NVMLDeviceHealthCheck)),
 	}
 	// KEP-5304: Enable Device Metadata support for the kubelet plugin implementation.
 	// See: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5304-dra-attributes-downward-api
@@ -169,6 +223,9 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		return nil, err
 	}
 	driver.pluginhelper = helper
+	driver.republishResources = func(ctx context.Context) error {
+		return driver.publishResources(ctx, driver.state.config)
+	}
 
 	healthcheck, err := startHealthcheck(ctx, config, helper)
 	if err != nil {
@@ -186,19 +243,16 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 	}
 
 	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
-		// RegisterEvents can queue unmonitored events before this consumer
-		// starts. Publish the initial ResourceSlices first, so subsequent health
-		// updates republish tainted resources without an initial snapshot
-		// overwriting them.
+		// The events queued at registration were already applied above
+		// (applyQueuedHealthEvents). The consumers republish ResourceSlices
+		// through the plugin helper for later taints, so they start only
+		// after the helper exists and the initial publish is done; the
+		// monitor's event wait loop starts after them.
 		// TODO: NVML does not replay XIDs emitted before registration. Because
 		// health taints are not persisted, a restart can advertise a device as
 		// healthy unless the fault emits another event. Persist health state or
 		// validate recovery before clearing taints during startup.
-		driver.wg.Add(1)
-		go func() {
-			defer driver.wg.Done()
-			driver.deviceHealthEvents(ctx)
-		}()
+		driver.startDeviceHealthConsumers(ctx)
 		if err := driver.deviceHealthMonitor.Start(ctx); err != nil {
 			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
 		}
@@ -401,10 +455,6 @@ func (d *driver) HandleError(ctx context.Context, err error, msg string) {
 	runtime.HandleErrorWithContext(ctx, err, msg)
 }
 
-func (d *driver) WatchHealthStatus(context.Context, chan<- kubeletplugin.DeviceHealthReport) error {
-	return kubeletplugin.ErrHealthNotSupported
-}
-
 func (d *driver) nodePrepareResource(ctx context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
 	t0 := time.Now()
 	// Instead of a global prepare/unprepare (PU) lock, we could rely on
@@ -479,6 +529,9 @@ func (d *driver) nodeUnprepareResource(ctx context.Context, claimRef kubeletplug
 		(featuregates.Enabled(featuregates.DynamicMIG) &&
 			featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) &&
 			taintRemovedRepublish) {
+		// The device set (VFIO) or a device's taints (Dynamic MIG) changed;
+		// the health reported to the kubelet is derived from them.
+		d.deviceHealthChanged()
 		// Re-advertise updated resourceslice after unpreparing devices
 		// or removed a Dynamic MIG XID taint.
 		if err = d.publishResources(ctx, d.state.config); err != nil {
@@ -532,8 +585,44 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 
 }
 
+// startDeviceHealthConsumers starts the goroutines that consume the NVML
+// monitor's channels. Heartbeats and health events are consumed separately:
+// applying an event waits for the state lock, which a claim operation may
+// hold for a long time, and the heartbeat-driven re-sends must not wait
+// behind that or the kubelet decays every device to Unknown while NVML is
+// answering.
+func (d *driver) startDeviceHealthConsumers(ctx context.Context) {
+	d.wg.Add(2)
+	go func() {
+		defer d.wg.Done()
+		d.deviceHealthHeartbeats(ctx)
+	}()
+	go func() {
+		defer d.wg.Done()
+		d.deviceHealthEvents(ctx)
+	}()
+}
+
+// deviceHealthHeartbeats confirms the health of all devices on each heartbeat
+// of the monitor's event loop and wakes the health watchers to re-send the
+// report, so the kubelet's health data does not go stale (the kubelet reports
+// device health as unknown once it is older than the health check timeout).
+func (d *driver) deviceHealthHeartbeats(ctx context.Context) {
+	klog.V(4).Info("Starting to watch for device health heartbeats")
+	for {
+		select {
+		case <-ctx.Done():
+			klog.V(6).Info("Stop processing device health heartbeats")
+			return
+		case <-d.deviceHealthMonitor.Heartbeat():
+			d.deviceHealthConfirmed()
+		}
+	}
+}
+
 func (d *driver) deviceHealthEvents(ctx context.Context) {
 	klog.V(4).Info("Starting to watch for device health notifications")
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -542,49 +631,66 @@ func (d *driver) deviceHealthEvents(ctx context.Context) {
 		case event, ok := <-d.deviceHealthMonitor.Unhealthy():
 			if !ok {
 				// NVML based deviceHealthMonitor is expected to close only during driver Shutdown.
-				klog.V(6).Info("Health monitor channel closed")
+				klog.V(6).Info("Device health monitor channel closed; stop processing device health notifications")
 				return
 			}
 
-			taint := healthEventToTaint(d.deviceHealthMonitor, event)
-			modified := false
-			for _, dev := range event.Devices {
-				klog.Warningf("Received %s health event for device %s", event.EventType, dev.CanonicalName())
-				if d.state.AddDeviceTaint(dev, taint) {
-					modified = true
-				}
-			}
-			if !modified {
-				continue
-			}
-
-			// NOTE: We only log an error on publish failure and do not retry.
-			// If this publish fails, our in-memory health update succeeds but the
-			// ResourceSlice in the API server remains stale and still advertises the
-			// now-unhealthy device as allocatable. Until a later publish succeeds,
-			// the scheduler and other consumers will continue to see the unhealthy
-			// device as available, and new pods may be placed onto hardware we know
-			// is unusable. If publishes continue to fail (e.g., API server issues),
-			// the cluster can remain in this inconsistent state indefinitely.
-			// This is a temporary compromise while device taints/tolerations (KEP-5055)
-			// are available as a Beta feature. An interim improvement could be adding
-			// a retry/backoff or switch to patch updates instead of full republish.
-			klog.V(4).Infof("Republishing ResourceSlice: %d device(s) tainted with %s=%q (effect=%s)",
-				len(event.Devices), taint.Key, taint.Value, taint.Effect)
-
-			// NOTE: GPU_LOST and unmonitored events are already batched at the
-			// sender (all affected devices arrive in a single DeviceHealthEvent).
-			// XID events are still per-device and may cause repeated publishes.
-			// TODO: Add receiver-side event aggregation before PublishResources.
-			// Evaluate two strategies:
-			// 1. Channel drain: non-blocking pull of all pending events (Pro: zero latency; Con: susceptible to NVML lag).
-			// 2. Timer debounce: e.g., 50ms window (Pro: standard K8s API protection; Con: slight delay).
-			// This also needs to be handled properly in the recovery path.
-			if err := d.publishResources(ctx, d.state.config); err != nil {
-				klog.Errorf("Failed to publish resources after taint update: %v", err)
+			// The taints put on the devices here are also what the health
+			// reported to the kubelet (KEP-4680) is derived from.
+			event.logIfUnknownType()
+			if d.applyHealthEventTaint(ctx, event) {
+				d.deviceHealthChanged()
 			}
 		}
 	}
+}
+
+// applyHealthEventTaint translates a health event into a DRA device taint on
+// the affected devices and republishes the ResourceSlices when anything
+// changed. Returns whether any device's taints were modified; an event that
+// changes nothing (a persistently lost GPU is re-reported on every retry of
+// the event wait) is logged at low verbosity only.
+func (d *driver) applyHealthEventTaint(ctx context.Context, event *DeviceHealthEvent) bool {
+	taint := healthEventToTaint(d.deviceHealthMonitor, event)
+	modified := false
+	for _, dev := range event.Devices {
+		if d.state.AddDeviceTaint(dev, taint) {
+			klog.Warningf("Received %s health event for device %s", event.EventType, dev.CanonicalName())
+			modified = true
+		} else {
+			klog.V(6).Infof("Received %s health event for device %s; taints unchanged", event.EventType, dev.CanonicalName())
+		}
+	}
+	if !modified {
+		return false
+	}
+
+	// NOTE: We only log an error on publish failure and do not retry.
+	// If this publish fails, our in-memory health update succeeds but the
+	// ResourceSlice in the API server remains stale and still advertises the
+	// now-unhealthy device as allocatable. Until a later publish succeeds,
+	// the scheduler and other consumers will continue to see the unhealthy
+	// device as available, and new pods may be placed onto hardware we know
+	// is unusable. If publishes continue to fail (e.g., API server issues),
+	// the cluster can remain in this inconsistent state indefinitely.
+	// This is a temporary compromise while device taints/tolerations (KEP-5055)
+	// are available as a Beta feature. An interim improvement could be adding
+	// a retry/backoff or switch to patch updates instead of full republish.
+	klog.V(4).Infof("Republishing ResourceSlice: %d device(s) tainted with %s=%q (effect=%s)",
+		len(event.Devices), taint.Key, taint.Value, taint.Effect)
+
+	// NOTE: GPU_LOST and unmonitored events are already batched at the
+	// sender (all affected devices arrive in a single DeviceHealthEvent).
+	// XID events are still per-device and may cause repeated publishes.
+	// TODO: Add receiver-side event aggregation before PublishResources.
+	// Evaluate two strategies:
+	// 1. Channel drain: non-blocking pull of all pending events (Pro: zero latency; Con: susceptible to NVML lag).
+	// 2. Timer debounce: e.g., 50ms window (Pro: standard K8s API protection; Con: slight delay).
+	// This also needs to be handled properly in the recovery path.
+	if err := d.republishResources(ctx); err != nil {
+		klog.Errorf("Failed to publish resources after taint update: %v", err)
+	}
+	return true
 }
 
 // shouldUseSplitResourceSlices detects the Kubernetes server version and

--- a/hack/ci/mock-nvml/e2e-test.sh
+++ b/hack/ci/mock-nvml/e2e-test.sh
@@ -262,6 +262,12 @@ fi
 if [ "${TEST_DRA_LIST_TYPE_ATTRIBUTES}" = "true" ]; then
   sed -i '/DynamicResourceAllocation: true/a\  DRAListTypeAttributes: true' "${KIND_CONFIG}"
 fi
+# KEP-4680 device health in pod status (tests/bats/test_gpu_health.bats):
+# beta and on by default from k8s 1.36, alpha (off) before.
+if [ "${K8S_MINOR}" -lt 36 ]; then
+  echo "K8s < 1.36 (${RESOLVED_K8S_VERSION}): enabling ResourceHealthStatus"
+  sed -i '/DynamicResourceAllocation: true/a\  ResourceHealthStatus: true' "${KIND_CONFIG}"
+fi
 
 # Select Kind node image if k8s version specified
 KIND_IMAGE_ARG=""

--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -195,6 +195,7 @@ tests-mock-nvml: runner-image
 		tests/bats/test_gpu_extres.bats \
 		tests/bats/test_gpu_stress.bats \
 		tests/bats/test_gpu_updowngrade.bats \
+		tests/bats/test_gpu_health.bats \
 		tests/bats/test_cd_imex_chan_inject.bats \
 		tests/bats/test_cd_misc.bats \
 		tests/bats/test_cd_logging.bats \
@@ -202,6 +203,11 @@ tests-mock-nvml: runner-image
 		tests/bats/test_cd_mnnvl_workload.bats \
 		tests/bats/test_cd_updowngrade.bats \
 		tests/bats/test_cd_leader_election.bats)
+
+# Run an explicit list of test files, e.g.
+#   make -f tests/bats/Makefile tests-files BATS_FILES="tests/bats/test_gpu_health.bats"
+tests-files: runner-image
+	$(call RUN_BATS, $(BATS_FILES))
 
 tests-gpu-single: runner-image
 	$(call RUN_BATS, \
@@ -236,6 +242,7 @@ tests-gpu: runner-image
 		tests/bats/test_gpu_dynmig.bats \
 		tests/bats/test_gpu_mig.bats \
 		tests/bats/test_gpu_updowngrade.bats \
+		tests/bats/test_gpu_health.bats \
 		tests/bats/test_gpu_stress.bats)
 
 # Run a subset covering mainly the CD plugin
@@ -260,6 +267,7 @@ tests: runner-image
 		tests/bats/test_gpu_dynmig.bats \
 		tests/bats/test_gpu_mig.bats \
 		tests/bats/test_gpu_updowngrade.bats \
+		tests/bats/test_gpu_health.bats \
 		tests/bats/test_cd_imex_chan_inject.bats \
 		tests/bats/test_cd_mnnvl_workload.bats \
 		tests/bats/test_cd_misc.bats \

--- a/tests/bats/specs/gpu-taint-tolerated.yaml
+++ b/tests/bats/specs/gpu-taint-tolerated.yaml
@@ -1,0 +1,38 @@
+# Scenario: single pod requesting any full GPU and tolerating the
+# gpu.nvidia.com/xid NoSchedule health taint (KEP-5055 device taints).
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-single-gpu-tolerate-xid
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          tolerations:
+          - key: gpu.nvidia.com/xid
+            operator: Exists
+            effect: NoSchedule
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-full-gpu-tolerated
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-single-gpu-tolerate-xid

--- a/tests/bats/specs/gpu-taint-untolerated.yaml
+++ b/tests/bats/specs/gpu-taint-untolerated.yaml
@@ -1,0 +1,34 @@
+# Scenario: single pod requesting any full GPU, without tolerating device
+# taints. Used to show that a NoSchedule health taint blocks scheduling.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-single-gpu-full
+  labels:
+    env: batssuite
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-full-gpu-untolerated
+  labels:
+    env: batssuite
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-single-gpu-full

--- a/tests/bats/test_gpu_health.bats
+++ b/tests/bats/test_gpu_health.bats
@@ -1,0 +1,488 @@
+# shellcheck disable=SC2148
+# shellcheck disable=SC2329
+
+# Tests for GPU device health reporting (KEP-4680) and health taints
+# (KEP-5055), driven by the NVML health monitor (featureGates.NVMLDeviceHealthCheck).
+#
+# These tests inject Xid errors through the mock NVML config override and
+# therefore only run against mock NVML (MOCK_NVML=true). The mock delivers the
+# configured Xid through the NVML event set after the first guarded NVML call
+# in the consuming process trips the failure injector; for the kubelet plugin
+# that call happens during device discovery, so the injection is followed by a
+# kubelet-plugin pod restart.
+
+setup_file() {
+  load 'helpers.sh'
+  _common_setup
+  local _iargs=("--set" "logVerbosity=6" "--set" "featureGates.NVMLDeviceHealthCheck=true")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+}
+
+teardown_file() {
+  load 'helpers.sh'
+  # Leave the node healthy for subsequent test files: drop the mock override
+  # (if any) and restart the plugin so both the mock's tripped state and the
+  # driver's sticky unhealthy state are reset.
+  if [ "${MOCK_NVML:-}" = "true" ]; then
+    health_clear_mock_override || true
+    restart_kubelet_plugin_pods || true
+  fi
+}
+
+setup() {
+  load 'helpers.sh'
+  _common_setup
+  if [ "${MOCK_NVML:-}" != "true" ]; then
+    skip "Xid injection requires mock NVML (MOCK_NVML=true)"
+  fi
+  log_objects
+}
+
+bats::on_failure() {
+  echo -e "\n\nFAILURE HOOK START"
+  log_objects
+  kubectl get resourceslices -o json | jq '.items[] | select(.spec.driver=="gpu.nvidia.com") | .spec.devices[]? | {name, taints}' || true
+  show_kubelet_plugin_error_logs
+  show_gpu_plugin_log_tails
+  echo -e "FAILURE HOOK END\n\n"
+}
+
+# --- helpers ---
+
+# Health values reported for all DRA claims of the pod, comma-separated
+# (pod.status.containerStatuses[].allocatedResourcesStatus[].resources[].health).
+pod_claim_health() {
+  kubectl get pod "$1" -o json \
+    | jq -r '[.status.containerStatuses[]? | .allocatedResourcesStatus[]? | select(.name | startswith("claim:")) | .resources[]? | .health] | join(",")'
+}
+
+# Wait until every claim resource of the pod reports the given health.
+wait_for_pod_claim_health() {
+  local pod="$1" want="$2" timeout="$3"
+  local start=$SECONDS got=""
+  while (( SECONDS - start < timeout )); do
+    got="$(pod_claim_health "${pod}")"
+    if [ -n "${got}" ] && [ "$(echo "${got}" | tr ',' '\n' | sort -u)" = "${want}" ]; then
+      log "pod ${pod} claim health: ${got}"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timeout (${timeout} s) waiting for claim health '${want}' on ${pod}; last: '${got}'"
+  return 1
+}
+
+# Number of GPU devices in the node's ResourceSlices carrying the given taint.
+count_gpu_taints() {
+  local node="$1" key="$2" value="$3" effect="$4"
+  kubectl get resourceslices -o json \
+    | jq -r --arg n "${node}" --arg k "${key}" --arg v "${value}" --arg e "${effect}" \
+      '[.items[] | select(.spec.driver=="gpu.nvidia.com" and .spec.nodeName==$n) | .spec.devices[]? | .taints[]? | select(.key==$k and .value==$v and .effect==$e)] | length'
+}
+
+# Number of GPU devices advertised for the node by the GPU driver.
+count_gpu_devices() {
+  kubectl get resourceslices -o json \
+    | jq -r --arg n "$1" \
+      '[.items[] | select(.spec.driver=="gpu.nvidia.com" and .spec.nodeName==$n) | .spec.devices[]?] | length'
+}
+
+wait_for_gpu_taint() {
+  local node="$1" key="$2" value="$3" effect="$4" timeout="$5"
+  local start=$SECONDS n=0
+  while (( SECONDS - start < timeout )); do
+    n="$(count_gpu_taints "${node}" "${key}" "${value}" "${effect}")"
+    if [ "${n}" -gt 0 ]; then
+      log "${n} device(s) on ${node} tainted with ${key}=${value}:${effect}"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timeout (${timeout} s) waiting for taint ${key}=${value}:${effect} on ${node}"
+  return 1
+}
+
+kubelet_plugin_pod_on_node() {
+  kubectl get pod -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin \
+    --field-selector "spec.nodeName=$1,status.phase=Running" \
+    --no-headers -o custom-columns=":metadata.name" | head -n1
+}
+
+# Write (or remove) the mock NVML config override through the kubelet plugin
+# container: the driver root is a host path mounted at /driver-root, and the
+# mock library resolves <driver_root>/config/overrides.yaml.
+# 1st arg: kubelet plugin pod on the target node; 2nd arg: Xid code to inject.
+health_write_mock_override() {
+  local plugin_pod="$1" xid="$2"
+  kubectl exec -n dra-driver-nvidia-gpu "${plugin_pod}" -c gpus -- sh -c \
+    "printf 'version: 1\\nall:\\n  failure:\\n    mode: ecc_uncorrectable\\n    xid:\\n      code: ${xid}\\n' > /driver-root/config/overrides.yaml && cat /driver-root/config/overrides.yaml"
+}
+
+# Inject the Xid on a single GPU (mock device index) instead of all of them.
+health_write_mock_override_device() {
+  local plugin_pod="$1" index="$2" xid="$3"
+  kubectl exec -n dra-driver-nvidia-gpu "${plugin_pod}" -c gpus -- sh -c \
+    "printf 'version: 1\\ndevices:\\n  \"${index}\":\\n    failure:\\n      mode: ecc_uncorrectable\\n      xid:\\n        code: ${xid}\\n' > /driver-root/config/overrides.yaml && cat /driver-root/config/overrides.yaml"
+}
+
+# JSON list of gpu.nvidia.com/xid taints on one named device of the node.
+device_xid_taints() {
+  local node="$1" device="$2"
+  kubectl get resourceslices -o json \
+    | jq -c --arg n "${node}" --arg d "${device}" \
+      '[.items[] | select(.spec.driver=="gpu.nvidia.com" and .spec.nodeName==$n) | .spec.devices[]? | select(.name==$d) | .taints[]? | select(.key=="gpu.nvidia.com/xid")]'
+}
+
+# Wait until the pod reports the given phase.
+wait_for_pod_phase() {
+  local pod="$1" want="$2" timeout="$3"
+  local start=$SECONDS got=""
+  while (( SECONDS - start < timeout )); do
+    got="$(kubectl get pod "${pod}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    [ "${got}" = "${want}" ] && return 0
+    sleep 2
+  done
+  echo "Timeout (${timeout} s) waiting for pod ${pod} phase '${want}'; last: '${got}'"
+  return 1
+}
+
+# Inject the Xid on every GPU of the node and restart the kubelet plugin so
+# device discovery trips the mock's failure injector and the health monitor
+# receives the event.
+inject_xid_and_restart_plugin() {
+  local plugin_pod="$1" xid="$2"
+  health_write_mock_override "${plugin_pod}" "${xid}"
+  restart_kubelet_plugin_pods
+}
+
+# Remove the override and restart the plugin, then wait until no Xid taint of
+# the given value remains on the node's devices.
+recover_from_xid() {
+  local node="$1" xid="$2"
+  health_clear_mock_override
+  restart_kubelet_plugin_pods
+  wait_for_all_gpu_resource_slices 60
+  local start=$SECONDS
+  while [ "$(count_gpu_taints "${node}" "gpu.nvidia.com/xid" "${xid}" "NoSchedule")" != "0" ] \
+     || [ "$(count_gpu_taints "${node}" "gpu.nvidia.com/xid" "${xid}" "None")" != "0" ]; do
+    (( SECONDS - start < 60 )) || { echo "Xid ${xid} taint still present after recovery"; return 1; }
+    sleep 2
+  done
+}
+
+health_clear_mock_override() {
+  local pod
+  for pod in $(kubectl get pod -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin \
+      --field-selector status.phase=Running --no-headers -o custom-columns=":metadata.name"); do
+    kubectl exec -n dra-driver-nvidia-gpu "${pod}" -c gpus -- rm -f /driver-root/config/overrides.yaml
+  done
+}
+
+restart_kubelet_plugin_pods() {
+  kubectl delete pod -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin --wait=true --timeout=60s
+  sleep 2
+  kubectl wait --for=condition=READY pods -n dra-driver-nvidia-gpu -l dra-driver-nvidia-gpu-component=kubelet-plugin --timeout=90s
+}
+
+# --- tests ---
+
+# The kubelet reports device health as Unknown once the driver's report is
+# older than the health check timeout (30 s by default). A healthy, idle GPU
+# must therefore still read Healthy well past that timeout: the driver has to
+# both re-send and refresh the timestamps on each monitor heartbeat.
+# bats test_tags=gpu-health
+@test "GPUs: health: allocated GPU is reported Healthy and stays Healthy past the kubelet health timeout" {
+  local _specpath="tests/bats/specs/gpu-simple-full.yaml"
+  local _podname="pod-full-gpu"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=30s
+
+  if ! wait_for_pod_claim_health "${_podname}" "Healthy" 60; then
+    if [ -z "$(pod_claim_health "${_podname}")" ]; then
+      local minor
+      minor="$(kubectl version -o json | jq -r '.serverVersion.minor' | tr -dc '0-9')"
+      if [ "${minor}" -lt 36 ]; then
+        kubectl delete -f "${_specpath}"
+        skip "kubelet does not populate allocatedResourcesStatus (ResourceHealthStatus gate off before k8s 1.36)"
+      fi
+    fi
+    false
+  fi
+
+  # Well past the 30 s kubelet health check timeout plus one 15 s heartbeat.
+  sleep 50
+  run pod_claim_health "${_podname}"
+  assert_output "Healthy"
+
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=30s
+}
+
+# A critical Xid must surface both as a NoSchedule taint on the device in the
+# ResourceSlice and as Unhealthy in the pod's allocatedResourcesStatus.
+# bats test_tags=gpu-health
+@test "GPUs: health: critical Xid taints the device and marks the allocated GPU Unhealthy" {
+  local _specpath="tests/bats/specs/gpu-simple-full.yaml"
+  local _podname="pod-full-gpu"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=30s
+
+  local node plugin_pod
+  node="$(kubectl get pod "${_podname}" -o jsonpath='{.spec.nodeName}')"
+  plugin_pod="$(kubelet_plugin_pod_on_node "${node}")"
+  [ -n "${plugin_pod}" ]
+
+  # Baseline: no Xid taints, pod healthy (if the kubelet reports health).
+  run count_gpu_taints "${node}" "gpu.nvidia.com/xid" "79" "NoSchedule"
+  assert_output "0"
+  local reports_health=true
+  wait_for_pod_claim_health "${_podname}" "Healthy" 60 || reports_health=false
+
+  # Inject: every GPU trips into ecc_uncorrectable with Xid 79 on the first
+  # guarded NVML call; restart the plugin so discovery trips it and the health
+  # monitor receives the event.
+  inject_xid_and_restart_plugin "${plugin_pod}" 79
+
+  wait_for_gpu_taint "${node}" "gpu.nvidia.com/xid" "79" "NoSchedule" 120
+
+  if [ "${reports_health}" = "true" ]; then
+    wait_for_pod_claim_health "${_podname}" "Unhealthy" 120
+  else
+    log "kubelet does not report DRA device health; skipping pod status assertion"
+  fi
+
+  # The pod itself keeps running; only scheduling of new pods onto the device
+  # is blocked by the taint.
+  run kubectl get pod "${_podname}" -o jsonpath='{.status.phase}'
+  assert_output "Running"
+
+  # Taint shape: exactly one gpu.nvidia.com/xid taint per device, carrying
+  # the Xid as value and a timeAdded timestamp.
+  local taints
+  taints="$(device_xid_taints "${node}" "gpu-0")"
+  run jq -r 'length' <<< "${taints}"
+  assert_output "1"
+  run jq -r '.[0].value + " " + .[0].effect + " " + (.[0].timeAdded | length | tostring)' <<< "${taints}"
+  assert_output --regexp '^79 NoSchedule [1-9][0-9]*$'
+
+  # KEP-5055: a new pod without a toleration must not be scheduled onto a
+  # NoSchedule tainted device (every GPU on the node is tainted), while a
+  # claim tolerating gpu.nvidia.com/xid is allocated and runs.
+  kubectl apply -f tests/bats/specs/gpu-taint-untolerated.yaml
+  sleep 20
+  run kubectl get pod pod-full-gpu-untolerated -o jsonpath='{.status.phase}'
+  assert_output "Pending"
+
+  kubectl apply -f tests/bats/specs/gpu-taint-tolerated.yaml
+  kubectl wait --for=condition=READY pods pod-full-gpu-tolerated --timeout=60s
+  run kubectl get pod pod-full-gpu-untolerated -o jsonpath='{.status.phase}'
+  assert_output "Pending"
+
+  # Unhealthy is sticky: well past the kubelet health timeout the allocated
+  # GPU still reads Unhealthy (not decayed to Unknown, not flipped back).
+  if [ "${reports_health}" = "true" ]; then
+    sleep 45
+    run pod_claim_health "${_podname}"
+    assert_output "Unhealthy"
+  fi
+
+  # The taint belongs to the device, not the pod: deleting the pod that was
+  # using the GPU leaves the taint in place and the device stays blocked.
+  kubectl delete --ignore-not-found -f tests/bats/specs/gpu-taint-tolerated.yaml
+  kubectl delete --ignore-not-found -f "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" pod-full-gpu-tolerated --timeout=60s
+  sleep 10
+  local gpu_count
+  gpu_count="$(count_gpu_devices "${node}")"
+  run count_gpu_taints "${node}" "gpu.nvidia.com/xid" "79" "NoSchedule"
+  assert_output "${gpu_count}"
+  run kubectl get pod pod-full-gpu-untolerated -o jsonpath='{.status.phase}'
+  assert_output "Pending"
+
+  kubectl delete --ignore-not-found -f tests/bats/specs/gpu-taint-untolerated.yaml
+  kubectl wait --for=delete pods -l env=batssuite --timeout=60s
+
+  # Recover: remove the override and restart the plugin; the devices must be
+  # advertised without the Xid taint again.
+  recover_from_xid "${node}" 79
+}
+
+# A non-fatal (application level) Xid is surfaced as an informational taint
+# with effect None: it must not block scheduling and the allocated GPU stays
+# Healthy in the pod status.
+# bats test_tags=gpu-health
+@test "GPUs: health: non-fatal Xid adds an informational taint and keeps the GPU Healthy and schedulable" {
+  local _specpath="tests/bats/specs/gpu-simple-full.yaml"
+  local _podname="pod-full-gpu"
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=30s
+
+  local node plugin_pod
+  node="$(kubectl get pod "${_podname}" -o jsonpath='{.spec.nodeName}')"
+  plugin_pod="$(kubelet_plugin_pod_on_node "${node}")"
+  [ -n "${plugin_pod}" ]
+  local reports_health=true
+  wait_for_pod_claim_health "${_podname}" "Healthy" 60 || reports_health=false
+
+  # Xid 43 (GPU stopped processing) is in the driver's built-in ignore list.
+  inject_xid_and_restart_plugin "${plugin_pod}" 43
+
+  wait_for_gpu_taint "${node}" "gpu.nvidia.com/xid" "43" "None" 120
+  run count_gpu_taints "${node}" "gpu.nvidia.com/xid" "43" "NoSchedule"
+  assert_output "0"
+
+  if [ "${reports_health}" = "true" ]; then
+    # Past the kubelet health timeout after the restart, still Healthy.
+    sleep 45
+    run pod_claim_health "${_podname}"
+    assert_output "Healthy"
+  fi
+
+  # An informational taint does not block scheduling.
+  kubectl apply -f tests/bats/specs/gpu-taint-untolerated.yaml
+  kubectl wait --for=condition=READY pods pod-full-gpu-untolerated --timeout=60s
+
+  kubectl delete --ignore-not-found -f tests/bats/specs/gpu-taint-untolerated.yaml
+  kubectl delete --ignore-not-found -f "${_specpath}"
+  kubectl wait --for=delete pods -l env=batssuite --timeout=60s
+
+  recover_from_xid "${node}" 43
+}
+
+# Xids listed in additionalXidsToIgnore (ADDITIONAL_XIDS_TO_IGNORE) are treated
+# as non-fatal: the same Xid 79 that is critical by default only produces an
+# informational taint.
+# bats test_tags=gpu-health
+@test "GPUs: health: additionalXidsToIgnore downgrades a critical Xid to an informational taint" {
+  local _specpath="tests/bats/specs/gpu-simple-full.yaml"
+  local _podname="pod-full-gpu"
+
+  local node plugin_pod
+  node="$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"
+  plugin_pod="$(kubelet_plugin_pod_on_node "${node}")"
+  [ -n "${plugin_pod}" ]
+
+  # Write the override first: the helm upgrade below rolls the plugin pods,
+  # which trips the injector during discovery.
+  health_write_mock_override "${plugin_pod}" 79
+  local _iargs=("--set" "logVerbosity=6" "--set" "featureGates.NVMLDeviceHealthCheck=true"
+    "--set" "kubeletPlugin.containers.gpus.env[1].name=ADDITIONAL_XIDS_TO_IGNORE"
+    "--set-string" "kubeletPlugin.containers.gpus.env[1].value=79")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+
+  wait_for_gpu_taint "${node}" "gpu.nvidia.com/xid" "79" "None" 120
+  run count_gpu_taints "${node}" "gpu.nvidia.com/xid" "79" "NoSchedule"
+  assert_output "0"
+
+  # Still schedulable and reported Healthy.
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=30s
+  wait_for_pod_claim_health "${_podname}" "Healthy" 60 || log "kubelet does not report DRA device health; skipping pod status assertion"
+  kubectl delete -f "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=30s
+
+  # Restore the default configuration for the remaining tests.
+  health_clear_mock_override
+  _iargs=("--set" "logVerbosity=6" "--set" "featureGates.NVMLDeviceHealthCheck=true")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+  recover_from_xid "${node}" 79
+}
+
+# A failure on one GPU only affects that device: the other GPU stays
+# untainted and keeps serving new pods.
+# bats test_tags=gpu-health,multi-gpu
+@test "GPUs: health: critical Xid on one GPU taints only that device and the other GPU stays schedulable" {
+  local _specpath="tests/bats/specs/gpu-simple-full.yaml"
+  local _podname="pod-full-gpu"
+
+  local node plugin_pod
+  node="$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"
+  plugin_pod="$(kubelet_plugin_pod_on_node "${node}")"
+  [ -n "${plugin_pod}" ]
+
+  # Mock device index 0 is advertised as gpu-0.
+  health_write_mock_override_device "${plugin_pod}" 0 79
+  restart_kubelet_plugin_pods
+
+  wait_for_gpu_taint "${node}" "gpu.nvidia.com/xid" "79" "NoSchedule" 120
+  run jq -r 'length' <<< "$(device_xid_taints "${node}" "gpu-0")"
+  assert_output "1"
+  run jq -r 'length' <<< "$(device_xid_taints "${node}" "gpu-1")"
+  assert_output "0"
+
+  # A new pod without a toleration lands on the untainted GPU.
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=60s
+  local claim allocated
+  claim="$(kubectl get pod "${_podname}" -o jsonpath='{.status.resourceClaimStatuses[0].resourceClaimName}')"
+  allocated="$(kubectl get resourceclaim "${claim}" -o jsonpath='{.status.allocation.devices.results[0].device}')"
+  log "pod ${_podname} was allocated ${allocated}"
+  [ -n "${allocated}" ]
+  [ "${allocated}" != "gpu-0" ]
+  run jq -r 'length' <<< "$(device_xid_taints "${node}" "${allocated}")"
+  assert_output "0"
+  wait_for_pod_claim_health "${_podname}" "Healthy" 60 || log "kubelet does not report DRA device health; skipping pod status assertion"
+
+  kubectl delete --ignore-not-found -f "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=30s
+  recover_from_xid "${node}" 79
+}
+
+# Without the NVMLDeviceHealthCheck feature gate the health service is not
+# advertised and no health taints are produced.
+# bats test_tags=gpu-health
+@test "GPUs: health: without featureGates.NVMLDeviceHealthCheck no health status and no taints are reported" {
+  local _specpath="tests/bats/specs/gpu-simple-full.yaml"
+  local _podname="pod-full-gpu"
+
+  local node plugin_pod
+  node="$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"
+  plugin_pod="$(kubelet_plugin_pod_on_node "${node}")"
+  [ -n "${plugin_pod}" ]
+
+  # Inject before the upgrade rolls the plugin pods.
+  health_write_mock_override "${plugin_pod}" 79
+  local _iargs=("--set" "logVerbosity=6" "--set" "featureGates.NVMLDeviceHealthCheck=false")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+  wait_for_all_gpu_resource_slices 60
+
+  kubectl apply -f "${_specpath}"
+  kubectl wait --for=condition=READY pods "${_podname}" --timeout=30s
+  sleep 30
+  run count_gpu_taints "${node}" "gpu.nvidia.com/xid" "79" "NoSchedule"
+  assert_output "0"
+  run count_gpu_taints "${node}" "gpu.nvidia.com/xid" "79" "None"
+  assert_output "0"
+  # The kubelet reports Unknown for devices of a driver without a health
+  # service (or nothing at all on kubelets without the ResourceHealthStatus
+  # gate); it must not be Healthy or Unhealthy.
+  run pod_claim_health "${_podname}"
+  assert_output --regexp '^(Unknown)?$'
+
+  kubectl delete --ignore-not-found -f "${_specpath}"
+  kubectl wait --for=delete pods "${_podname}" --timeout=30s
+
+  # Restore the default configuration.
+  health_clear_mock_override
+  _iargs=("--set" "logVerbosity=6" "--set" "featureGates.NVMLDeviceHealthCheck=true")
+  if [ "${DISABLE_COMPUTE_DOMAINS:-}" = "true" ]; then
+    _iargs+=("--set" "resources.computeDomains.enabled=false")
+  fi
+  iupgrade_wait "${TEST_CHART_REPO}" "${TEST_CHART_VERSION}" _iargs
+  recover_from_xid "${node}" 79
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `tests/bats/test_gpu_health.bats`, an e2e for the device health path on full GPUs. It covers both KEP-4680 (device health in pod status, added in #1243) and KEP-5055 (device taints from health events, added in #983), since the same NVML events drive both. It runs on the mock NVML setup only and injects Xids through the mock's config override.

Six tests:

1. KEP-4680: a healthy allocated GPU stays `Healthy` in the pod's `allocatedResourcesStatus` well past the kubelet health check timeout. This checks the heartbeat resend and timestamp refresh against a real kubelet.
2. KEP-4680 and KEP-5055: a critical Xid (79) taints the device with `gpu.nvidia.com/xid=79:NoSchedule` and marks the allocated GPU `Unhealthy`. The taint is checked for shape (one per device, value, `timeAdded`), the running pod keeps running, a new pod without a toleration stays `Pending`, a claim that tolerates `gpu.nvidia.com/xid` gets allocated and runs, `Unhealthy` stays past the kubelet timeout, the taint survives deleting the pod that used the GPU, and clearing the injection plus a plugin restart recovers the device.
3. KEP-5055: a non fatal Xid (43, in the built in ignore list) only adds an informational taint with effect `None`; the GPU stays `Healthy` (KEP-4680) and schedulable.
4. KEP-5055: `additionalXidsToIgnore` (`ADDITIONAL_XIDS_TO_IGNORE`) downgrades Xid 79 to an informational taint.
5. KEP-5055: an Xid on one GPU taints only that device; a new pod is allocated the other, untainted GPU.
6. Both: with `featureGates.NVMLDeviceHealthCheck=false` no taints appear and the kubelet reports the device health as `Unknown`, its default for drivers without a health service.

While writing these I found that a non fatal Xid after a critical one overwrote the device taint to `None`, which made the device schedulable again while the KEP-4680 status stayed `Unhealthy`. `AddOrUpdateTaint` now never lowers an existing taint's effect (`None` < `NoSchedule` < `NoExecute`); a later critical event still updates the value. This is unit tested only, because the mock delivers a single Xid per plugin process.

Also: a `tests-files` Makefile target to run an explicit list of bats files, the `ResourceHealthStatus` kubelet gate (KEP-4680) in the mock e2e kind config for Kubernetes older than 1.36, and a bump of the pinned k8s-test-infra ref in `mock-nvml-e2e.yaml` to `57ef016`, which contains the mock fixes from NVIDIA/k8s-test-infra#735 that these tests need.

#### Which issue(s) this PR is related to:

Follow up to #1243 (KEP-4680), as requested there. N/A

#### Special notes for your reviewer:

@guptaNswati this is the follow up you asked for in #1243, and since you mentioned health checking tests are on your radar too, I extended it to the KEP-5055 taints you added in #983. The taint effect change above touches your `AddOrUpdateTaint` semantics ("only the most recent event data is retained"), so please check that you agree with making it sticky in the downgrade direction.

This is stacked on #1243 and includes its commit until that merges; only the last commit is new here. I will rebase once #1243 lands.

Not covered on purpose: `gpu-lost` and `unmonitored` taints (the mock's lost mode fails device discovery, so the plugin never starts, and there is no way to make event registration fail) and MIG devices (the mock e2e filters `!mig,!dynmig`). Those still need a real GPU.

Verified locally with the mock e2e (kind v1.36.4, gb200 profile, 2 GPUs); all six tests pass. The Xid injection needs a plugin restart because the mock only trips a failure on a guarded NVML call, which for the plugin happens during device discovery.

#### Does this PR introduce a user-facing change?

```release-note
A later non-fatal XID no longer downgrades an existing NoSchedule health taint on the same device; the taint keeps the critical XID until the driver restarts.
```

#### Additional documentation (design docs, usage docs, etc.):

KEP-4680: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4680-add-resource-health-to-pod-status
KEP-5055: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5055-dra-device-taints-and-tolerations
NVIDIA/k8s-test-infra#735 describes the mock NVML changes and a small reproducer.

#### AI Usage

Claude Code assisted with the investigation, tests and this write up; I reviewed the changes and verified the results myself.
