### PR TITLE
xid classification into fatal vs non-fatal based on recovery action 

### DIFF
--- a/cmd/gpu-kubelet-plugin/allocatable.go
+++ b/cmd/gpu-kubelet-plugin/allocatable.go
@@ -348,16 +348,19 @@ func (d *AllocatableDevice) Taints() []resourceapi.DeviceTaint {
 }
 
 // AddOrUpdateTaint adds a new taint or updates an existing one with the same
-// key. The value and effect are always updated to the latest event received.
-// Meaning, if a device receives multiple events for the same taint dimension
-// (e.g., XID 48 followed by XID 63), the value is overwritten and only the most recent event data is retained.
+// key. NoSchedule taints are sticky and remain unchanged until explicit
+// recovery removes them.
 // Returns true if the taint set was modified.
 func (d *AllocatableDevice) AddOrUpdateTaint(taint *resourceapi.DeviceTaint) bool {
 	for i, existing := range d.taints {
 		if existing.Key == taint.Key {
-
 			// 1. If nothing actually changed, exit early to avoid API calls
 			if existing.Value == taint.Value && existing.Effect == taint.Effect {
+				return false
+			}
+
+			// Keep the NoSchedule taint until recovery explicitly removes the taint.
+			if existing.Effect == resourceapi.DeviceTaintEffectNoSchedule {
 				return false
 			}
 

--- a/cmd/gpu-kubelet-plugin/device_health.go
+++ b/cmd/gpu-kubelet-plugin/device_health.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"strings"
@@ -401,64 +402,135 @@ func (m *nvmlDeviceHealthMonitor) sendBatchedHealthEvent(devices []*AllocatableD
 	}
 }
 
-// getAdditionalXids returns a list of additional Xids to skip from the specified string.
-// The input is treated as a comma-separated string and all valid uint64 values are considered as Xid values.
-// Invalid values are ignored.
-// TODO: add list of EXPLICIT XIDs from [https://github.com/NVIDIA/k8s-device-plugin/pull/1443].
-func getAdditionalXids(input string) []uint64 {
-	if input == "" {
-		return nil
-	}
-
-	var additionalXids []uint64
-	klog.V(6).Infof("Creating a list of additional xids to ignore: [%s]", input)
-	for _, additionalXid := range strings.Split(input, ",") {
-		trimmed := strings.TrimSpace(additionalXid)
-		if trimmed == "" {
-			continue
-		}
-		xid, err := strconv.ParseUint(trimmed, 10, 64)
-		if err != nil {
-			klog.V(6).Infof("Ignoring malformed Xid value %v: %v", trimmed, err)
-			continue
-		}
-		additionalXids = append(additionalXids, xid)
-	}
-
-	return additionalXids
-}
-
-func xidsToSkip(additionalXids string) map[uint64]bool {
-	// Add the list of hardcoded disabled (ignored) XIDs:
-	// https://docs.nvidia.com/deploy/xid-errors/latest/analyzing-xid-catalog.html
-	// Application errors: the GPU should still be healthy.
-	// If you change this list, update the documentation.
-	ignoredXids := []uint64{
-		13,  // Graphics Engine Exception
-		31,  // GPU memory page fault
-		43,  // GPU stopped processing
-		45,  // Preemptive cleanup, due to previous errors
-		68,  // Video processor exception
-		109, // Context Switch Timeout Error
-	}
-
+// xidsToSkip returns the XIDs explicitly configured by the administrator.
+//
+// Earlier versions also treated the following XIDs as non-fatal by default.
+// The NVIDIA XID Catalog documents their immediate actions as:
+//
+//   - XID 13, Graphics Engine Exception: RESTART_APP.
+//   - XID 31, GPU memory page fault: RESTART_APP.
+//   - XID 43, GPU stopped processing: IGNORE.
+//   - XID 45, Preemptive cleanup due to previous errors: WORKFLOW_XID_45.
+//   - XID 68, NVDEC0 Exception: RESTART_APP.
+//   - XID 109, Context Switch Timeout Error: RESET_GPU.
+//
+// The built-in list is no longer used for classification. The parent GPU's
+// current recovery action determines the scheduling impact. This configured
+// list remains as an explicit administrator override.
+//
+// See:
+// https://docs.nvidia.com/deploy/xid-errors/latest/analyzing-xid-catalog.html
+func xidsToSkip(input string) map[uint64]bool {
 	skippedXids := make(map[uint64]bool)
-	for _, id := range ignoredXids {
-		skippedXids[id] = true
+	if input == "" {
+		return skippedXids
 	}
 
-	for _, additionalXid := range getAdditionalXids(additionalXids) {
-		skippedXids[additionalXid] = true
+	klog.V(6).Infof("Creating a list of XIDs to ignore: [%s]", input)
+
+	for _, value := range strings.Split(input, ",") {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+
+		xid, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			klog.V(6).Infof("Ignoring malformed XID value %q: %v", value, err)
+			continue
+		}
+
+		skippedXids[xid] = true
 	}
+
 	return skippedXids
 }
 
-// IsEventNonFatal evaluates whether a hardware event is considered an application-level
-// warning (None) rather than a critical hardware failure (NoSchedule).
-// Currently, it only checks for XID events.
-func (m *nvmlDeviceHealthMonitor) IsEventNonFatal(event *DeviceHealthEvent) bool {
-	if event.EventType == HealthEventXID {
-		return m.skippedXids[event.EventData]
+// queryGPURecoveryAction reads the current recovery action reported by NVML.
+func queryGPURecoveryAction(device nvml.Device) (nvml.DeviceGpuRecoveryAction, error) {
+	values := []nvml.FieldValue{{
+		FieldId: nvml.FI_DEV_GET_GPU_RECOVERY_ACTION,
+	}}
+
+	if ret := device.GetFieldValues(values); ret != nvml.SUCCESS {
+		return nvml.GPU_RECOVERY_ACTION_NONE, fmt.Errorf("failed to query GPU recovery action: %w", ret)
 	}
-	return false
+
+	value := values[0]
+	if ret := nvml.Return(value.NvmlReturn); ret != nvml.SUCCESS {
+		return nvml.GPU_RECOVERY_ACTION_NONE, fmt.Errorf("failed to read GPU recovery action field: %w", ret)
+	}
+	if nvml.ValueType(value.ValueType) != nvml.VALUE_TYPE_UNSIGNED_INT {
+		return nvml.GPU_RECOVERY_ACTION_NONE, fmt.Errorf("failed to decode GPU recovery action: unexpected value type %d", value.ValueType)
+	}
+
+	// NVML stores this unsigned-int field in the first four bytes of its 8-byte
+	// value union using host byte order.
+	return nvml.DeviceGpuRecoveryAction(binary.NativeEndian.Uint32(value.Value[:4])), nil
+}
+
+func gpuRecoveryActionString(action nvml.DeviceGpuRecoveryAction) string {
+	switch action {
+	case nvml.GPU_RECOVERY_ACTION_NONE:
+		return "None"
+	case nvml.GPU_RECOVERY_ACTION_GPU_RESET:
+		return "GPU Reset Required"
+	case nvml.GPU_RECOVERY_ACTION_NODE_REBOOT:
+		return "Node Reboot Required"
+	case nvml.GPU_RECOVERY_ACTION_DRAIN_P2P:
+		return "Drain P2P"
+	case nvml.GPU_RECOVERY_ACTION_DRAIN_AND_RESET:
+		return "Drain and Reset"
+	case nvml.GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN:
+		return "Recover IMEX Domain"
+	default:
+		return fmt.Sprintf("Unknown (%d)", action)
+	}
+}
+
+// IsEventNonFatal classifies an XID using the parent GPU's current recovery
+// action. An administrator-configured XID remains non-fatal, but the recovery
+// action is still queried and logged.
+func (m *nvmlDeviceHealthMonitor) IsEventNonFatal(event *DeviceHealthEvent) bool {
+	if event.EventType != HealthEventXID {
+		return false
+	}
+
+	xid := event.EventData
+	ignored := m.skippedXids[xid]
+
+	pciBusID := event.Devices[0].GetGPUPCIBusID()
+	device, ret := m.nvmllib.DeviceGetHandleByPciBusId(pciBusID)
+	if ret != nvml.SUCCESS {
+		klog.Warningf("Failed to get parent GPU handle for PCI bus ID %s while processing XID=%d: %v", pciBusID, xid, ret)
+		return ignored
+	}
+
+	action, err := queryGPURecoveryAction(device)
+	if err != nil {
+		klog.Warningf("Failed to query GPU recovery action while processing XID=%d: %v", xid, err)
+		return ignored
+	}
+
+	if ignored {
+		klog.Warningf("XID %d: NVML reported GPU recovery action=%q; treating the event as non-fatal because the XID is configured via --additional-xids-to-ignore", xid, gpuRecoveryActionString(action))
+		return true
+	}
+
+	switch action {
+	case nvml.GPU_RECOVERY_ACTION_NONE:
+		klog.V(4).Infof("XID %d: NVML reported GPU recovery action=%q; treating the event as non-fatal", xid, gpuRecoveryActionString(action))
+		return true
+
+	case nvml.GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN:
+		// RECOVER_IMEX_DOMAIN requests recovery of the IMEX domain rather than
+		// recovery of the local GPU device. Keep the XID informational for GPU
+		// scheduling and surface the recovery requirement in the log.
+		klog.Warningf("XID %d: NVML reports GPU recovery action=%q; the action is scoped to IMEX-domain recovery, so treating the event as non-fatal for GPU scheduling", xid, gpuRecoveryActionString(action))
+		return true
+
+	default:
+		klog.Warningf("XID %d: NVML reported GPU recovery action=%q; treating the event as fatal", xid, gpuRecoveryActionString(action))
+		return false
+	}
 }

--- a/cmd/gpu-kubelet-plugin/device_health_test.go
+++ b/cmd/gpu-kubelet-plugin/device_health_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"testing"
 
 	nvdev "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
@@ -27,6 +28,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type mockNVMLDevice struct {
+	nvml.Device
+	getFieldValuesFunc  func([]nvml.FieldValue) nvml.Return
+	getFieldValuesCalls int
+}
+
+func (m *mockNVMLDevice) GetFieldValues(values []nvml.FieldValue) nvml.Return {
+	m.getFieldValuesCalls++
+	return m.getFieldValuesFunc(values)
+}
+
+type mockNVMLLibrary struct {
+	nvml.Interface
+	deviceGetHandleByPciBusIdFunc  func(string) (nvml.Device, nvml.Return)
+	deviceGetHandleByPciBusIdCalls int
+}
+
+func (m *mockNVMLLibrary) DeviceGetHandleByPciBusId(busID string) (nvml.Device, nvml.Return) {
+	m.deviceGetHandleByPciBusIdCalls++
+	return m.deviceGetHandleByPciBusIdFunc(busID)
+}
 
 // mockHealthMonitor implements deviceHealthMonitor for testing healthEventToTaint.
 type mockHealthMonitor struct {
@@ -74,23 +97,43 @@ func TestAddOrUpdateTaint_DuplicateNoChange(t *testing.T) {
 	assert.Len(t, dev.Taints(), 1)
 }
 
-func TestAddOrUpdateTaint_UpdateValue(t *testing.T) {
-	dev := &AllocatableDevice{}
-	dev.AddOrUpdateTaint(&resourceapi.DeviceTaint{
-		Key:    TaintKeyXID,
-		Value:  "48",
-		Effect: resourceapi.DeviceTaintEffectNoSchedule,
-	})
+func TestAddOrUpdateTaint_NoScheduleIsSticky(t *testing.T) {
+	tests := []struct {
+		name     string
+		incoming resourceapi.DeviceTaint
+	}{
+		{
+			name: "later NoSchedule XID",
+			incoming: resourceapi.DeviceTaint{
+				Key:    TaintKeyXID,
+				Value:  "63",
+				Effect: resourceapi.DeviceTaintEffectNoSchedule,
+			},
+		},
+		{
+			name: "later informational XID",
+			incoming: resourceapi.DeviceTaint{
+				Key:    TaintKeyXID,
+				Value:  "43",
+				Effect: resourceapi.DeviceTaintEffectNone,
+			},
+		},
+	}
 
-	changed := dev.AddOrUpdateTaint(&resourceapi.DeviceTaint{
-		Key:    TaintKeyXID,
-		Value:  "63",
-		Effect: resourceapi.DeviceTaintEffectNoSchedule,
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			original := resourceapi.DeviceTaint{
+				Key:    TaintKeyXID,
+				Value:  "48",
+				Effect: resourceapi.DeviceTaintEffectNoSchedule,
+			}
+			dev := &AllocatableDevice{}
+			require.True(t, dev.AddOrUpdateTaint(&original))
 
-	require.True(t, changed)
-	require.Len(t, dev.Taints(), 1)
-	assert.Equal(t, "63", dev.Taints()[0].Value, "value should be overwritten to latest XID")
+			assert.False(t, dev.AddOrUpdateTaint(&tc.incoming))
+			assert.Equal(t, []resourceapi.DeviceTaint{original}, dev.Taints())
+		})
+	}
 }
 
 func TestAddOrUpdateTaint_UpdateEffect(t *testing.T) {
@@ -260,55 +303,274 @@ func TestHealthEventToTaint(t *testing.T) {
 	}
 }
 
-func TestIsEventNonFatal(t *testing.T) {
-	m := &nvmlDeviceHealthMonitor{
-		skippedXids: map[uint64]bool{
-			13: true,
-			31: true,
-			43: true,
+func newMockRecoveryActionDevice(
+	t *testing.T,
+	action nvml.DeviceGpuRecoveryAction,
+	queryRet nvml.Return,
+	fieldRet nvml.Return,
+	valueType nvml.ValueType,
+) *mockNVMLDevice {
+	t.Helper()
+
+	return &mockNVMLDevice{
+		getFieldValuesFunc: func(values []nvml.FieldValue) nvml.Return {
+			require.Len(t, values, 1)
+			require.EqualValues(t, nvml.FI_DEV_GET_GPU_RECOVERY_ACTION, values[0].FieldId)
+
+			if queryRet != nvml.SUCCESS {
+				return queryRet
+			}
+
+			values[0].NvmlReturn = uint32(fieldRet)
+			values[0].ValueType = uint32(valueType)
+			binary.NativeEndian.PutUint32(values[0].Value[:4], uint32(action))
+			return nvml.SUCCESS
 		},
 	}
+}
 
-	tests := []struct {
-		name     string
-		event    *DeviceHealthEvent
-		expected bool
+func TestXidsToSkip(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  map[uint64]bool
 	}{
-		{
-			name: "skipped XID is non-fatal",
-			event: &DeviceHealthEvent{
-				EventType: HealthEventXID,
-				EventData: 13,
-			},
-			expected: true,
+		"empty input has no built-in defaults": {
+			want: map[uint64]bool{},
 		},
-		{
-			name: "non-skipped XID is fatal",
-			event: &DeviceHealthEvent{
-				EventType: HealthEventXID,
-				EventData: 48,
-			},
-			expected: false,
+		"configured XIDs": {
+			input: "13, 109",
+			want:  map[uint64]bool{13: true, 109: true},
 		},
-		{
-			name: "GPU_LOST is always fatal",
-			event: &DeviceHealthEvent{
-				EventType: HealthEventGPULost,
-			},
-			expected: false,
-		},
-		{
-			name: "unmonitored is not an XID event",
-			event: &DeviceHealthEvent{
-				EventType: HealthEventUnmonitored,
-			},
-			expected: false,
+		"malformed empty and duplicate values": {
+			input: "43,invalid,,43",
+			want:  map[uint64]bool{43: true},
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, m.IsEventNonFatal(tc.event))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, xidsToSkip(tc.input))
+		})
+	}
+}
+
+func TestQueryGPURecoveryAction(t *testing.T) {
+	tests := map[string]struct {
+		action    nvml.DeviceGpuRecoveryAction
+		queryRet  nvml.Return
+		fieldRet  nvml.Return
+		valueType nvml.ValueType
+		want      nvml.DeviceGpuRecoveryAction
+		wantErr   string
+	}{
+		"none": {
+			action:    nvml.GPU_RECOVERY_ACTION_NONE,
+			fieldRet:  nvml.SUCCESS,
+			valueType: nvml.VALUE_TYPE_UNSIGNED_INT,
+			want:      nvml.GPU_RECOVERY_ACTION_NONE,
+		},
+		"GPU reset": {
+			action:    nvml.GPU_RECOVERY_ACTION_GPU_RESET,
+			fieldRet:  nvml.SUCCESS,
+			valueType: nvml.VALUE_TYPE_UNSIGNED_INT,
+			want:      nvml.GPU_RECOVERY_ACTION_GPU_RESET,
+		},
+		"recover IMEX domain": {
+			action:    nvml.GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN,
+			fieldRet:  nvml.SUCCESS,
+			valueType: nvml.VALUE_TYPE_UNSIGNED_INT,
+			want:      nvml.GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN,
+		},
+		"unknown action": {
+			action:    nvml.DeviceGpuRecoveryAction(99),
+			fieldRet:  nvml.SUCCESS,
+			valueType: nvml.VALUE_TYPE_UNSIGNED_INT,
+			want:      nvml.DeviceGpuRecoveryAction(99),
+		},
+		"query failure": {
+			queryRet: nvml.ERROR_UNKNOWN,
+			wantErr:  "failed to query GPU recovery action",
+		},
+		"field failure": {
+			fieldRet:  nvml.ERROR_NOT_SUPPORTED,
+			valueType: nvml.VALUE_TYPE_UNSIGNED_INT,
+			wantErr:   "failed to read GPU recovery action field",
+		},
+		"unexpected value type": {
+			fieldRet:  nvml.SUCCESS,
+			valueType: nvml.VALUE_TYPE_DOUBLE,
+			wantErr:   "failed to decode GPU recovery action",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			device := newMockRecoveryActionDevice(t, tc.action, tc.queryRet, tc.fieldRet, tc.valueType)
+
+			got, err := queryGPURecoveryAction(device)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				assert.Equal(t, 1, device.getFieldValuesCalls)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, 1, device.getFieldValuesCalls)
+		})
+	}
+}
+
+func TestIsEventNonFatal(t *testing.T) {
+	const (
+		pciBusID = "0000:01:00.0"
+		xid      = uint64(43)
+	)
+
+	tests := map[string]struct {
+		eventType DeviceHealthEventType
+		action    nvml.DeviceGpuRecoveryAction
+		ignored   bool
+		mig       bool
+		handleRet nvml.Return
+		queryRet  nvml.Return
+		fieldRet  nvml.Return
+		want      bool
+	}{
+		"recovery action none is non-fatal": {
+			eventType: HealthEventXID,
+			action:    nvml.GPU_RECOVERY_ACTION_NONE,
+			want:      true,
+		},
+		"MIG event queries the parent GPU": {
+			eventType: HealthEventXID,
+			action:    nvml.GPU_RECOVERY_ACTION_NONE,
+			mig:       true,
+			want:      true,
+		},
+		"GPU reset is fatal": {
+			eventType: HealthEventXID,
+			action:    nvml.GPU_RECOVERY_ACTION_GPU_RESET,
+		},
+		"node reboot is fatal": {
+			eventType: HealthEventXID,
+			action:    nvml.GPU_RECOVERY_ACTION_NODE_REBOOT,
+		},
+		"drain P2P is fatal": {
+			eventType: HealthEventXID,
+			action:    nvml.GPU_RECOVERY_ACTION_DRAIN_P2P,
+		},
+		"drain and reset is fatal": {
+			eventType: HealthEventXID,
+			action:    nvml.GPU_RECOVERY_ACTION_DRAIN_AND_RESET,
+		},
+		"recover IMEX domain is non-fatal for GPU scheduling": {
+			eventType: HealthEventXID,
+			action:    nvml.GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN,
+			want:      true,
+		},
+		"unknown non-zero action is fatal": {
+			eventType: HealthEventXID,
+			action:    nvml.DeviceGpuRecoveryAction(99),
+		},
+		"administrator override remains non-fatal": {
+			eventType: HealthEventXID,
+			action:    nvml.GPU_RECOVERY_ACTION_GPU_RESET,
+			ignored:   true,
+			want:      true,
+		},
+		"query failure is fatal": {
+			eventType: HealthEventXID,
+			queryRet:  nvml.ERROR_UNKNOWN,
+		},
+		"administrator override survives query failure": {
+			eventType: HealthEventXID,
+			ignored:   true,
+			queryRet:  nvml.ERROR_UNKNOWN,
+			want:      true,
+		},
+		"field failure is fatal": {
+			eventType: HealthEventXID,
+			fieldRet:  nvml.ERROR_NOT_SUPPORTED,
+		},
+		"parent handle failure is fatal": {
+			eventType: HealthEventXID,
+			handleRet: nvml.ERROR_INVALID_ARGUMENT,
+		},
+		"administrator override survives parent handle failure": {
+			eventType: HealthEventXID,
+			ignored:   true,
+			handleRet: nvml.ERROR_INVALID_ARGUMENT,
+			want:      true,
+		},
+		"GPU lost is not classified as a non-fatal XID": {
+			eventType: HealthEventGPULost,
+		},
+		"unmonitored is not classified as a non-fatal XID": {
+			eventType: HealthEventUnmonitored,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			parent := &GpuInfo{UUID: "GPU-parent-1", pciBusID: pciBusID}
+			affectedDevice := &AllocatableDevice{Gpu: parent}
+			if tc.mig {
+				affectedDevice = &AllocatableDevice{
+					MigStatic: &MigDeviceInfo{
+						ParentUUID: parent.UUID,
+						parent:     parent,
+					},
+				}
+			}
+
+			device := newMockRecoveryActionDevice(
+				t,
+				tc.action,
+				tc.queryRet,
+				tc.fieldRet,
+				nvml.VALUE_TYPE_UNSIGNED_INT,
+			)
+
+			nvmllib := &mockNVMLLibrary{
+				deviceGetHandleByPciBusIdFunc: func(got string) (nvml.Device, nvml.Return) {
+					assert.Equal(t, pciBusID, got)
+					if tc.handleRet != nvml.SUCCESS {
+						return nil, tc.handleRet
+					}
+					return device, nvml.SUCCESS
+				},
+			}
+
+			skippedXids := make(map[uint64]bool)
+			if tc.ignored {
+				skippedXids[xid] = true
+			}
+
+			monitor := &nvmlDeviceHealthMonitor{
+				nvmllib:     nvmllib,
+				skippedXids: skippedXids,
+			}
+			event := &DeviceHealthEvent{
+				EventType: tc.eventType,
+				EventData: xid,
+			}
+			if tc.eventType == HealthEventXID {
+				event.Devices = []*AllocatableDevice{affectedDevice}
+			}
+
+			assert.Equal(t, tc.want, monitor.IsEventNonFatal(event))
+
+			wantHandleCalls := 0
+			wantQueryCalls := 0
+			if tc.eventType == HealthEventXID {
+				wantHandleCalls = 1
+				if tc.handleRet == nvml.SUCCESS {
+					wantQueryCalls = 1
+				}
+			}
+			assert.Equal(t, wantHandleCalls, nvmllib.deviceGetHandleByPciBusIdCalls)
+			assert.Equal(t, wantQueryCalls, device.getFieldValuesCalls)
 		})
 	}
 }

--- a/cmd/gpu-kubelet-plugin/main.go
+++ b/cmd/gpu-kubelet-plugin/main.go
@@ -190,9 +190,12 @@ func newApp() *cli.App {
 			EnvVars:     []string{"HEALTHCHECK_PORT"},
 		},
 		// TODO: change to StringSliceFlag.
+		// Retain the existing flag for an explicit administrator
+		// override: listed XIDs do not produce a NoSchedule taint even when NVML
+		// reports a GPU recovery action. The action is still queried and logged.
 		&cli.StringFlag{
 			Name:        "additional-xids-to-ignore",
-			Usage:       "A comma-separated list of additional XIDs to ignore.",
+			Usage:       "A comma-separated list of XIDs to treat as non-fatal, overriding the NVML-reported GPU recovery action.",
 			Value:       "",
 			Destination: &flags.additionalXidsToIgnore,
 			EnvVars:     []string{"ADDITIONAL_XIDS_TO_IGNORE"},


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### Which issue(s) this PR is related to:
fixes https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/1323

#### Special notes for your reviewer:
Intent is explained here https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/904#issuecomment-5223152665
AI assisted with the PR

#### Does this PR introduce a user-facing change?
NONE

```release-note
Introducing xid classification based on recovery action 
```

#### Checklist

<!-- Tick what applies; leave others unchecked. CI re-runs some of these, but catching them locally shortens the review loop. -->
- [ x] `make check test` passes locally
- [ ] `make check-generate` passes if `api/` changed (CRDs, deepcopy, informers, listers, clientset)
- [ ] `make check-modules` passes if `go.mod` / `go.sum` changed
- [ x] Tests added or updated for the change
- [ ] Helm chart (`deployments/helm`) updated if flags, RBAC, or defaults changed
