### PR TITLE
fix healthcheckPort 0 being treated as disabled in helm chart

### DIFF
--- a/deployments/helm/dra-driver-nvidia-gpu/templates/_helpers.tpl
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/_helpers.tpl
@@ -84,7 +84,7 @@ TOOD: remove the override feature, or make the override work per-component.
 {{ $name }}-component: {{ .componentName }}
 {{- end }}
 {{- else -}}
-fail "selectorLabels: both arguments are required: context, componentName"
+{{- fail "selectorLabels: both arguments are required: context, componentName" -}}
 {{- end }}
 {{- end }}
 

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/kubeletplugin.yaml
@@ -180,7 +180,7 @@ spec:
           value: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}
         - name: KUBELET_PLUGINS_DIRECTORY_PATH
           value: {{ .Values.kubeletPlugin.kubeletPluginsDirectoryPath | quote }}
-        {{- if .Values.kubeletPlugin.containers.computeDomains.healthcheckPort }}
+        {{- if ge (int .Values.kubeletPlugin.containers.computeDomains.healthcheckPort) 0 }}
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.computeDomains.healthcheckPort | quote }}
         {{- end }}
@@ -317,7 +317,7 @@ spec:
           value: {{ .Values.kubeletPlugin.kubeletRegistrarDirectoryPath | quote }}
         - name: KUBELET_PLUGINS_DIRECTORY_PATH
           value: {{ .Values.kubeletPlugin.kubeletPluginsDirectoryPath | quote }}
-        {{- if .Values.kubeletPlugin.containers.gpus.healthcheckPort }}
+        {{- if ge (int .Values.kubeletPlugin.containers.gpus.healthcheckPort) 0 }}
         - name: HEALTHCHECK_PORT
           value: {{ .Values.kubeletPlugin.containers.gpus.healthcheckPort | quote }}
         {{- end }}

--- a/deployments/helm/dra-driver-nvidia-gpu/templates/validation.yaml
+++ b/deployments/helm/dra-driver-nvidia-gpu/templates/validation.yaml
@@ -47,7 +47,7 @@
 {{- $error = printf "%s\nSetting a user-defined nvidiaCtkPath is no longer supported. It can simply be removed without consequence." $error }}
 {{- $error = printf "%s\nIt was previously required to point the DRA driver at the host-path to the nvidia-ctk binary." $error }}
 {{- $error = printf "%s\nThis, in turn, was used to execute any CDI hooks injected into containers by the DRA driver." $error }}
-{{- $error = printf "%s\nNow a diffent binary is used called nvidia-cdi-hook that is installed by the DRA driver itself." $error }}
+{{- $error = printf "%s\nNow a different binary is used called nvidia-cdi-hook that is installed by the DRA driver itself." $error }}
 {{- $error = printf "%s\nThis renders the need for passing this user-defined flag obsolete." $error }}
 {{- fail $error }}
 {{- end }}


### PR DESCRIPTION
/kind bug
The chart docs and the binary both say healthcheckPort 0 means "allocate a random port", but the template guard treats 0 as falsey, so HEALTHCHECK_PORT is never set and the binary falls back to its default of -1, which disables the health service. Use an explicit `ge 0` check instead. Also wraps a `fail` call in _helpers.tpl that was rendered as literal text, and fixes a typo in a validation message.
