### PR TITLE
Disable health service by default during plugin registration to avoid constant error logging

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/driver.go
+++ b/cmd/compute-domain-kubelet-plugin/driver.go
@@ -116,6 +116,9 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		kubeletplugin.Serialize(false),
 		kubeletplugin.RegistrarDirectoryPath(config.flags.kubeletRegistrarDirectoryPath),
 		kubeletplugin.PluginDataDirectoryPath(config.DriverPluginPath()),
+		// This plugin does not report device health (KEP-4680), so don't
+		// advertise the DRAResourceHealth service to the kubelet.
+		kubeletplugin.HealthService(false),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/gpu-kubelet-plugin/driver.go
+++ b/cmd/gpu-kubelet-plugin/driver.go
@@ -164,6 +164,9 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 			drametadatav1alpha1.SchemeGroupVersion,
 		}))
 	}
+	// This plugin does not report device health (KEP-4680), so don't
+	// advertise the DRAResourceHealth service to the kubelet.
+	opts = append(opts, kubeletplugin.HealthService(false))
 	helper, err := kubeletplugin.Start(ctx, driver, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION


<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:

Disables the health service explicitly during plugin registration to avoid below repeated errors in the plugin logs.

```
E0902 20:48:24.809602       1 nonblockinggrpcserver.go:180] "handling stream failed" err="rpc error: code = Unimplemented desc = device health reporting is not supported by this driver" logger="dra" requestID=139 method="/v1alpha1.DRAResourceHealth/NodeWatchResources"
```

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

Fixes: https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1423

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
    Fix spurious kubelet-plugin error logs caused by the unimplemented NodeWatchResources service.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
