### PR TITLE
Add unit tests for gpu-kubelet-plugin health checks

### DIFF
--- a/cmd/gpu-kubelet-plugin/device_health_test.go
+++ b/cmd/gpu-kubelet-plugin/device_health_test.go
@@ -444,6 +444,111 @@ func TestHealthMonitorStartRequiresRegisteredEvents(t *testing.T) {
 	require.ErrorContains(t, m.Start(context.Background()), "events have not been registered")
 }
 
+func TestGetAdditionalXids(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []uint64
+	}{
+		{name: "empty", input: "", want: nil},
+		{name: "single", input: "79", want: []uint64{79}},
+		{name: "multiple", input: "79,94,95", want: []uint64{79, 94, 95}},
+		{name: "whitespace trimmed", input: " 79 , 94 ", want: []uint64{79, 94}},
+		{name: "malformed ignored", input: "79,foo,94", want: []uint64{79, 94}},
+		{name: "empty entries ignored", input: "79,,94,", want: []uint64{79, 94}},
+		{name: "all malformed", input: "foo,bar", want: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, getAdditionalXids(tc.input))
+		})
+	}
+}
+
+func TestXidsToSkip(t *testing.T) {
+	hardcoded := []uint64{13, 31, 43, 45, 68, 109}
+
+	t.Run("hardcoded XIDs always skipped", func(t *testing.T) {
+		skip := xidsToSkip("")
+		for _, xid := range hardcoded {
+			assert.Truef(t, skip[xid], "expected hardcoded XID %d to be skipped", xid)
+		}
+		assert.False(t, skip[48], "XID 48 is fatal and must not be skipped")
+	})
+
+	t.Run("additional XIDs merged with hardcoded", func(t *testing.T) {
+		skip := xidsToSkip("79,94")
+		for _, xid := range hardcoded {
+			assert.Truef(t, skip[xid], "expected hardcoded XID %d to be skipped", xid)
+		}
+		assert.True(t, skip[79])
+		assert.True(t, skip[94])
+	})
+}
+
+func TestSendBatchedHealthEvent(t *testing.T) {
+	devA := &AllocatableDevice{Gpu: &GpuInfo{UUID: "GPU-a"}}
+	devB := &AllocatableDevice{Gpu: &GpuInfo{UUID: "GPU-b"}}
+
+	t.Run("empty devices sends nothing", func(t *testing.T) {
+		m := &nvmlDeviceHealthMonitor{unhealthy: make(chan *DeviceHealthEvent, 1)}
+		m.sendBatchedHealthEvent(nil, HealthEventGPULost)
+		assert.Len(t, m.unhealthy, 0)
+	})
+
+	t.Run("normal batched send", func(t *testing.T) {
+		m := &nvmlDeviceHealthMonitor{unhealthy: make(chan *DeviceHealthEvent, 1)}
+		m.sendBatchedHealthEvent([]*AllocatableDevice{devA, devB}, HealthEventGPULost)
+		require.Len(t, m.unhealthy, 1)
+		event := <-m.unhealthy
+		assert.Equal(t, HealthEventGPULost, event.EventType)
+		assert.Len(t, event.Devices, 2)
+	})
+
+	t.Run("full channel drops without blocking", func(t *testing.T) {
+		m := &nvmlDeviceHealthMonitor{unhealthy: make(chan *DeviceHealthEvent, 1)}
+		m.unhealthy <- &DeviceHealthEvent{} // fill the channel
+		// Must return instead of blocking; the second event is dropped.
+		m.sendBatchedHealthEvent([]*AllocatableDevice{devA}, HealthEventUnmonitored)
+		assert.Len(t, m.unhealthy, 1)
+	})
+}
+
+func TestSendHealthEventForAllDevices(t *testing.T) {
+	devA := &AllocatableDevice{Gpu: &GpuInfo{UUID: "GPU-a"}}
+	devB := &AllocatableDevice{MigStatic: &MigDeviceInfo{ParentUUID: "GPU-a"}}
+	m := &nvmlDeviceHealthMonitor{
+		unhealthy: make(chan *DeviceHealthEvent, 1),
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				"0000:01:00.0": {"gpu": devA, "mig": devB},
+			},
+		},
+	}
+
+	m.sendHealthEventForAllDevices(HealthEventGPULost)
+
+	require.Len(t, m.unhealthy, 1)
+	event := <-m.unhealthy
+	assert.Equal(t, HealthEventGPULost, event.EventType)
+	assert.Len(t, event.Devices, 2)
+}
+
+func TestResolveDeviceByEventAddressUnknownPCIBus(t *testing.T) {
+	// Parent GPU is in the UUID index but its PCI bus is absent from the
+	// allocatable inventory: an inconsistent inventory must surface an error.
+	parent := &GpuInfo{UUID: "GPU-parent-1", pciBusID: "0000:01:00.0"}
+	monitor := &nvmlDeviceHealthMonitor{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{},
+		},
+		gpuInfosByUUID: map[string]*GpuInfo{parent.UUID: parent},
+	}
+
+	_, err := monitor.resolveDeviceByEventAddress(parent.UUID, nil, FullGPUInstanceID, FullGPUInstanceID)
+	require.ErrorContains(t, err, "failed to find PCI Bus ID")
+}
+
 func TestGetDeviceIncludesHealthTaints(t *testing.T) {
 	dev := &AllocatableDevice{Gpu: &GpuInfo{
 		UUID:                  "GPU-1",

--- a/cmd/gpu-kubelet-plugin/health_test.go
+++ b/cmd/gpu-kubelet-plugin/health_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	drapb "k8s.io/kubelet/pkg/apis/dra/v1beta1"
+	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+)
+
+// fakeRegistrationClient is a minimal registerapi.RegistrationClient stub whose
+// GetInfo behavior is driven by getInfoErr.
+type fakeRegistrationClient struct {
+	getInfoErr error
+}
+
+func (f *fakeRegistrationClient) GetInfo(ctx context.Context, in *registerapi.InfoRequest, opts ...grpc.CallOption) (*registerapi.PluginInfo, error) {
+	if f.getInfoErr != nil {
+		return nil, f.getInfoErr
+	}
+	return &registerapi.PluginInfo{}, nil
+}
+
+func (f *fakeRegistrationClient) NotifyRegistrationStatus(ctx context.Context, in *registerapi.RegistrationStatus, opts ...grpc.CallOption) (*registerapi.RegistrationStatusResponse, error) {
+	return &registerapi.RegistrationStatusResponse{}, nil
+}
+
+// fakeDRAPluginClient is a minimal drapb.DRAPluginClient stub whose
+// NodePrepareResources behavior is driven by prepareErr.
+type fakeDRAPluginClient struct {
+	prepareErr error
+}
+
+func (f *fakeDRAPluginClient) NodePrepareResources(ctx context.Context, in *drapb.NodePrepareResourcesRequest, opts ...grpc.CallOption) (*drapb.NodePrepareResourcesResponse, error) {
+	if f.prepareErr != nil {
+		return nil, f.prepareErr
+	}
+	return &drapb.NodePrepareResourcesResponse{}, nil
+}
+
+func (f *fakeDRAPluginClient) NodeUnprepareResources(ctx context.Context, in *drapb.NodeUnprepareResourcesRequest, opts ...grpc.CallOption) (*drapb.NodeUnprepareResourcesResponse, error) {
+	return &drapb.NodeUnprepareResourcesResponse{}, nil
+}
+
+func TestHealthcheckCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		service    string
+		getInfoErr error
+		prepareErr error
+		wantStatus grpc_health_v1.HealthCheckResponse_ServingStatus
+		wantCode   codes.Code // codes.OK means no error expected
+	}{
+		{
+			name:     "unknown service is rejected",
+			service:  "bogus",
+			wantCode: codes.NotFound,
+		},
+		{
+			name:       "GetInfo failure reports NOT_SERVING",
+			service:    "liveness",
+			getInfoErr: fmt.Errorf("registration socket down"),
+			wantStatus: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+			wantCode:   codes.OK,
+		},
+		{
+			name:       "NodePrepareResources failure reports NOT_SERVING",
+			service:    "liveness",
+			prepareErr: fmt.Errorf("dra socket down"),
+			wantStatus: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+			wantCode:   codes.OK,
+		},
+		{
+			name:       "healthy plugin reports SERVING",
+			service:    "",
+			wantStatus: grpc_health_v1.HealthCheckResponse_SERVING,
+			wantCode:   codes.OK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &healthcheck{
+				regClient: &fakeRegistrationClient{getInfoErr: tc.getInfoErr},
+				draClient: &fakeDRAPluginClient{prepareErr: tc.prepareErr},
+				// Zero-value Helper: RegistrationStatus() is nil-safe.
+				kphelper: &kubeletplugin.Helper{},
+			}
+
+			resp, err := h.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: tc.service})
+
+			if tc.wantCode != codes.OK {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantCode, status.Code(err))
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, tc.wantStatus, resp.Status)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The health code in `cmd/gpu-kubelet-plugin` had no unit test coverage. This adds tests for two files:

- `health.go`: the `Check` gRPC health handler, covering an unknown service name, a registration socket failure, a DRA socket failure, and the healthy path that reports `SERVING`. The tests use small stub clients for the registration and DRA interfaces and a zero-value kubelet-plugin `Helper`, so no real sockets or server are needed.
- `device_health.go`: the XID parsing helpers (`getAdditionalXids`, `xidsToSkip`), the batched health-event senders (`sendBatchedHealthEvent`, `sendHealthEventForAllDevices`, including the empty-batch and full-channel-drop cases), and the previously untested unknown-PCI-bus error branch of `resolveDeviceByEventAddress`.

Test-only change. No production code is modified.

#### Which issue(s) this PR is related to:

Fixes #1310

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):

```docs
NONE
```

#### Checklist

- [x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
