### PR TITLE
fix: gracefully handle missing IOMMU with PassthroughSupport

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -124,6 +124,19 @@ func newFabricManager(nvdevlib *deviceLib, driver *root.Driver) (*fabricmanager.
 	return fmManager, nil
 }
 
+func newVfioPciManagerForNode(containerDriverRoot, hostDriverRoot string, nvdevlib *deviceLib) (*VfioPciManager, error) {
+	vfioPciManager, err := NewVfioPciManager(containerDriverRoot, hostDriverRoot, nvdevlib, true /* nvidiaEnabled */)
+	if errors.Is(err, errIommuUnavailable) {
+		klog.Warningf("PassthroughSupport enabled but IOMMU is unavailable; VFIO devices will not be advertised")
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to create vfio pci manager: %w", err)
+	}
+	nvdevlib.vfioEnabled = true
+	return vfioPciManager, nil
+}
+
 func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	driver := root.New(root.WithDriverRoot(config.flags.containerDriverRoot))
 	devRoot := driver.DevRoot
@@ -134,12 +147,19 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		return nil, fmt.Errorf("failed to create device library: %w", err)
 	}
 
+	hostDriverRoot := config.flags.hostDriverRoot
+
+	var vfioPciManager *VfioPciManager
+	if featuregates.Enabled(featuregates.PassthroughSupport) {
+		vfioPciManager, err = newVfioPciManagerForNode(driver.Root, hostDriverRoot, nvdevlib)
+		if err != nil {
+			return nil, err
+		}
+	}
 	perGPUAllocatable, err := nvdevlib.enumerateAllPossibleDevices()
 	if err != nil {
 		return nil, fmt.Errorf("error enumerating all possible devices: %w", err)
 	}
-
-	hostDriverRoot := config.flags.hostDriverRoot
 
 	// Let nvcdi logs see the light of day (emit to standard streams) when we've
 	// been configured with verbosity level 7 or higher.
@@ -160,7 +180,7 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		WithLogger(cdilogger),
 	}
 	var vfioCDIHandler *vfioCDIHandler
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
+	if nvdevlib.vfioEnabled {
 		vfioCDIHandler, err = NewVfioCDIHandler(nvdevlib)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create vfio CDI handler: %w", err)
@@ -192,14 +212,6 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	var mpsManager *MpsManager
 	if featuregates.Enabled(featuregates.MPSSupport) {
 		mpsManager = NewMpsManager(config, nvdevlib, hostDriverRoot, MpsControlDaemonTemplatePath)
-	}
-
-	var vfioPciManager *VfioPciManager
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
-		vfioPciManager, err = NewVfioPciManager(driver.Root, hostDriverRoot, nvdevlib, true /* nvidiaEnabled */)
-		if err != nil {
-			return nil, fmt.Errorf("unable to create vfio pci manager: %w", err)
-		}
 	}
 
 	fmManager, err := newFabricManager(nvdevlib, driver)
@@ -1240,7 +1252,7 @@ func (s *DeviceState) unprepareVfioDevices(ctx context.Context, devices Prepared
 func (s *DeviceState) discoverSiblingAllocatables(device *AllocatableDevice) error {
 	switch device.Type() {
 	case GpuDeviceType:
-		if !device.Gpu.vfioEnabled {
+		if s.vfioPciManager == nil || !device.Gpu.vfioEnabled {
 			return nil
 		}
 		vfioAllocatable, err := s.nvdevlib.discoverVfioDevice(device.Gpu)

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -126,15 +126,17 @@ func newFabricManager(nvdevlib *deviceLib, driver *root.Driver) (*fabricmanager.
 
 func newVfioPciManagerForNode(containerDriverRoot, hostDriverRoot string, nvdevlib *deviceLib) (*VfioPciManager, error) {
 	vfioPciManager, err := NewVfioPciManager(containerDriverRoot, hostDriverRoot, nvdevlib, true /* nvidiaEnabled */)
-	if errors.Is(err, errIommuUnavailable) {
-		klog.Warningf("PassthroughSupport enabled but IOMMU is unavailable; VFIO devices will not be advertised")
-		return nil, nil
-	}
 	if err != nil {
 		return nil, fmt.Errorf("unable to create vfio pci manager: %w", err)
 	}
-	nvdevlib.vfioEnabled = true
 	return vfioPciManager, nil
+}
+
+func newVfioCDIHandlerForNode(nvdevlib *deviceLib) (*vfioCDIHandler, error) {
+	if !nvdevlib.vfioEnabled {
+		return nil, nil
+	}
+	return NewVfioCDIHandler(nvdevlib)
 }
 
 func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
@@ -152,10 +154,14 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	var vfioPciManager *VfioPciManager
 	if featuregates.Enabled(featuregates.PassthroughSupport) {
 		vfioPciManager, err = newVfioPciManagerForNode(driver.Root, hostDriverRoot, nvdevlib)
-		if err != nil {
+		if errors.Is(err, errIommuUnavailable) {
+			klog.Warningf("PassthroughSupport enabled but IOMMU is unavailable; VFIO devices will not be advertised")
+			vfioPciManager = nil
+		} else if err != nil {
 			return nil, err
 		}
 	}
+	nvdevlib.vfioEnabled = vfioPciManager != nil
 	perGPUAllocatable, err := nvdevlib.enumerateAllPossibleDevices()
 	if err != nil {
 		return nil, fmt.Errorf("error enumerating all possible devices: %w", err)
@@ -179,12 +185,11 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		WithCDIRoot(config.flags.cdiRoot),
 		WithLogger(cdilogger),
 	}
-	var vfioCDIHandler *vfioCDIHandler
-	if nvdevlib.vfioEnabled {
-		vfioCDIHandler, err = NewVfioCDIHandler(nvdevlib)
-		if err != nil {
-			return nil, fmt.Errorf("unable to create vfio CDI handler: %w", err)
-		}
+	vfioCDIHandler, err := newVfioCDIHandlerForNode(nvdevlib)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create vfio CDI handler: %w", err)
+	}
+	if vfioCDIHandler != nil {
 		cdiOptions = append(cdiOptions, WithVfioCDIHandler(vfioCDIHandler))
 	}
 	cdi, err := NewCDIHandler(cdiOptions...)
@@ -378,7 +383,7 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	}
 
 	// TODO: Remove this once partitionable device support is introduced for vfio devices.
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
+	if s.nvdevlib.vfioEnabled {
 		for _, device := range preparedDevices.GetDevices() {
 			allocatableDevice := s.perGPUAllocatable.GetAllocatableDevice(device.DeviceName)
 			if allocatableDevice == nil {
@@ -543,7 +548,7 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 	}
 
 	// TODO: Remove this once partitionable device support is introduced for vfio devices.
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
+	if s.nvdevlib.vfioEnabled {
 		for _, device := range pc.PreparedDevices.GetDevices() {
 			allocatableDevice := s.perGPUAllocatable.GetAllocatableDevice(device.DeviceName)
 			if allocatableDevice == nil {
@@ -653,8 +658,8 @@ func (s *DeviceState) unpreparePartiallyPreparedClaim(ctx context.Context, cuid 
 		}
 	}
 
-	// Attempt rollback of VFIO devices if PassthroughSupport is enabled.
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
+	// Attempt rollback of VFIO devices if passthrough is available on this node.
+	if s.nvdevlib.vfioEnabled {
 		vfioDevices := allocDevsForClaim.GetVfioDevices()
 		if len(vfioDevices) > 0 {
 			klog.V(2).Infof("unprepare: VFIO rollback for partially prepared claim %s (devices: %d)", PreparedClaimToString(&pc, cuid), len(vfioDevices))
@@ -986,7 +991,7 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 		return nil, err
 	}
 
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
+	if s.nvdevlib.vfioEnabled {
 		vfioGroups := 0
 		for c := range configResultsMap {
 			if _, ok := c.(*configapi.VfioDeviceConfig); ok {
@@ -1147,7 +1152,7 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, dev
 	var taintRemoved bool
 	for _, group := range devices {
 		// Unconfigure the vfio-pci devices.
-		if featuregates.Enabled(featuregates.PassthroughSupport) {
+		if s.nvdevlib.vfioEnabled {
 			err := s.unprepareVfioDevices(ctx, group.Devices.VfioDevices())
 			if err != nil {
 				return false, fmt.Errorf("error unpreparing VFIO devices: %w", err)
@@ -1252,7 +1257,7 @@ func (s *DeviceState) unprepareVfioDevices(ctx context.Context, devices Prepared
 func (s *DeviceState) discoverSiblingAllocatables(device *AllocatableDevice) error {
 	switch device.Type() {
 	case GpuDeviceType:
-		if s.vfioPciManager == nil || !device.Gpu.vfioEnabled {
+		if !s.nvdevlib.vfioEnabled || !device.Gpu.vfioEnabled {
 			return nil
 		}
 		vfioAllocatable, err := s.nvdevlib.discoverVfioDevice(device.Gpu)
@@ -1379,6 +1384,10 @@ func (s *DeviceState) applySharingConfig(ctx context.Context, config configapi.S
 }
 
 func (s *DeviceState) applyVfioDeviceConfig(ctx context.Context, config *configapi.VfioDeviceConfig, claim *resourceapi.ResourceClaim, results []*resourceapi.DeviceRequestAllocationResult) (*DeviceConfigState, error) {
+	if !s.nvdevlib.vfioEnabled {
+		return nil, errors.New("VFIO is unavailable on this node")
+	}
+
 	configState := DeviceConfigState{
 		Config: config,
 	}

--- a/cmd/gpu-kubelet-plugin/device_state.go
+++ b/cmd/gpu-kubelet-plugin/device_state.go
@@ -124,44 +124,21 @@ func newFabricManager(nvdevlib *deviceLib, driver *root.Driver) (*fabricmanager.
 	return fmManager, nil
 }
 
-func newVfioPciManagerForNode(containerDriverRoot, hostDriverRoot string, nvdevlib *deviceLib) (*VfioPciManager, error) {
-	vfioPciManager, err := NewVfioPciManager(containerDriverRoot, hostDriverRoot, nvdevlib, true /* nvidiaEnabled */)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create vfio pci manager: %w", err)
-	}
-	return vfioPciManager, nil
-}
-
-func newVfioCDIHandlerForNode(nvdevlib *deviceLib) (*vfioCDIHandler, error) {
-	if !nvdevlib.vfioEnabled {
-		return nil, nil
-	}
-	return NewVfioCDIHandler(nvdevlib)
-}
-
 func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	driver := root.New(root.WithDriverRoot(config.flags.containerDriverRoot))
-	devRoot := driver.DevRoot
-	klog.Infof("Using devRoot=%v", devRoot)
-
 	nvdevlib, err := newDeviceLib(driver, config.flags.hostRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create device library: %w", err)
 	}
 
+	return newDeviceState(ctx, config, driver, nvdevlib)
+}
+
+func newDeviceState(ctx context.Context, config *Config, driver *root.Driver, nvdevlib *deviceLib) (*DeviceState, error) {
+	devRoot := driver.DevRoot
+	klog.Infof("Using devRoot=%v", devRoot)
 	hostDriverRoot := config.flags.hostDriverRoot
 
-	var vfioPciManager *VfioPciManager
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
-		vfioPciManager, err = newVfioPciManagerForNode(driver.Root, hostDriverRoot, nvdevlib)
-		if errors.Is(err, errIommuUnavailable) {
-			klog.Warningf("PassthroughSupport enabled but IOMMU is unavailable; VFIO devices will not be advertised")
-			vfioPciManager = nil
-		} else if err != nil {
-			return nil, err
-		}
-	}
-	nvdevlib.vfioEnabled = vfioPciManager != nil
 	perGPUAllocatable, err := nvdevlib.enumerateAllPossibleDevices()
 	if err != nil {
 		return nil, fmt.Errorf("error enumerating all possible devices: %w", err)
@@ -185,11 +162,11 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 		WithCDIRoot(config.flags.cdiRoot),
 		WithLogger(cdilogger),
 	}
-	vfioCDIHandler, err := newVfioCDIHandlerForNode(nvdevlib)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create vfio CDI handler: %w", err)
-	}
-	if vfioCDIHandler != nil {
+	if featuregates.Enabled(featuregates.PassthroughSupport) && nvdevlib.IsVfioEnabled() {
+		vfioCDIHandler, err := NewVfioCDIHandler(nvdevlib)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create vfio CDI handler: %w", err)
+		}
 		cdiOptions = append(cdiOptions, WithVfioCDIHandler(vfioCDIHandler))
 	}
 	cdi, err := NewCDIHandler(cdiOptions...)
@@ -217,6 +194,14 @@ func NewDeviceState(ctx context.Context, config *Config) (*DeviceState, error) {
 	var mpsManager *MpsManager
 	if featuregates.Enabled(featuregates.MPSSupport) {
 		mpsManager = NewMpsManager(config, nvdevlib, hostDriverRoot, MpsControlDaemonTemplatePath)
+	}
+
+	var vfioPciManager *VfioPciManager
+	if featuregates.Enabled(featuregates.PassthroughSupport) && nvdevlib.IsVfioEnabled() {
+		vfioPciManager, err = NewVfioPciManager(driver.Root, hostDriverRoot, nvdevlib, true /* nvidiaEnabled */)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create vfio pci manager: %w", err)
+		}
 	}
 
 	fmManager, err := newFabricManager(nvdevlib, driver)
@@ -383,7 +368,7 @@ func (s *DeviceState) Prepare(ctx context.Context, claim *resourceapi.ResourceCl
 	}
 
 	// TODO: Remove this once partitionable device support is introduced for vfio devices.
-	if s.nvdevlib.vfioEnabled {
+	if featuregates.Enabled(featuregates.PassthroughSupport) && s.nvdevlib.IsVfioEnabled() {
 		for _, device := range preparedDevices.GetDevices() {
 			allocatableDevice := s.perGPUAllocatable.GetAllocatableDevice(device.DeviceName)
 			if allocatableDevice == nil {
@@ -548,7 +533,7 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 	}
 
 	// TODO: Remove this once partitionable device support is introduced for vfio devices.
-	if s.nvdevlib.vfioEnabled {
+	if featuregates.Enabled(featuregates.PassthroughSupport) && s.nvdevlib.IsVfioEnabled() {
 		for _, device := range pc.PreparedDevices.GetDevices() {
 			allocatableDevice := s.perGPUAllocatable.GetAllocatableDevice(device.DeviceName)
 			if allocatableDevice == nil {
@@ -659,7 +644,7 @@ func (s *DeviceState) unpreparePartiallyPreparedClaim(ctx context.Context, cuid 
 	}
 
 	// Attempt rollback of VFIO devices if passthrough is available on this node.
-	if s.nvdevlib.vfioEnabled {
+	if featuregates.Enabled(featuregates.PassthroughSupport) && s.nvdevlib.IsVfioEnabled() {
 		vfioDevices := allocDevsForClaim.GetVfioDevices()
 		if len(vfioDevices) > 0 {
 			klog.V(2).Infof("unprepare: VFIO rollback for partially prepared claim %s (devices: %d)", PreparedClaimToString(&pc, cuid), len(vfioDevices))
@@ -991,7 +976,7 @@ func (s *DeviceState) prepareDevices(ctx context.Context, claim *resourceapi.Res
 		return nil, err
 	}
 
-	if s.nvdevlib.vfioEnabled {
+	if featuregates.Enabled(featuregates.PassthroughSupport) && s.nvdevlib.IsVfioEnabled() {
 		vfioGroups := 0
 		for c := range configResultsMap {
 			if _, ok := c.(*configapi.VfioDeviceConfig); ok {
@@ -1152,7 +1137,7 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimUID string, dev
 	var taintRemoved bool
 	for _, group := range devices {
 		// Unconfigure the vfio-pci devices.
-		if s.nvdevlib.vfioEnabled {
+		if featuregates.Enabled(featuregates.PassthroughSupport) && s.nvdevlib.IsVfioEnabled() {
 			err := s.unprepareVfioDevices(ctx, group.Devices.VfioDevices())
 			if err != nil {
 				return false, fmt.Errorf("error unpreparing VFIO devices: %w", err)
@@ -1257,7 +1242,7 @@ func (s *DeviceState) unprepareVfioDevices(ctx context.Context, devices Prepared
 func (s *DeviceState) discoverSiblingAllocatables(device *AllocatableDevice) error {
 	switch device.Type() {
 	case GpuDeviceType:
-		if !s.nvdevlib.vfioEnabled || !device.Gpu.vfioEnabled {
+		if !featuregates.Enabled(featuregates.PassthroughSupport) || !s.nvdevlib.IsVfioEnabled() || !device.Gpu.vfioEnabled {
 			return nil
 		}
 		vfioAllocatable, err := s.nvdevlib.discoverVfioDevice(device.Gpu)
@@ -1384,7 +1369,7 @@ func (s *DeviceState) applySharingConfig(ctx context.Context, config configapi.S
 }
 
 func (s *DeviceState) applyVfioDeviceConfig(ctx context.Context, config *configapi.VfioDeviceConfig, claim *resourceapi.ResourceClaim, results []*resourceapi.DeviceRequestAllocationResult) (*DeviceConfigState, error) {
-	if !s.nvdevlib.vfioEnabled {
+	if !featuregates.Enabled(featuregates.PassthroughSupport) || !s.nvdevlib.IsVfioEnabled() {
 		return nil, errors.New("VFIO is unavailable on this node")
 	}
 

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,6 +31,86 @@ import (
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/fabricmanager"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 )
+
+func TestNewVfioPciManagerForNode(t *testing.T) {
+	t.Run("IOMMU unavailable disables passthrough", func(t *testing.T) {
+		nvdevlib := &deviceLib{hostRoot: t.TempDir()}
+
+		manager, err := newVfioPciManagerForNode("", "", nvdevlib)
+
+		require.NoError(t, err)
+		require.Nil(t, manager)
+		require.False(t, nvdevlib.vfioEnabled)
+	})
+
+	t.Run("IOMMU available enables passthrough", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(hostRoot, kernelIommuGroupPath, "0"), 0o755))
+		nvdevlib := &deviceLib{hostRoot: hostRoot}
+
+		manager, err := newVfioPciManagerForNode("", "", nvdevlib)
+
+		require.NoError(t, err)
+		require.NotNil(t, manager)
+		require.True(t, nvdevlib.vfioEnabled)
+	})
+
+	t.Run("unexpected IOMMU check error remains fatal", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		iommuGroupsPath := filepath.Join(hostRoot, kernelIommuGroupPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(iommuGroupsPath), 0o755))
+		require.NoError(t, os.WriteFile(iommuGroupsPath, nil, 0o644))
+		nvdevlib := &deviceLib{hostRoot: hostRoot}
+
+		manager, err := newVfioPciManagerForNode("", "", nvdevlib)
+
+		require.Error(t, err)
+		require.Nil(t, manager)
+		require.False(t, nvdevlib.vfioEnabled)
+	})
+}
+
+func TestIommuUnavailableDoesNotAdvertiseVfio(t *testing.T) {
+	nvdevlib := &deviceLib{hostRoot: t.TempDir()}
+	vfioPciManager, err := newVfioPciManagerForNode("", "", nvdevlib)
+	require.NoError(t, err)
+	require.Nil(t, vfioPciManager)
+
+	gpu := &AllocatableDevice{Gpu: &GpuInfo{
+		UUID:                  "GPU-0000",
+		minor:                 0,
+		productName:           "NVIDIA Test GPU",
+		brand:                 "Test",
+		architecture:          "Test",
+		cudaComputeCapability: "8.0",
+		driverVersion:         "550.0",
+		cudaDriverVersion:     "12.0",
+		pciBusID:              "0000:00:00.0",
+		vfioEnabled:           nvdevlib.vfioEnabled,
+	}}
+	perGPU := &PerGPUAllocatableDevices{
+		allocatablesMap: map[PCIBusID]AllocatableDevices{
+			gpu.Gpu.pciBusID: {gpu.CanonicalName(): gpu},
+		},
+	}
+	state := &DeviceState{
+		vfioPciManager:    vfioPciManager,
+		perGPUAllocatable: perGPU,
+		nvdevlib:          nvdevlib,
+	}
+
+	require.NoError(t, state.discoverSiblingAllocatables(gpu))
+	require.Same(t, gpu, perGPU.GetAllocatableDevice(gpu.CanonicalName()))
+	require.Empty(t, perGPU.GetAllDevices().GetVfioDevices())
+
+	resources := (&driver{state: state}).generateLegacyDriverResources("test-node", nil)
+	var devices []resourceapi.Device
+	for _, slice := range resources.Pools["test-node"].Slices {
+		devices = append(devices, slice.Devices...)
+	}
+	require.Len(t, devices, 1)
+	require.Equal(t, GpuDeviceType, *devices[0].Attributes["type"].StringValue)
+}
 
 func TestValidateNoOverlappingPreparedDevices(t *testing.T) {
 	perGPU := &PerGPUAllocatableDevices{

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -33,17 +33,17 @@ import (
 )
 
 func TestNewVfioPciManagerForNode(t *testing.T) {
-	t.Run("IOMMU unavailable disables passthrough", func(t *testing.T) {
+	t.Run("IOMMU unavailable is reported without changing VFIO state", func(t *testing.T) {
 		nvdevlib := &deviceLib{hostRoot: t.TempDir()}
 
 		manager, err := newVfioPciManagerForNode("", "", nvdevlib)
 
-		require.NoError(t, err)
+		require.ErrorIs(t, err, errIommuUnavailable)
 		require.Nil(t, manager)
 		require.False(t, nvdevlib.vfioEnabled)
 	})
 
-	t.Run("IOMMU available enables passthrough", func(t *testing.T) {
+	t.Run("IOMMU available returns a manager without changing VFIO state", func(t *testing.T) {
 		hostRoot := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(hostRoot, kernelIommuGroupPath, "0"), 0o755))
 		nvdevlib := &deviceLib{hostRoot: hostRoot}
@@ -52,7 +52,7 @@ func TestNewVfioPciManagerForNode(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, manager)
-		require.True(t, nvdevlib.vfioEnabled)
+		require.False(t, nvdevlib.vfioEnabled)
 	})
 
 	t.Run("unexpected IOMMU check error remains fatal", func(t *testing.T) {
@@ -70,11 +70,43 @@ func TestNewVfioPciManagerForNode(t *testing.T) {
 	})
 }
 
+func TestNewVfioCDIHandlerForNode(t *testing.T) {
+	t.Run("VFIO disabled skips handler initialization", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(hostRoot, "dev"), nil, 0o644))
+		nvdevlib := &deviceLib{hostRoot: hostRoot, vfioEnabled: false}
+
+		handler, err := newVfioCDIHandlerForNode(nvdevlib)
+
+		require.NoError(t, err)
+		require.Nil(t, handler)
+	})
+
+	t.Run("VFIO enabled initializes handler", func(t *testing.T) {
+		nvdevlib := &deviceLib{hostRoot: t.TempDir(), vfioEnabled: true}
+
+		handler, err := newVfioCDIHandlerForNode(nvdevlib)
+
+		require.NoError(t, err)
+		require.NotNil(t, handler)
+	})
+}
+
+func TestApplyVfioDeviceConfigUnavailable(t *testing.T) {
+	state := &DeviceState{nvdevlib: &deviceLib{vfioEnabled: false}}
+
+	configState, err := state.applyVfioDeviceConfig(context.Background(), configapi.DefaultVfioDeviceConfig(), nil, nil)
+
+	require.ErrorContains(t, err, "VFIO is unavailable on this node")
+	require.Nil(t, configState)
+}
+
 func TestIommuUnavailableDoesNotAdvertiseVfio(t *testing.T) {
 	nvdevlib := &deviceLib{hostRoot: t.TempDir()}
 	vfioPciManager, err := newVfioPciManagerForNode("", "", nvdevlib)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, errIommuUnavailable)
 	require.Nil(t, vfioPciManager)
+	require.False(t, nvdevlib.vfioEnabled)
 
 	gpu := &AllocatableDevice{Gpu: &GpuInfo{
 		UUID:                  "GPU-0000",

--- a/cmd/gpu-kubelet-plugin/device_state_test.go
+++ b/cmd/gpu-kubelet-plugin/device_state_test.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,118 +29,6 @@ import (
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/fabricmanager"
 	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
 )
-
-func TestNewVfioPciManagerForNode(t *testing.T) {
-	t.Run("IOMMU unavailable is reported without changing VFIO state", func(t *testing.T) {
-		nvdevlib := &deviceLib{hostRoot: t.TempDir()}
-
-		manager, err := newVfioPciManagerForNode("", "", nvdevlib)
-
-		require.ErrorIs(t, err, errIommuUnavailable)
-		require.Nil(t, manager)
-		require.False(t, nvdevlib.vfioEnabled)
-	})
-
-	t.Run("IOMMU available returns a manager without changing VFIO state", func(t *testing.T) {
-		hostRoot := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(hostRoot, kernelIommuGroupPath, "0"), 0o755))
-		nvdevlib := &deviceLib{hostRoot: hostRoot}
-
-		manager, err := newVfioPciManagerForNode("", "", nvdevlib)
-
-		require.NoError(t, err)
-		require.NotNil(t, manager)
-		require.False(t, nvdevlib.vfioEnabled)
-	})
-
-	t.Run("unexpected IOMMU check error remains fatal", func(t *testing.T) {
-		hostRoot := t.TempDir()
-		iommuGroupsPath := filepath.Join(hostRoot, kernelIommuGroupPath)
-		require.NoError(t, os.MkdirAll(filepath.Dir(iommuGroupsPath), 0o755))
-		require.NoError(t, os.WriteFile(iommuGroupsPath, nil, 0o644))
-		nvdevlib := &deviceLib{hostRoot: hostRoot}
-
-		manager, err := newVfioPciManagerForNode("", "", nvdevlib)
-
-		require.Error(t, err)
-		require.Nil(t, manager)
-		require.False(t, nvdevlib.vfioEnabled)
-	})
-}
-
-func TestNewVfioCDIHandlerForNode(t *testing.T) {
-	t.Run("VFIO disabled skips handler initialization", func(t *testing.T) {
-		hostRoot := t.TempDir()
-		require.NoError(t, os.WriteFile(filepath.Join(hostRoot, "dev"), nil, 0o644))
-		nvdevlib := &deviceLib{hostRoot: hostRoot, vfioEnabled: false}
-
-		handler, err := newVfioCDIHandlerForNode(nvdevlib)
-
-		require.NoError(t, err)
-		require.Nil(t, handler)
-	})
-
-	t.Run("VFIO enabled initializes handler", func(t *testing.T) {
-		nvdevlib := &deviceLib{hostRoot: t.TempDir(), vfioEnabled: true}
-
-		handler, err := newVfioCDIHandlerForNode(nvdevlib)
-
-		require.NoError(t, err)
-		require.NotNil(t, handler)
-	})
-}
-
-func TestApplyVfioDeviceConfigUnavailable(t *testing.T) {
-	state := &DeviceState{nvdevlib: &deviceLib{vfioEnabled: false}}
-
-	configState, err := state.applyVfioDeviceConfig(context.Background(), configapi.DefaultVfioDeviceConfig(), nil, nil)
-
-	require.ErrorContains(t, err, "VFIO is unavailable on this node")
-	require.Nil(t, configState)
-}
-
-func TestIommuUnavailableDoesNotAdvertiseVfio(t *testing.T) {
-	nvdevlib := &deviceLib{hostRoot: t.TempDir()}
-	vfioPciManager, err := newVfioPciManagerForNode("", "", nvdevlib)
-	require.ErrorIs(t, err, errIommuUnavailable)
-	require.Nil(t, vfioPciManager)
-	require.False(t, nvdevlib.vfioEnabled)
-
-	gpu := &AllocatableDevice{Gpu: &GpuInfo{
-		UUID:                  "GPU-0000",
-		minor:                 0,
-		productName:           "NVIDIA Test GPU",
-		brand:                 "Test",
-		architecture:          "Test",
-		cudaComputeCapability: "8.0",
-		driverVersion:         "550.0",
-		cudaDriverVersion:     "12.0",
-		pciBusID:              "0000:00:00.0",
-		vfioEnabled:           nvdevlib.vfioEnabled,
-	}}
-	perGPU := &PerGPUAllocatableDevices{
-		allocatablesMap: map[PCIBusID]AllocatableDevices{
-			gpu.Gpu.pciBusID: {gpu.CanonicalName(): gpu},
-		},
-	}
-	state := &DeviceState{
-		vfioPciManager:    vfioPciManager,
-		perGPUAllocatable: perGPU,
-		nvdevlib:          nvdevlib,
-	}
-
-	require.NoError(t, state.discoverSiblingAllocatables(gpu))
-	require.Same(t, gpu, perGPU.GetAllocatableDevice(gpu.CanonicalName()))
-	require.Empty(t, perGPU.GetAllDevices().GetVfioDevices())
-
-	resources := (&driver{state: state}).generateLegacyDriverResources("test-node", nil)
-	var devices []resourceapi.Device
-	for _, slice := range resources.Pools["test-node"].Slices {
-		devices = append(devices, slice.Devices...)
-	}
-	require.Len(t, devices, 1)
-	require.Equal(t, GpuDeviceType, *devices[0].Attributes["type"].StringValue)
-}
 
 func TestValidateNoOverlappingPreparedDevices(t *testing.T) {
 	perGPU := &PerGPUAllocatableDevices{

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -509,7 +509,15 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 		return nil
 	}
 
-	// Enumerate the set of GPU, MIG and VFIO devices and publish them
+	resources := d.generateLegacyDriverResources(config.flags.nodeName, config)
+	if err := d.pluginhelper.PublishResources(ctx, resources); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *driver) generateLegacyDriverResources(nodeName string, config *Config) resourceslice.DriverResources {
 	var resourceSlice resourceslice.Slice
 	for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
 		for _, device := range devices {
@@ -518,18 +526,11 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 		}
 	}
 
-	resources := resourceslice.DriverResources{
+	return resourceslice.DriverResources{
 		Pools: map[string]resourceslice.Pool{
-			config.flags.nodeName: {Slices: []resourceslice.Slice{resourceSlice}},
+			nodeName: {Slices: []resourceslice.Slice{resourceSlice}},
 		},
 	}
-
-	if err := d.pluginhelper.PublishResources(ctx, resources); err != nil {
-		return err
-	}
-
-	return nil
-
 }
 
 func (d *driver) deviceHealthEvents(ctx context.Context) {

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -518,6 +518,7 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 }
 
 func (d *driver) generateLegacyDriverResources(nodeName string, config *Config) resourceslice.DriverResources {
+	// Enumerate the set of GPU, MIG and VFIO devices and publish them
 	var resourceSlice resourceslice.Slice
 	for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
 		for _, device := range devices {

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -210,12 +210,15 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 }
 
 // GenerateDriverResources() returns the set of DRA ResourceSlices announced by
-// this DRA driver to the system, using the Partitionable Devices paradigm.
+// this DRA driver to the system.
 func (d *driver) GenerateDriverResources(nodeName string) resourceslice.DriverResources {
-	if d.useSplitResourceSlices {
-		return d.generateSplitResourceSlices(nodeName)
+	if featuregates.Enabled(featuregates.DynamicMIG) {
+		if d.useSplitResourceSlices {
+			return d.generateSplitResourceSlices(nodeName)
+		}
+		return d.generateCombinedResourceSlices(nodeName)
 	}
-	return d.generateCombinedResourceSlices(nodeName)
+	return d.generateLegacyDriverResources(nodeName, d.state.config)
 }
 
 // generateSplitResourceSlices generates ResourceSlices for DynamicMIG for k8s 1.35+.
@@ -437,7 +440,7 @@ func (d *driver) nodePrepareResource(ctx context.Context, claim *resourceapi.Res
 		}
 	}
 
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
+	if featuregates.Enabled(featuregates.PassthroughSupport) && d.state.nvdevlib.IsVfioEnabled() {
 		// Re-advertise updated resourceslice after preparing devices.
 		if err = d.publishResources(ctx, d.state.config); err != nil {
 			drametrics.IncNodePrepareError(DriverName, "publish_resources")
@@ -475,7 +478,7 @@ func (d *driver) nodeUnprepareResource(ctx context.Context, claimRef kubeletplug
 		return fmt.Errorf("error unpreparing devices for claim %v: %w", claimRef.String(), err)
 	}
 
-	if featuregates.Enabled(featuregates.PassthroughSupport) ||
+	if (featuregates.Enabled(featuregates.PassthroughSupport) && d.state.nvdevlib.IsVfioEnabled()) ||
 		(featuregates.Enabled(featuregates.DynamicMIG) &&
 			featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) &&
 			taintRemovedRepublish) {
@@ -502,14 +505,9 @@ func (d *driver) publishResources(ctx context.Context, config *Config) error {
 		// TODO: implement error handler for bad slices:
 		// https://github.com/kubernetes/kubernetes/commit/a171795e313ee9f407fef4897c1a1e2052120991
 		klog.V(1).Infof("featuregates.DynamicMIG enabled: construct ResourceSlice objects according to KEP 4815 (partitionable devices)")
-		resources := d.GenerateDriverResources(config.flags.nodeName)
-		if err := d.pluginhelper.PublishResources(ctx, resources); err != nil {
-			return err
-		}
-		return nil
 	}
 
-	resources := d.generateLegacyDriverResources(config.flags.nodeName, config)
+	resources := d.GenerateDriverResources(config.flags.nodeName)
 	if err := d.pluginhelper.PublishResources(ctx, resources); err != nil {
 		return err
 	}

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -51,6 +51,8 @@ type deviceLib struct {
 	hostRoot          string
 	sysfsRoot         string
 	nvidiaSMIPath     string
+	// vfioEnabled combines the feature gate with node-local IOMMU availability.
+	vfioEnabled       bool
 	gpuInfosByUUID    map[string]*GpuInfo
 	gpuUUIDbyPCIBusID map[PCIBusID]string
 	devhandleByUUID   map[string]nvml.Device
@@ -193,7 +195,7 @@ func (l deviceLib) enumerateAllPossibleDevices() (*PerGPUAllocatableDevices, err
 		return nil, fmt.Errorf("error enumerating allocatable devices: %w", err)
 	}
 
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
+	if l.vfioEnabled {
 		// Discover passthrough devices and insert them into the
 		// `perGPUAllocatable` devices map
 		err = l.enumerateGpuVfioDevices(perGPUAllocatable)
@@ -309,7 +311,7 @@ func (l deviceLib) GetPerGpuAllocatableDevices(indices ...int) (*PerGPUAllocatab
 			return fmt.Errorf("error discovering MIG devices for GPU %q: %w", gpuInfo.CanonicalName(), err)
 		}
 
-		if featuregates.Enabled(featuregates.PassthroughSupport) {
+		if l.vfioEnabled {
 			// Only if no MIG devices are found, allow VFIO devices.
 			klog.Infof("PassthroughSupport enabled, and %d MIG devices found", len(migdevs))
 			gpuInfo.vfioEnabled = len(migdevs) == 0

--- a/cmd/gpu-kubelet-plugin/nvlib.go
+++ b/cmd/gpu-kubelet-plugin/nvlib.go
@@ -51,7 +51,7 @@ type deviceLib struct {
 	hostRoot          string
 	sysfsRoot         string
 	nvidiaSMIPath     string
-	// vfioEnabled combines the feature gate with node-local IOMMU availability.
+	// vfioEnabled records node-local IOMMU capability, independent of feature gates.
 	vfioEnabled       bool
 	gpuInfosByUUID    map[string]*GpuInfo
 	gpuUUIDbyPCIBusID map[PCIBusID]string
@@ -59,6 +59,11 @@ type deviceLib struct {
 }
 
 func newDeviceLib(driver *root.Driver, hostRoot string) (*deviceLib, error) {
+	vfioEnabled, err := checkIommuEnabled(hostRoot)
+	if err != nil {
+		return nil, fmt.Errorf("error checking if IOMMU is enabled: %w", err)
+	}
+
 	driverLibraryPath, err := driver.DriverLibraryPath()
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate driver libraries: %w", err)
@@ -90,6 +95,7 @@ func newDeviceLib(driver *root.Driver, hostRoot string) (*deviceLib, error) {
 		driverLibraryPath: driverLibraryPath,
 		devRoot:           driver.DevRoot,
 		hostRoot:          hostRoot,
+		vfioEnabled:       vfioEnabled,
 		sysfsRoot:         sysfsRoot,
 		nvidiaSMIPath:     nvidiaSMIPath,
 		nvpci:             nvpci,
@@ -109,6 +115,10 @@ func newDeviceLib(driver *root.Driver, hostRoot string) (*deviceLib, error) {
 	}
 
 	return &d, nil
+}
+
+func (d *deviceLib) IsVfioEnabled() bool {
+	return d.vfioEnabled
 }
 
 // prependPathListEnvvar prepends a specified list of strings to a specified envvar and returns its value.
@@ -195,7 +205,7 @@ func (l deviceLib) enumerateAllPossibleDevices() (*PerGPUAllocatableDevices, err
 		return nil, fmt.Errorf("error enumerating allocatable devices: %w", err)
 	}
 
-	if l.vfioEnabled {
+	if featuregates.Enabled(featuregates.PassthroughSupport) && l.IsVfioEnabled() {
 		// Discover passthrough devices and insert them into the
 		// `perGPUAllocatable` devices map
 		err = l.enumerateGpuVfioDevices(perGPUAllocatable)
@@ -311,7 +321,7 @@ func (l deviceLib) GetPerGpuAllocatableDevices(indices ...int) (*PerGPUAllocatab
 			return fmt.Errorf("error discovering MIG devices for GPU %q: %w", gpuInfo.CanonicalName(), err)
 		}
 
-		if l.vfioEnabled {
+		if featuregates.Enabled(featuregates.PassthroughSupport) && l.IsVfioEnabled() {
 			// Only if no MIG devices are found, allow VFIO devices.
 			klog.Infof("PassthroughSupport enabled, and %d MIG devices found", len(migdevs))
 			gpuInfo.vfioEnabled = len(migdevs) == 0

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -50,6 +50,8 @@ const (
 	driverChangeTimeout = 15 * time.Second
 )
 
+var errIommuUnavailable = errors.New("IOMMU is not enabled in the kernel")
+
 type VfioPciManager struct {
 	sync.Mutex
 	containerDriverRoot string
@@ -66,7 +68,7 @@ func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib 
 		return nil, fmt.Errorf("error checking if IOMMU is enabled: %w", err)
 	}
 	if !iommuEnabled {
-		return nil, fmt.Errorf("IOMMU is not enabled in the kernel")
+		return nil, errIommuUnavailable
 	}
 
 	vm := &VfioPciManager{

--- a/cmd/gpu-kubelet-plugin/vfio-device.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device.go
@@ -50,8 +50,6 @@ const (
 	driverChangeTimeout = 15 * time.Second
 )
 
-var errIommuUnavailable = errors.New("IOMMU is not enabled in the kernel")
-
 type VfioPciManager struct {
 	sync.Mutex
 	containerDriverRoot string
@@ -63,14 +61,6 @@ type VfioPciManager struct {
 }
 
 func NewVfioPciManager(containerDriverRoot string, hostDriverRoot string, nvlib *deviceLib, nvidiaEnabled bool) (*VfioPciManager, error) {
-	iommuEnabled, err := checkIommuEnabled(nvlib.hostRoot)
-	if err != nil {
-		return nil, fmt.Errorf("error checking if IOMMU is enabled: %w", err)
-	}
-	if !iommuEnabled {
-		return nil, errIommuUnavailable
-	}
-
 	vm := &VfioPciManager{
 		containerDriverRoot:    containerDriverRoot,
 		hostDriverRoot:         hostDriverRoot,

--- a/cmd/gpu-kubelet-plugin/vfio-device_test.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device_test.go
@@ -27,6 +27,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCheckIommuEnabled(t *testing.T) {
+	tests := map[string]struct {
+		setup       func(t *testing.T, path string)
+		wantEnabled bool
+		wantErr     bool
+	}{
+		"missing iommu groups": {},
+		"empty iommu groups": {
+			setup: func(t *testing.T, path string) {
+				require.NoError(t, os.MkdirAll(path, 0o755))
+			},
+		},
+		"populated iommu groups": {
+			setup: func(t *testing.T, path string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(path, "0"), 0o755))
+			},
+			wantEnabled: true,
+		},
+		"unexpected read error": {
+			setup: func(t *testing.T, path string) {
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, nil, 0o644))
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			hostRoot := t.TempDir()
+			iommuGroupsPath := filepath.Join(hostRoot, kernelIommuGroupPath)
+			if tc.setup != nil {
+				tc.setup(t, iommuGroupsPath)
+			}
+
+			enabled, err := checkIommuEnabled(hostRoot)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantEnabled, enabled)
+		})
+	}
+}
+
+func TestNewVfioPciManagerIommuUnavailable(t *testing.T) {
+	manager, err := NewVfioPciManager("", "", &deviceLib{hostRoot: t.TempDir()}, true)
+
+	require.Nil(t, manager)
+	require.ErrorIs(t, err, errIommuUnavailable)
+}
+
 func TestGetDriver(t *testing.T) {
 	t.Run("returns empty driver", func(t *testing.T) {
 		pciDevicesPath := t.TempDir()

--- a/cmd/gpu-kubelet-plugin/vfio-device_test.go
+++ b/cmd/gpu-kubelet-plugin/vfio-device_test.go
@@ -73,13 +73,6 @@ func TestCheckIommuEnabled(t *testing.T) {
 	}
 }
 
-func TestNewVfioPciManagerIommuUnavailable(t *testing.T) {
-	manager, err := NewVfioPciManager("", "", &deviceLib{hostRoot: t.TempDir()}, true)
-
-	require.Nil(t, manager)
-	require.ErrorIs(t, err, errIommuUnavailable)
-}
-
 func TestGetDriver(t *testing.T) {
 	t.Run("returns empty driver", func(t *testing.T) {
 		pciDevicesPath := t.TempDir()

--- a/cmd/gpu-kubelet-plugin/vfio_capability_test.go
+++ b/cmd/gpu-kubelet-plugin/vfio_capability_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
+	cdispec "tags.cncf.io/container-device-interface/specs-go"
+
+	nvdev "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvlib/pkg/nvpci"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+
+	configapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/internal/lookup/root"
+	"sigs.k8s.io/dra-driver-nvidia-gpu/pkg/featuregates"
+)
+
+func TestNewDeviceLibVfioCapability(t *testing.T) {
+	for _, gate := range []bool{false, true} {
+		for _, mode := range []string{"missing", "empty", "populated", "read error"} {
+			t.Run(fmt.Sprintf("gate=%t/%s", gate, mode), func(t *testing.T) {
+				setVfioTestFeatureGate(t, featuregates.PassthroughSupport, gate)
+				setVfioTestFeatureGate(t, featuregates.DynamicMIG, false)
+				hostRoot := t.TempDir()
+				path := filepath.Join(hostRoot, kernelIommuGroupPath)
+				switch mode {
+				case "empty":
+					require.NoError(t, os.MkdirAll(path, 0o755))
+				case "populated":
+					require.NoError(t, os.MkdirAll(filepath.Join(path, "0"), 0o755))
+				case "read error":
+					require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+					require.NoError(t, os.WriteFile(path, nil, 0o644))
+				}
+				// Construction locates these files but does not load NVML with DynamicMIG disabled.
+				for _, name := range []string{"libnvidia-ml.so.1", "nvidia-smi"} {
+					require.NoError(t, os.WriteFile(filepath.Join(hostRoot, name), nil, 0o644))
+				}
+				lib, err := newDeviceLib(root.New(root.WithDriverRoot(hostRoot)), hostRoot)
+				if mode == "read error" {
+					require.ErrorContains(t, err, "error checking if IOMMU is enabled")
+					var pathErr *os.PathError
+					require.ErrorAs(t, err, &pathErr)
+					require.Nil(t, lib)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, mode == "populated", lib.IsVfioEnabled())
+			})
+		}
+	}
+}
+
+// Embed the interfaces so unexpected hardware calls fail in these CPU-only tests.
+type emptyVfioTestNVML struct{ nvml.Interface }
+
+func (emptyVfioTestNVML) InitWithFlags(uint32) nvml.Return              { return nvml.SUCCESS }
+func (emptyVfioTestNVML) Init() nvml.Return                             { return nvml.SUCCESS }
+func (emptyVfioTestNVML) SystemGetDriverVersion() (string, nvml.Return) { return "550.0", nvml.SUCCESS }
+func (emptyVfioTestNVML) Shutdown() nvml.Return                         { return nvml.SUCCESS }
+
+type emptyVfioTestDevices struct{ nvdev.Interface }
+
+func (emptyVfioTestDevices) VisitDevices(func(int, nvdev.Device) error) error { return nil }
+
+func TestDeviceStateVfioCapability(t *testing.T) {
+	for _, gate := range []bool{false, true} {
+		for _, capable := range []bool{false, true} {
+			t.Run(fmt.Sprintf("gate=%t/capable=%t", gate, capable), func(t *testing.T) {
+				setVfioTestFeatureGate(t, featuregates.PassthroughSupport, gate)
+				setVfioTestFeatureGate(t, featuregates.DynamicMIG, false)
+				setVfioTestFeatureGate(t, featuregates.FabricManagerPartitioning, false)
+				setVfioTestFeatureGate(t, featuregates.TimeSlicingSettings, false)
+				setVfioTestFeatureGate(t, featuregates.MPSSupport, false)
+				hostRoot := t.TempDir()
+				pci := &nvpci.InterfaceMock{GetGPUsFunc: func() ([]*nvpci.NvidiaPCIDevice, error) { return nil, nil }}
+				lib := &deviceLib{hostRoot: hostRoot, vfioEnabled: capable, nvmllib: emptyVfioTestNVML{}, Interface: emptyVfioTestDevices{}, nvpci: pci}
+				config := &Config{flags: &Flags{kubeletPluginsDirectoryPath: t.TempDir(), cdiRoot: t.TempDir()}}
+				state, err := newDeviceState(context.Background(), config, root.New(root.WithDriverRoot(hostRoot)), lib)
+				require.NoError(t, err)
+				require.Equal(t, capable, lib.IsVfioEnabled())
+				require.Equal(t, gate && capable, state.vfioPciManager != nil)
+				require.Equal(t, gate && capable, state.cdi.vfiocdi != nil)
+				if gate && capable {
+					require.Len(t, pci.GetGPUsCalls(), 1)
+				} else {
+					require.Empty(t, pci.GetGPUsCalls())
+					require.Empty(t, state.perGPUAllocatable.GetAllDevices().GetVfioDevices())
+					result, err := state.applyVfioDeviceConfig(context.Background(), configapi.DefaultVfioDeviceConfig(), nil, nil)
+					require.ErrorContains(t, err, "VFIO is unavailable on this node")
+					require.Nil(t, result)
+				}
+
+				state.cdi.specCache.Set("commonEdits", &cdiapi.ContainerEdits{ContainerEdits: &cdispec.ContainerEdits{}}, time.Minute)
+
+				// Exercise normal GPU preparation through the checkpoint and CDI flow.
+				gpu := &AllocatableDevice{Gpu: &GpuInfo{UUID: "GPU-0000", pciBusID: "0000:00:00.0"}}
+				require.NoError(t, state.perGPUAllocatable.AddAllocatableDevice(gpu))
+				state.cdi.specCache.Set("GPU-0000", []cdispec.Device{{Name: "gpu-0", ContainerEdits: cdispec.ContainerEdits{Env: []string{"TEST_GPU=0"}}}}, time.Minute)
+				claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{UID: "test-claim", Name: "test-claim"}, Status: resourceapi.ResourceClaimStatus{Allocation: &resourceapi.AllocationResult{Devices: resourceapi.DeviceAllocationResult{Results: []resourceapi.DeviceRequestAllocationResult{{Driver: DriverName, Device: gpu.CanonicalName(), Request: "gpu", Pool: "test-node"}}}}}}
+				_, err = state.Prepare(context.Background(), claim)
+				require.NoError(t, err)
+				_, err = state.Unprepare(context.Background(), kubeletplugin.NamespacedObject{UID: claim.UID})
+				require.NoError(t, err)
+
+				// A broken IOMMUFD path must be ignored when VFIO is disabled,
+				// but a real handler initialization error must remain fatal.
+				require.NoError(t, os.Symlink("dev", filepath.Join(hostRoot, "dev")))
+				initialized, initErr := newDeviceState(context.Background(), config, root.New(root.WithDriverRoot(hostRoot)), lib)
+				if gate && capable {
+					require.ErrorContains(t, initErr, "unable to create vfio CDI handler")
+					require.Nil(t, initialized)
+					return
+				}
+				require.NoError(t, initErr)
+				require.Nil(t, initialized.vfioPciManager)
+				require.Nil(t, initialized.cdi.vfiocdi)
+				// Even a stale VFIO allocation must not dereference an absent manager during rollback or unprepare.
+				vfio := &VfioDeviceInfo{index: 0, PciBusID: "0000:00:00.0"}
+				require.NoError(t, state.perGPUAllocatable.AddAllocatableDevice(&AllocatableDevice{Vfio: vfio}))
+				pc := PreparedClaim{Status: resourceapi.ResourceClaimStatus{Allocation: &resourceapi.AllocationResult{Devices: resourceapi.DeviceAllocationResult{Results: []resourceapi.DeviceRequestAllocationResult{{Driver: DriverName, Device: vfio.CanonicalName()}}}}}}
+				require.NoError(t, state.unpreparePartiallyPreparedClaim(context.Background(), "stale-claim", pc, &Checkpoint{}))
+				prepared := PreparedDevices{{Devices: PreparedDeviceList{{Vfio: &PreparedVfioDevice{Info: vfio, Device: &CheckpointedDevice{DeviceName: vfio.CanonicalName()}}}}}}
+				_, err = state.unprepareDevices(context.Background(), "stale-claim", prepared, &Checkpoint{})
+				require.NoError(t, err)
+			})
+		}
+	}
+}
+
+func TestVfioUnavailableResourceGeneration(t *testing.T) {
+	for _, gate := range []bool{false, true} {
+		for _, capable := range []bool{false, true} {
+			if gate && capable {
+				continue
+			}
+			for _, dynamic := range []bool{false, true} {
+				for _, split := range []bool{false, true} {
+					t.Run(fmt.Sprintf("gate=%t/capable=%t/dynamic=%t/split=%t", gate, capable, dynamic, split), func(t *testing.T) {
+						setVfioTestFeatureGate(t, featuregates.PassthroughSupport, gate)
+						setVfioTestFeatureGate(t, featuregates.DynamicMIG, dynamic)
+						gpu := &AllocatableDevice{Gpu: &GpuInfo{UUID: "GPU-0000", productName: "NVIDIA Test GPU", brand: "Test", architecture: "Test", cudaComputeCapability: "8.0", driverVersion: "550.0", cudaDriverVersion: "12.0", pciBusID: "0000:00:00.0", vfioEnabled: true}}
+						state := &DeviceState{nvdevlib: &deviceLib{vfioEnabled: capable}, perGPUAllocatable: &PerGPUAllocatableDevices{allocatablesMap: map[PCIBusID]AllocatableDevices{gpu.Gpu.pciBusID: {gpu.CanonicalName(): gpu}}}}
+						// GPU-local eligibility must not override the feature gate or node capability.
+						require.NoError(t, state.discoverSiblingAllocatables(gpu))
+						require.Empty(t, state.perGPUAllocatable.GetAllDevices().GetVfioDevices())
+						resources := (&driver{state: state, useSplitResourceSlices: split}).GenerateDriverResources("test-node")
+						slices := resources.Pools["test-node"].Slices
+						expectedSlices := 1
+						if dynamic && split {
+							expectedSlices = 2
+						}
+						require.Len(t, slices, expectedSlices)
+						var devices []resourceapi.Device
+						for _, slice := range slices {
+							devices = append(devices, slice.Devices...)
+						}
+						require.Len(t, devices, 1)
+						require.Equal(t, GpuDeviceType, *devices[0].Attributes["type"].StringValue)
+					})
+				}
+			}
+		}
+	}
+}
+
+func setVfioTestFeatureGate(t *testing.T, gate featuregate.Feature, enabled bool) {
+	t.Helper()
+	previous := featuregates.Enabled(gate)
+	t.Cleanup(func() {
+		require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{string(gate): previous}))
+	})
+	require.NoError(t, featuregates.FeatureGates().SetFromMap(map[string]bool{string(gate): enabled}))
+}

--- a/site/content/docs/guides/gpu-allocation/kubevirt-vfio-gpu-passthrough.md
+++ b/site/content/docs/guides/gpu-allocation/kubevirt-vfio-gpu-passthrough.md
@@ -26,7 +26,7 @@ Refer to the [feature gates reference](../../reference/feature-gates.md) and [co
 ## Prerequisites
 
 - Meet the general driver [prerequisites](../../prerequisites.md).
-- **IOMMU enabled** on GPU nodes. VFIO passthrough requires IOMMU; the GPU kubelet plugin fails to start with `PassthroughSupport` enabled if IOMMU is off.
+- **IOMMU enabled** on GPU nodes intended for VFIO passthrough. Without IOMMU, the GPU kubelet plugin continues serving normal GPU devices but does not advertise VFIO devices.
 - Enable the `PassthroughSupport` and `DeviceMetadata` feature gates in the DRA Driver.
 - Use **KubeVirt v1.8.0 or later** with the **`GPUsWithDRA`** feature gate enabled. This gate is enabled by default from KubeVirt v1.9.0, so it only needs to be set explicitly on v1.8.x.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `PassthroughSupport` is enabled on a node without IOMMU, `vfioPciManager` initialization currently causes the GPU kubelet plugin to exit.

This change treats missing IOMMU support as node-local passthrough unavailability:

- normal GPU devices remain available;
- VFIO discovery and CDI initialization are skipped;
- VFIO devices are omitted from the ResourceSlice;
- sibling rediscovery cannot reintroduce VFIO devices;
- unexpected IOMMU filesystem and VFIO initialization failures remain fatal;
- behavior is unchanged when IOMMU is available.

It also adds CPU-only regression tests and updates the VFIO passthrough prerequisite documentation.

#### Which issue(s) this PR is related to:

Fixes #1413

#### Special notes for your reviewer:

This change was prepared with assistance from OpenAI Codex.

#### Does this PR introduce a user-facing change?

```release-note
Continue serving normal GPU devices while omitting VFIO devices on nodes where IOMMU is unavailable.
```

#### Additional documentation (design docs, usage docs, etc.):

```docs
Updated the VFIO passthrough prerequisite documentation to describe behavior on nodes without IOMMU.
```

#### Checklist

- [ ] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed