### PR TITLE
docs: Add limitation for Dynamic MIG and DGCM Exp

### DIFF
--- a/site/content/docs/guides/gpu-allocation/mig.md
+++ b/site/content/docs/guides/gpu-allocation/mig.md
@@ -124,6 +124,12 @@ no action is required.
   mode is off, the driver falls back to full-GPU allocation and advertises no
   MIG partitions. Hopper and later architectures enable MIG mode on demand.
 - Dynamic MIG is not supported on vGPU guests.
+- NVIDIA DCGM Exporter cannot attribute MIG metrics to pods on dynamic MIG nodes.
+  With `KUBERNETES_ENABLE_DRA=true`, the exporter identifies pods by the MIG
+  instance UUID, but dynamic MIG advertises partitions that do not exist yet, so
+  their `ResourceSlice` entries have no `uuid` attribute and the UUID created
+  during pod preparation is never published.
+  The exporter drops those mappings and reports MIG metrics without pod labels.
 
 ## Examples
 


### PR DESCRIPTION
Addresses 6502760

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:

Bug 6502760.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs
Acknowledge limitation for dynamic MIG and NVIDIA DCGM Exporter.
```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
