### PR TITLE
test(gpu-kubelet-plugin): add unit tests for deviceinfo.go

### DIFF
--- a/cmd/gpu-kubelet-plugin/deviceinfo_test.go
+++ b/cmd/gpu-kubelet-plugin/deviceinfo_test.go
@@ -107,3 +107,155 @@ func TestVfioDeviceIncludesStandardNumaNode(t *testing.T) {
 
 	requireNumaNodeAttribute(t, vfio.GetDevice().Attributes, 3)
 }
+
+func TestGpuInfoCanonicalName(t *testing.T) {
+	tests := map[string]struct {
+		minor int
+		want  DeviceName
+	}{
+		"minor zero":      {minor: 0, want: "gpu-0"},
+		"single digit":    {minor: 7, want: "gpu-7"},
+		"multiple digits": {minor: 42, want: "gpu-42"},
+	}
+
+	for description, tc := range tests {
+		t.Run(description, func(t *testing.T) {
+			gpu := &GpuInfo{minor: tc.minor}
+			require.Equal(t, tc.want, gpu.CanonicalName())
+		})
+	}
+}
+
+func TestGpuInfoString(t *testing.T) {
+	// String() is used in log messages and combines the canonical name (for
+	// recognizability) with the UUID (for precision).
+	gpu := &GpuInfo{minor: 3, UUID: "GPU-abc123"}
+	require.Equal(t, "gpu-3-GPU-abc123", gpu.String())
+}
+
+func TestVfioDeviceInfoCanonicalName(t *testing.T) {
+	tests := map[string]struct {
+		index int
+		want  string
+	}{
+		"index zero":    {index: 0, want: "gpu-vfio-0"},
+		"index nonzero": {index: 5, want: "gpu-vfio-5"},
+	}
+
+	for description, tc := range tests {
+		t.Run(description, func(t *testing.T) {
+			vfio := &VfioDeviceInfo{index: tc.index}
+			require.Equal(t, tc.want, vfio.CanonicalName())
+		})
+	}
+}
+
+func TestMigDeviceInfoSpecTuple(t *testing.T) {
+	mig := &MigDeviceInfo{
+		ParentMinor:    2,
+		GiProfileID:    19,
+		PlacementStart: 4,
+	}
+
+	require.Equal(t, &MigSpecTuple{
+		ParentMinor:    2,
+		ProfileID:      19,
+		PlacementStart: 4,
+	}, mig.SpecTuple())
+}
+
+func TestMigDeviceInfoLiveTuple(t *testing.T) {
+	mig := &MigDeviceInfo{
+		UUID:        "MIG-live",
+		ParentUUID:  "GPU-parent",
+		ParentMinor: 1,
+		GIID:        6,
+		CIID:        0,
+	}
+
+	require.Equal(t, &MigLiveTuple{
+		ParentMinor: 1,
+		ParentUUID:  "GPU-parent",
+		GIID:        6,
+		CIID:        0,
+		MigUUID:     "MIG-live",
+	}, mig.LiveTuple())
+}
+
+func TestAddDeviceAttribute(t *testing.T) {
+	t.Run("nil attribute is a no-op", func(t *testing.T) {
+		attrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{}
+		addDeviceAttribute(attrs, nil)
+		require.Empty(t, attrs)
+	})
+
+	t.Run("non-nil attribute is added under its name", func(t *testing.T) {
+		attrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{}
+		attr := &deviceattribute.DeviceAttribute{
+			Name: resourceapi.QualifiedName("pciBusID"),
+			Value: resourceapi.DeviceAttribute{
+				StringValue: ptr.To("0000:65:00.0"),
+			},
+		}
+
+		addDeviceAttribute(attrs, attr)
+
+		got, ok := attrs["pciBusID"]
+		require.True(t, ok)
+		require.NotNil(t, got.StringValue)
+		require.Equal(t, "0000:65:00.0", *got.StringValue)
+	})
+}
+
+func TestGpuInfoAttributesCoreValues(t *testing.T) {
+	gpu := newTestGpuInfo(nil)
+
+	attrs := gpu.Attributes()
+
+	// String-valued attributes are copied through verbatim.
+	stringAttrs := map[resourceapi.QualifiedName]string{
+		"type":         GpuDeviceType,
+		"uuid":         "GPU-test",
+		"productName":  "NVIDIA Test GPU",
+		"brand":        "NVIDIA",
+		"architecture": "Test",
+	}
+	for name, want := range stringAttrs {
+		attr, ok := attrs[name]
+		require.True(t, ok, "expected attribute %q", name)
+		require.NotNil(t, attr.StringValue, "attribute %q should be string-valued", name)
+		require.Equal(t, want, *attr.StringValue)
+	}
+
+	// Version-valued attributes are normalized to full semver (e.g. "9.0" ->
+	// "9.0.0") by semver.MustParse(...).String().
+	versionAttrs := map[resourceapi.QualifiedName]string{
+		"cudaComputeCapability": "9.0.0",
+		"driverVersion":         "580.0.0",
+		"cudaDriverVersion":     "13.0.0",
+	}
+	for name, want := range versionAttrs {
+		attr, ok := attrs[name]
+		require.True(t, ok, "expected attribute %q", name)
+		require.NotNil(t, attr.VersionValue, "attribute %q should be version-valued", name)
+		require.Equal(t, want, *attr.VersionValue)
+	}
+}
+
+func TestGpuInfoAttributesAddressingMode(t *testing.T) {
+	t.Run("omitted when unset", func(t *testing.T) {
+		gpu := newTestGpuInfo(nil)
+		_, ok := gpu.Attributes()["addressingMode"]
+		require.False(t, ok)
+	})
+
+	t.Run("included when set", func(t *testing.T) {
+		gpu := newTestGpuInfo(nil)
+		gpu.addressingMode = ptr.To("hmm")
+
+		attr, ok := gpu.Attributes()["addressingMode"]
+		require.True(t, ok)
+		require.NotNil(t, attr.StringValue)
+		require.Equal(t, "hmm", *attr.StringValue)
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Adds table-driven unit tests for the pure, hardware-independent functions in
`cmd/gpu-kubelet-plugin/deviceinfo.go`, which had no coverage before:
- `GpuInfo.CanonicalName`, `GpuInfo.String`, `VfioDeviceInfo.CanonicalName`
- `MigDeviceInfo.SpecTuple` and `LiveTuple` field mappings
- `addDeviceAttribute` (nil is a no-op; non-nil is added under its name)
- `GpuInfo.Attributes`: core string attributes, semver normalization of the
  version attributes (for example `9.0` becomes `9.0.0`), and the optional
  `addressingMode`
- NUMA-node standard attribute wiring for GPU, MIG, and VFIO devices

Several of these produce externally visible strings (the ResourceSlice device
name in particular), so the tests help catch accidental format changes.

#### Which issue(s) this PR is related to:
Fixes #1302
Part of #1297

#### Special notes for your reviewer:
The tests are pure and deterministic, so they need no GPU, NVML, or CGO runtime
and run under `go test ./cmd/gpu-kubelet-plugin/`. I verified them locally with
`gofmt` and the project's `golangci-lint` config (0 issues). These were drafted
with the help of Claude Code, and I reviewed and verified each assertion against
the current behavior of deviceinfo.go.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation (design docs, usage docs, etc.):
N/A

#### Checklist
- [x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
