### PR TITLE
Update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     - dependency-name: k8s.io/*
     labels:
     - dependencies
+    - "ok-to-test"
+    - "kind/cleanup"
 
   - package-ecosystem: "docker"
     target-branch: main
@@ -26,6 +28,8 @@ updates:
       interval: "daily"
     labels:
     - dependencies
+    - "ok-to-test"
+    - "kind/cleanup"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -35,3 +39,6 @@ updates:
       actions-all:
         patterns:
         - "*"
+    labels:
+    - "ok-to-test"
+    - "kind/cleanup"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      actions-all:
+        patterns:
+        - "*"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
If dependabot does not bump all codeql action versions at the same time, it causes CI breakages.
Eg:
https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1382
https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1383

Additionally added the following labels to dependabot PRs:
* ok-to-test
* kind/cleanup

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
