### PR TITLE
Fix IMEX node-index swap caused by a race in compute-domain-controller which incorrectly prunes nodes from ComputeDomain status.

### DIFF
--- a/cmd/compute-domain-controller/cdstatus.go
+++ b/cmd/compute-domain-controller/cdstatus.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	nvapi "sigs.k8s.io/dra-driver-nvidia-gpu/api/nvidia.com/resource/v1beta1"
@@ -215,7 +216,7 @@ func (m *ComputeDomainStatusManager) syncCD(ctx context.Context, cd *nvapi.Compu
 		newNodes = slices.Concat(fabricNodes, nonFabricNodes)
 	} else {
 		// Feature gate disabled: filter stale fabric nodes + rebuild non-fabric nodes
-		fabricNodes = m.getNonStaleFabricNodes(cd.Status.Nodes, fabricPods)
+		fabricNodes = m.getNonStaleFabricNodes(ctx, string(cd.UID), cd.Status.Nodes, fabricPods)
 		nonFabricNodes = m.buildNodesFromPods(nonFabricPods)
 		newNodes = slices.Concat(fabricNodes, nonFabricNodes)
 	}
@@ -282,7 +283,21 @@ func (m *ComputeDomainStatusManager) buildNodesFromPods(pods []*corev1.Pod) []*n
 	return nodes
 }
 
-// cleanupClique removes stale daemon entries from a single clique.
+func podMatchesDaemon(pod *corev1.Pod, nodeName, daemonIP string) bool {
+	if pod.Spec.NodeName != nodeName {
+		return false
+	}
+	if daemonIP != "" && pod.Status.PodIP != "" && pod.Status.PodIP != daemonIP {
+		return false
+	}
+	return true
+}
+
+// cleanupClique removes stale daemon entries from a single clique. A daemon is only removed
+// after a live, quorum-consistent read against the API server confirms its pod is actually gone
+// (see listLivePodsForNode) rather than trusting the cached pod list's absence alone, so a momentary lag
+// between the clique informer and the pod informer can't be mistaken for a genuinely gone node,
+// while a real deletion is still acted on immediately.
 func (m *ComputeDomainStatusManager) cleanupClique(ctx context.Context, clique *nvapi.ComputeDomainClique, pods []*corev1.Pod) {
 	// Build set of node names that have running daemon pods
 	runningNodes := make(map[string]struct{})
@@ -292,15 +307,33 @@ func (m *ComputeDomainStatusManager) cleanupClique(ctx context.Context, clique *
 		}
 	}
 
+	cdUID := clique.Labels[computeDomainLabelKey]
+
 	var updatedDaemons []*nvapi.ComputeDomainDaemonInfo
 	var removedNodes []string
 
 	for _, daemon := range clique.Daemons {
 		if _, exists := runningNodes[daemon.NodeName]; exists {
 			updatedDaemons = append(updatedDaemons, daemon)
-		} else {
-			removedNodes = append(removedNodes, daemon.NodeName)
+			continue
 		}
+
+		// Not in the cached pod list: the clique informer and pod informer
+		// are independent caches with no ordering guarantee between them, so
+		// don't trust the cache miss alone. Confirm live before removing.
+		livePods, err := m.listLivePodsForNode(ctx, cdUID, daemon.NodeName)
+		if err != nil {
+			klog.Errorf("CliqueCleanup: error confirming pod liveness for node %q: %v", daemon.NodeName, err)
+			// Fail safe: don't remove on an unconfirmed cache miss.
+			updatedDaemons = append(updatedDaemons, daemon)
+			continue
+		}
+		if len(livePods) > 0 {
+			updatedDaemons = append(updatedDaemons, daemon)
+			continue
+		}
+
+		removedNodes = append(removedNodes, daemon.NodeName)
 	}
 
 	// Nothing to clean up
@@ -326,29 +359,70 @@ func (m *ComputeDomainStatusManager) cleanupClique(ctx context.Context, clique *
 // It filters the existing nodes list to only keep those with a corresponding pod in the pods list.
 // getNonStaleFabricNodes returns fabric-attached nodes from existingNodes that still have running pods.
 // Non-fabric nodes are filtered out (they'll be rebuilt from nonFabricPods).
-func (m *ComputeDomainStatusManager) getNonStaleFabricNodes(existingNodes []*nvapi.ComputeDomainNode, fabricPods []*corev1.Pod) []*nvapi.ComputeDomainNode {
-	// Build set of fabric pod IPs
-	fabricPodIPs := make(map[string]struct{})
-	for _, pod := range fabricPods {
-		if pod.Status.PodIP != "" {
-			fabricPodIPs[pod.Status.PodIP] = struct{}{}
-		}
-	}
-
-	// Keep only fabric nodes (CliqueID != "") that still have pods
+func (m *ComputeDomainStatusManager) getNonStaleFabricNodes(ctx context.Context, cdUID string, existingNodes []*nvapi.ComputeDomainNode, fabricPods []*corev1.Pod) []*nvapi.ComputeDomainNode {
+	// Keep only fabric nodes (CliqueID != "") that still have a matching pod.
 	var result []*nvapi.ComputeDomainNode
 	for _, node := range existingNodes {
 		// Skip non-fabric nodes (they're rebuilt fresh)
 		if node.CliqueID == "" {
 			continue
 		}
-		// Keep fabric node if its pod still exists
-		if _, exists := fabricPodIPs[node.IPAddress]; exists {
-			result = append(result, node)
+
+		// Keep fabric node if its pod is visible in the cached pod list.
+		matched := false
+		for _, pod := range fabricPods {
+			if podMatchesDaemon(pod, node.Name, node.IPAddress) {
+				matched = true
+				break
+			}
 		}
+		if matched {
+			result = append(result, node)
+			continue
+		}
+
+		// Not in the cache: don't trust that alone. Confirm live before
+		// removing.
+		livePods, err := m.listLivePodsForNode(ctx, cdUID, node.Name)
+		if err != nil {
+			klog.Errorf("CDStatusSync: error confirming pod liveness for node %q: %v", node.Name, err)
+			// Fail safe: don't remove on an unconfirmed cache miss.
+			result = append(result, node)
+			continue
+		}
+
+		liveMatched := false
+		for i := range livePods {
+			if podMatchesDaemon(&livePods[i], node.Name, node.IPAddress) {
+				liveMatched = true
+				break
+			}
+		}
+		if liveMatched {
+			result = append(result, node)
+			continue
+		}
+
+		klog.Infof("CDStatusSync: pruning stale fabric node %q", node.Name)
 	}
 
 	return result
+}
+
+// listLivePodsForNode does a live read straight against the API server for daemon pods
+// belonging to ComputeDomain cdUID and scheduled on nodeName. It's used as a confirmation
+// fallback only when a node isn't found in the faster, but potentially lagging, informer-cached
+// pod list so getNonStaleFabricNodes and cleanupClique never prune a node based solely on a cache
+// that hasn't caught up yet.
+func (m *ComputeDomainStatusManager) listLivePodsForNode(ctx context.Context, cdUID, nodeName string) ([]corev1.Pod, error) {
+	pods, err := m.config.clientsets.Core.CoreV1().Pods(m.config.driverNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", computeDomainLabelKey, cdUID),
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
 }
 
 // nodesEqual checks if two slices of ComputeDomainNode are equal.


### PR DESCRIPTION
Fixes a race in compute-domain-controller that can silently wipe live fabric-attached nodes out of a ComputeDomain's status.nodes list, which in turn corrupts IMEX's node-index-to-IP mapping and disrupts in-flight GPU memory export/import operations. Mostly seen when `ComputeDomainCliques` feature is disabled (enabled by default from v25.12.0)

<!--  Thanks for sending a pull request! See CONTRIBUTING.md for guidelines. -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind dependency
/kind documentation
/kind feature
-->

/kind bug

#### What this PR does / why we need it:

`ComputeDomainStatusManager.syncCD` (and `cleanupClique` when `ComputeDomainCliques` is enabled) reconciles a ComputeDomain's node list every 2s by comparing two independently refreshed informer caches: the ComputeDomain/ComputeDomainClique object and the controller's own cached list of daemon pods (DaemonSetPodManager). These two caches have no guaranteed ordering relative to each other. When a node's daemon pod has just started, the ComputeDomain informer can already show that node's self-inserted status entry while the controller's Pod informer hasn't picked up that pod's IP yet. Right now, if a pod is missing from the informer cache, it's treated as a deleted daemon and the corresponding node entry gets cleaned up from the ComputeDomain object..

Because the controller always reads the ComputeDomain fresh immediately before writing its status, the update always carries a genuinely current resourceVersion so this destructive rewrite passes the API server's optimistic-concurrency check cleanly and produces no conflict error, even though it silently drops a live peer's entry. Both nodes then detect their own absence and scramble to re-register, and that race is what swaps their IMEX node indices, breaking the DNS-name-to-IP mapping IMEX relies on mid-operation.

Before pruning a fabric node (or clique daemon entry) that's missing from the cached pod list, we now do a live read straight against the API server to confirm the pod is actually gone. If the pod is just invisible in a lagging cache, we keep the node. If the live read confirms it's gone, we prune it. The live call only fires when a node is missing from the fast cached path, so normal sync ticks don't add any extra API calls.

#### Which issue(s) this PR is related to:
<!--
Use "Fixes #<issue number>" to auto-close the issue on merge.
Write "N/A" if there is no associated issue.
-->

Fixes #1418 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
Write "NONE" if there is no user-facing change.
Otherwise, describe the change for driver users / cluster admins. Examples:
- new or changed CLI flags on the kubelet-plugin / controller
- changes to DeviceClass, ResourceClaim, or CRD shapes
- behavior changes for MIG, time-slicing, IMEX, or sharing modes
- deployment/Helm chart changes (values, defaults, RBAC)
Include "action required" if users must change configs or manifests when upgrading.
-->
```release-note
    Fixed a race in compute-domain-controller that could incorrectly remove a live node from a ComputeDomain's status shortly after the node joined (most reproducible with ComputeDomainCliques disabled), causing IMEX node-index reassignment and disrupting in-flight GPU memory export/import operations.
```

#### Additional documentation (design docs, usage docs, etc.):

<!--
Link any supporting docs, e.g.:
- updates under site/content/ (design, MIG, IMEX, sharing, etc.)
- README or demo/ updates
- related KEPs in kubernetes/enhancements
Use permalinks (commit SHA) rather than branch links so references stay stable.
-->
```docs

```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [x] `make check test` passes locally
- [x] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [x] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ ] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
