### PR TITLE
Convert basic gpu/mig tests from bats to ginkgo

### DIFF
--- a/test/e2e/framework/gpu.go
+++ b/test/e2e/framework/gpu.go
@@ -67,6 +67,27 @@ func DetectGPU(ctx context.Context, cs *kubernetes.Clientset) (*GPUDetails, erro
 	return nil, fmt.Errorf("no gpu.nvidia.com ResourceSlice with a device found")
 }
 
+// HasDeviceType reports whether the NVIDIA GPU driver currently advertises a
+// device with the requested type (for example, "gpu" or "mig").
+func HasDeviceType(ctx context.Context, cs *kubernetes.Clientset, deviceType string) (bool, error) {
+	slices, err := cs.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("list ResourceSlices: %w", err)
+	}
+	for _, s := range slices.Items {
+		if s.Spec.Driver != "gpu.nvidia.com" {
+			continue
+		}
+		for _, d := range s.Spec.Devices {
+			attr, ok := d.Attributes["type"]
+			if ok && attr.StringValue != nil && *attr.StringValue == deviceType {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 // StripSemverLeadingZeros normalizes "580.105.04" to "580.105.4" so CEL's
 // semver() parser accepts it (it rejects leading zeros).
 func StripSemverLeadingZeros(v string) string {

--- a/test/e2e/framework/manifests.go
+++ b/test/e2e/framework/manifests.go
@@ -16,6 +16,10 @@ import (
 	"os"
 	"os/exec"
 	"text/template"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Specs are the embedded YAML / YAML-template sources for DRA workloads.
@@ -54,4 +58,21 @@ func ApplyYAML(ctx context.Context, yaml []byte) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// PodLogs returns the complete log stream for one container in a Pod. An
+// empty container name selects the pod's only container.
+func PodLogs(ctx context.Context, cs *kubernetes.Clientset, ns, pod, container string) (string, error) {
+	request := cs.CoreV1().Pods(ns).GetLogs(pod, &corev1.PodLogOptions{Container: container})
+	data, err := request.DoRaw(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get logs for pod %s/%s: %w", ns, pod, err)
+	}
+	return string(data), nil
+}
+
+// CreateNamespace creates an isolated namespace for an e2e spec.
+func CreateNamespace(ctx context.Context, cs *kubernetes.Clientset, name string) error {
+	_, err := cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}, metav1.CreateOptions{})
+	return err
 }

--- a/test/e2e/framework/specs/gpu-anymig.yaml.tmpl
+++ b/test/e2e/framework/specs/gpu-anymig.yaml.tmpl
@@ -1,0 +1,31 @@
+# Migrated from tests/bats/specs/gpu-anymig.yaml.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-anymig
+  namespace: {{ .Namespace }}
+spec:
+  spec:
+    devices:
+      requests:
+      - name: anymig
+        exactly:
+          deviceClassName: mig.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-anymig
+  namespace: {{ .Namespace }}
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: migdev
+  resourceClaims:
+  - name: migdev
+    resourceClaimTemplateName: rct-anymig

--- a/test/e2e/framework/specs/gpu-simple-full.yaml.tmpl
+++ b/test/e2e/framework/specs/gpu-simple-full.yaml.tmpl
@@ -1,0 +1,31 @@
+# Migrated from tests/bats/specs/gpu-simple-full.yaml.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rct-single-gpu-full
+  namespace: {{ .Namespace }}
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-full-gpu
+  namespace: {{ .Namespace }}
+spec:
+  containers:
+  - name: ctr
+    image: ubuntu:24.04
+    command: ["bash", "-c"]
+    args: ["nvidia-smi -L; trap 'exit 0' TERM; sleep 9999 & wait"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: rct-single-gpu-full

--- a/test/e2e/framework/wait.go
+++ b/test/e2e/framework/wait.go
@@ -79,3 +79,31 @@ func WaitForPodsReady(ctx context.Context, cs *kubernetes.Clientset, ns, labelSe
 	})
 	return ready, err
 }
+
+// WaitForPodReady waits until a named Pod is Running and every container is
+// Ready. It is useful for workloads which must remain running while their
+// logs or DRA allocation are inspected.
+func WaitForPodReady(ctx context.Context, cs *kubernetes.Clientset, ns, name string, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(ctx, DefaultPollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		pod, err := cs.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if pod.Status.Phase != corev1.PodRunning || len(pod.Status.ContainerStatuses) == 0 {
+			return false, nil
+		}
+		for _, status := range pod.Status.ContainerStatuses {
+			if !status.Ready {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("pod %s/%s never became Ready: %w", ns, name, err)
+	}
+	return nil
+}

--- a/test/e2e/gpu_mig_test.go
+++ b/test/e2e/gpu_mig_test.go
@@ -1,0 +1,66 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/test/e2e/framework"
+)
+
+// This is the allocation portion of the Bats case "StaticMIG: allocate (1
+// cnt)". The Bats case provisions a slice itself; this e2e suite instead
+// expects an administrator to have configured static MIG before it starts.
+var _ = Describe("static MIG workloads", Label("mig", "static-mig"), func() {
+	var ns string
+
+	BeforeEach(func(ctx SpecContext) {
+		hasMIG, err := framework.HasDeviceType(ctx, cs, "mig")
+		Expect(err).NotTo(HaveOccurred())
+		if !hasMIG {
+			Skip("no MIG device is advertised by gpu.nvidia.com")
+		}
+
+		ns = fmt.Sprintf("gpu-e2e-mig-%d", time.Now().UnixNano()%1_000_000)
+		Expect(framework.CreateNamespace(ctx, cs, ns)).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		if ns != "" {
+			Expect(cs.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})).To(Succeed())
+		}
+	})
+
+	It("allocates one preconfigured MIG device", Label("fastfeedback"), func(ctx SpecContext) {
+		yaml, err := framework.Render("gpu-anymig", map[string]any{"Namespace": ns})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(framework.ApplyYAML(ctx, yaml)).To(Succeed())
+
+		Expect(framework.WaitForPodReady(ctx, cs, ns, "pod-anymig", 3*time.Minute)).To(Succeed())
+
+		logs, err := framework.PodLogs(ctx, cs, ns, "pod-anymig", "ctr")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).To(ContainSubstring("UUID: MIG-"))
+		Expect(logs).To(ContainSubstring("UUID: GPU-"))
+	})
+})

--- a/test/e2e/gpu_workloads_test.go
+++ b/test/e2e/gpu_workloads_test.go
@@ -1,0 +1,54 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/dra-driver-nvidia-gpu/test/e2e/framework"
+)
+
+var _ = Describe("GPU workloads", Label("gpu-workloads"), func() {
+	var ns string
+
+	BeforeEach(func(ctx SpecContext) {
+		ns = fmt.Sprintf("gpu-e2e-workload-%d", time.Now().UnixNano()%1_000_000)
+		Expect(framework.CreateNamespace(ctx, cs, ns)).To(Succeed())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		Expect(cs.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})).To(Succeed())
+	})
+
+	It("allocates one full GPU to a pod", Label("fastfeedback"), func(ctx SpecContext) {
+		yaml, err := framework.Render("gpu-simple-full", map[string]any{"Namespace": ns})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(framework.ApplyYAML(ctx, yaml)).To(Succeed())
+
+		Expect(framework.WaitForPodReady(ctx, cs, ns, "pod-full-gpu", 3*time.Minute)).To(Succeed())
+
+		logs, err := framework.PodLogs(ctx, cs, ns, "pod-full-gpu", "ctr")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).To(ContainSubstring("UUID: GPU-"))
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

Creates ginkgo based tests

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

#### Special notes for your reviewer:

Tested manually on an A100 machine

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note

```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
