### PR TITLE
Avoid cliqueID race in applyComputeDomainChannelConfig when cliqueID is refreshed

### DIFF
--- a/cmd/compute-domain-kubelet-plugin/device_state.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state.go
@@ -668,7 +668,7 @@ func (s *DeviceState) applyComputeDomainChannelConfigHostManaged(ctx context.Con
 		ComputeDomain: config.DomainID,
 	}
 
-	if s.computeDomainManager.cliqueID == "" {
+	if s.computeDomainManager.CliqueID() == "" {
 		// Non-fabric node (e.g. not part of an MNNVL clique): do not inject
 		// IMEX channel device nodes, but let the claim succeed.
 		return &configState, nil

--- a/cmd/compute-domain-kubelet-plugin/device_state_test.go
+++ b/cmd/compute-domain-kubelet-plugin/device_state_test.go
@@ -19,6 +19,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -755,6 +757,65 @@ func TestApplyComputeDomainChannelConfigHostManagedRequiresHostIMEXReady(t *test
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "host nvidia-imex daemon readiness check failed")
 	assert.False(t, isPermanentError(err), "an unready host daemon must be retried, not treated as permanently broken")
+}
+
+// TestApplyComputeDomainChannelConfigHostManagedCliqueIDRace guards against a
+// race between periodicGPUCliqueIDRefresh's locked setCliqueID() writes and
+// applyComputeDomainChannelConfigHostManaged's read of the clique ID. Run
+// with -race.
+func TestApplyComputeDomainChannelConfigHostManagedCliqueIDRace(t *testing.T) {
+	cd := &configapi.ComputeDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "cd", Namespace: "default", UID: "cd-uid"},
+	}
+	factory := nvinformers.NewSharedInformerFactory(nvfake.NewSimpleClientset(), 0)
+	informer := factory.Resource().V1beta1().ComputeDomains().Informer()
+	require.NoError(t, informer.AddIndexers(cache.Indexers{"computeDomainUID": uidIndexer[*configapi.ComputeDomain]}))
+	require.NoError(t, informer.GetIndexer().Add(cd))
+
+	state := &DeviceState{
+		config:               hostManagedConfig(),
+		checkpointManager:    &fakeCheckpointManager{checkpoint: checkpointWithClaims(nil)},
+		computeDomainManager: &ComputeDomainManager{informer: informer},
+		nvdevlib:             &deviceLib{devRoot: t.TempDir()},
+		allocatable: AllocatableDevices{
+			"channel-0": &AllocatableDevice{Channel: &ComputeDomainChannelInfo{ID: 0}},
+		},
+	}
+
+	config := channelConfig("cd-uid")
+	result := allocationResult("request", DriverName, "channel-0", nil)
+	claim := claimWithResults("claim-uid", result)
+
+	stop := make(chan struct{})
+	var writerWG, readerWG sync.WaitGroup
+
+	// Writer: mimics periodicGPUCliqueIDRefresh's locked cliqueID writes.
+	writerWG.Go(func() {
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			state.computeDomainManager.setCliqueID(strconv.Itoa(i))
+		}
+	})
+
+	// Reader: mimics a concurrent NodePrepareResources call hitting the host-managed channel config path.
+	readerWG.Go(func() {
+		for range 20000 {
+			_, _ = state.applyComputeDomainChannelConfig(
+				context.Background(),
+				config,
+				claim,
+				[]*resourceapi.DeviceRequestAllocationResult{&result},
+			)
+		}
+	})
+
+	readerWG.Wait()
+	close(stop)
+	writerWG.Wait()
 }
 
 func TestUnprepareDevicesHostManagedSkipsRemoveNodeLabel(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Prevent a race in the `applyComputeDomainChannelConfig` when cliqueID is refreshed v


#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Additional steps.

1. Set up mock GPU fabric with etup-mock-gpu.sh with GPU_PROFILE=gb200 GPU_COUNT=8/                            
 2. Run with race detector: CGO_ENABLED=1 go build -race for gpu-kubelet-plugin, compute-domain-kubelet-plugin, compute-domain-controller, compute-domain-daemon from the clean tree (no debug code needed).                                                                                               
3. Create a `ComputeDomain` + workload pod claiming
4. Force the write path to actually fire using ` /var/lib/nvml-mock/driver/config/overrides.yaml`
5. Wait for the `periodicGPUCliqueIDRefresh`, and the race detector reports the hit

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation (design docs, usage docs, etc.):

#### Checklist

- [X] `make check test` passes locally
- [X] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [X] Tests added or updated for the change